### PR TITLE
renaming for consistency #44

### DIFF
--- a/cohttp/cookie.ml
+++ b/cohttp/cookie.ml
@@ -34,10 +34,8 @@ module Set_cookie_hdr = struct
     secure : bool }
 
   (* Does not check the contents of name or value for ';', ',', '\s', or name[0]='$' *)
-  let make ?(expiry=`Session) ?path ?domain ?(secure=false) cookie =
-    { cookie = cookie;
-    expiration = expiry; domain = domain;
-    path = path; secure = secure }
+  let make ?(expiration=`Session) ?path ?domain ?(secure=false) cookie =
+    { cookie ; expiration ; domain ; path ; secure }
     
   (* TODO: deprecated by RFC 6265 and almost certainly buggy without
      reference to cookie field *)
@@ -121,12 +119,12 @@ module Set_cookie_hdr = struct
       | _ -> (fun _ a -> a)
     ) hdr []
 
-  let binding { cookie } = cookie
-  let value { cookie=(_,v) } = v
+  let cookie { cookie } = cookie
   let expiration { expiration } = expiration
   let domain { domain } = domain
   let path { path } = path
-  let is_secure { secure } = secure
+  let secure { secure } = secure
+  let value { cookie=(_,v) } = v
 end
 
 module Cookie_hdr = struct

--- a/cohttp/cookie.mli
+++ b/cohttp/cookie.mli
@@ -10,7 +10,7 @@ module Set_cookie_hdr : sig
     returns the cookie in future requests, under certain conditions. *)
 
   val make :
-    ?expiry:expiration ->
+    ?expiration:expiration ->
     ?path:string ->
     ?domain:string -> ?secure:bool -> cookie -> t
 
@@ -22,7 +22,7 @@ module Set_cookie_hdr : sig
   val extract : Header.t -> (string * t) list
   (** Return the list of cookies sent by the server *)
 
-  val binding : t -> cookie
+  val cookie : t -> cookie
   (** The name-value binding *)
 
   val value : t -> string
@@ -37,7 +37,7 @@ module Set_cookie_hdr : sig
   val path : t -> string option
   (** The path for which the cookie is valid, if any *)
 
-  val is_secure : t -> bool
+  val secure : t -> bool
   (** Has the cookie's secure attribute been set? *)
 end
 

--- a/lib_test/test_header.ml
+++ b/lib_test/test_header.ml
@@ -28,7 +28,7 @@ let valid_auth () =
   assert_equal (H.get_authorization h) (Some auth)
 
 let valid_set_cookie () =
-  let c = Cohttp.Cookie.Set_cookie_hdr.make ~expiry:`Session
+  let c = Cohttp.Cookie.Set_cookie_hdr.make ~expiration:`Session
      ~path:"/foo/bar" ~domain:"ocaml.org"
 	 ~secure:true ("key", "value") in
   let k, v = Cohttp.Cookie.Set_cookie_hdr.serialize ~version:`HTTP_1_0 c in


### PR DESCRIPTION
expiry -> expiration
is_secure -> secure
binding -> cookie

will look around for more to squeeze in as many breakers before 1.0
