### PR TITLE
sharing constraints -> destructive substitution

### DIFF
--- a/async/cohttp_async.mli
+++ b/async/cohttp_async.mli
@@ -24,13 +24,13 @@ val body_to_string : string Pipe.Reader.t -> string Deferred.t
 module IO : Cohttp.IO.S
 
 module Request : sig
-  include module type of Cohttp.Request with type t = Cohttp.Request.t
-  include Cohttp.Request.S with module IO=IO
+  include module type of Cohttp.Request  with type t = Cohttp.Request.t
+  include Cohttp.Request.S with module IO := IO
 end
 
 module Response : sig
   include module type of Cohttp.Response with type t = Cohttp.Response.t
-  include Cohttp.Response.S with module IO=IO
+  include Cohttp.Response.S with module IO := IO
 end
 
 module Client : sig
@@ -83,18 +83,18 @@ module Server : sig
 
   (** Respond with a [string] Pipe that provides the response string Pipe.Reader.t.
       @param code Default is HTTP 200 `OK *)
-  val respond_with_pipe : 
-    ?headers:Cohttp.Header.t -> ?code:Cohttp.Code.status_code -> 
+  val respond_with_pipe :
+    ?headers:Cohttp.Header.t -> ?code:Cohttp.Code.status_code ->
     string Pipe.Reader.t -> response Deferred.t
 
   (** Respond with a static [string] string Pipe.Reader.t
       @param code Default is HTTP 200 `OK *)
-  val respond_with_string : 
-    ?headers:Cohttp.Header.t -> ?code:Cohttp.Code.status_code -> 
+  val respond_with_string :
+    ?headers:Cohttp.Header.t -> ?code:Cohttp.Code.status_code ->
     string -> response Deferred.t
 
   (** Respond with file contents, and [error_string Pipe.Reader.t] if the file isn't found *)
-  val respond_with_file : 
+  val respond_with_file :
     ?headers:Cohttp.Header.t -> ?error_body:string ->
     string -> response Deferred.t
 

--- a/cohttp/request.mli
+++ b/cohttp/request.mli
@@ -19,7 +19,7 @@
 
 (** This contains the metadata for a HTTP/1.1 request header, including
     the {!headers}, {!version}, {!meth} and {!uri}.  The body is handled by
-    the separate {!S} module type, as it is dependent on the IO 
+    the separate {!S} module type, as it is dependent on the IO
     implementation. *)
 type t
 
@@ -38,7 +38,7 @@ val version : t -> Code.version
 (** Retrieve the transfer encoding of this HTTP request *)
 val encoding : t -> Transfer.encoding
 
-val make : ?meth:Code.meth -> ?version:Code.version -> 
+val make : ?meth:Code.meth -> ?version:Code.version ->
   ?encoding:Transfer.encoding -> ?headers:Header.t ->
   Uri.t -> t
 
@@ -64,4 +64,4 @@ module type S = sig
   val read_form : t -> IO.ic -> (string * string list) list IO.t
 end
 
-module Make(IO : IO.S) : S with module IO = IO
+module Make(IO : IO.S) : S with module IO := IO

--- a/cohttp/response.mli
+++ b/cohttp/response.mli
@@ -30,10 +30,10 @@ val version : t -> Code.version
 val status : t -> Code.status_code
 
 val make :
-  ?version:Code.version -> 
+  ?version:Code.version ->
   ?status:Code.status_code ->
-  ?encoding:Transfer.encoding -> 
-  ?headers:Header.t -> 
+  ?encoding:Transfer.encoding ->
+  ?headers:Header.t ->
   unit -> t
 
 module type S = sig
@@ -52,4 +52,4 @@ module type S = sig
   val write : (t -> IO.oc -> unit IO.t) -> t -> IO.oc -> unit IO.t
 end
 
-module Make(IO : IO.S) : S with module IO = IO
+module Make(IO : IO.S) : S with module IO := IO


### PR DESCRIPTION
I'm not sure if this builds because I couldn't build it against the version of URI in OPAM.  But I went ahead and gamely added in the bits of destructive substitution that I thought would be helpful.  I now understand why there is a request sub-module; that's because there are IO operations for Request.t's.  That seems reasonable enough, and the duplication isn't terrible, I think.  But there's no reason to have separate copies of the IO module in the different interfaces, and that's what this patch does.
