### PR TITLE
serialize to a stream

### DIFF
--- a/http_message.mli
+++ b/http_message.mli
@@ -28,4 +28,10 @@ val init :
   version:Http_types.version ->
   clisockaddr:Unix.sockaddr -> srvsockaddr:Unix.sockaddr -> message
 val serialize :
+  message ->
+  'a -> ('a -> string -> unit Lwt.t) -> ('a -> string -> int -> int -> unit Lwt.t) ->
+  fstLineToString:string -> unit Lwt.t
+val serialize_to_output_channel :
   message -> Lwt_io.output_channel -> fstLineToString:string -> unit Lwt.t
+val serialize_to_stream :
+  message -> fstLineToString:string -> string Lwt_stream.t

--- a/http_response.ml
+++ b/http_response.ml
@@ -95,7 +95,17 @@ let set_expires = rh "Expires"
 let server = gh "Server"
 let set_server = rh "Server"
 
-let serialize r outchan = 
-  let fstLineToString =
-    sprintf "%s %d %s" (version_string r) (code r) (reason r) in
-  Http_message.serialize r.r_msg outchan ~fstLineToString
+let fstLineToString r =
+  sprintf "%s %d %s" (version_string r) (code r) (reason r)
+
+let serialize r outchan write write_from_exactly = 
+  let fstLineToString = fstLineToString r in
+  Http_message.serialize r.r_msg outchan write write_from_exactly ~fstLineToString
+
+let serialize_to_output_channel r outchan =
+  let fstLineToString = fstLineToString r in
+  Http_message.serialize_to_output_channel r.r_msg outchan ~fstLineToString
+
+let serialize_to_stream r =
+  let fstLineToString = fstLineToString r in
+  Http_message.serialize_to_stream r.r_msg ~fstLineToString

--- a/http_response.mli
+++ b/http_response.mli
@@ -32,4 +32,9 @@ val expires : response -> string option
 val set_expires : response -> value:string -> unit
 val server : response -> string option
 val set_server : response -> value:string -> unit
-val serialize : response -> Lwt_io.output_channel -> unit Lwt.t
+val serialize :
+  response ->
+  'a -> ('a -> string -> unit Lwt.t) -> ('a -> string -> int -> int -> unit Lwt.t) ->
+  unit Lwt.t
+val serialize_to_output_channel : response -> Lwt_io.output_channel -> unit Lwt.t
+val serialize_to_stream : response -> string Lwt_stream.t


### PR DESCRIPTION
Here is the cohttp half of the change we discussed to hide the output channel from the handler, so that different handler invocations can't interfere. It renames `serialize` to `serialize_to_output_channel` and adds a new `serialize_to_stream` function, in both `Http_message` and `Http_response`. You can see in `serialize_to_stream` that in the `write_from_exactly` case the buffer is copied.
