### PR TITLE
remove manually defined accessors in mlis

### DIFF
--- a/cohttp/request.mli
+++ b/cohttp/request.mli
@@ -22,27 +22,12 @@
     the separate {!S} module type, as it is dependent on the IO 
     implementation. *)
 type t = {
-  mutable headers: Header.t;
-  mutable meth: Code.meth;
-  mutable uri: Uri.t;
-  mutable version: Code.version;
-  mutable encoding: Transfer.encoding;
+  mutable headers: Header.t;    (** HTTP request headers *)
+  mutable meth: Code.meth;      (** HTTP request method *)
+  mutable uri: Uri.t;           (** Full HTTP request uri *)
+  mutable version: Code.version; (** HTTP version, usually 1.1 *)
+  mutable encoding: Transfer.encoding; (** transfer encoding of this HTTP request *)
 } with fields, sexp
-
-(** Retrieve the HTTP request headers *)
-val headers : t -> Header.t
-
-(** Retrieve the HTTP request method *)
-val meth : t -> Code.meth
-
-(** Retrieve the full HTTP request uri *)
-val uri : t -> Uri.t
-
-(** Retrieve the HTTP version, usually 1.1 *)
-val version : t -> Code.version
-
-(** Retrieve the transfer encoding of this HTTP request *)
-val encoding : t -> Transfer.encoding
 
 val make : ?meth:Code.meth -> ?version:Code.version -> 
   ?encoding:Transfer.encoding -> ?headers:Header.t ->

--- a/cohttp/response.mli
+++ b/cohttp/response.mli
@@ -13,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+*)
 
 (** HTTP/1.1 response handling *)
 
@@ -24,24 +24,12 @@
     the separate {!S} module type, as it is dependent on the IO 
     implementation. *)
 type t = {
-  mutable encoding: Transfer.encoding;
-  mutable headers: Header.t;
-  mutable version: Code.version;
-  mutable status: Code.status_code;
+  mutable encoding: Transfer.encoding; (** Transfer encoding of this HTTP response *)
+  mutable headers: Header.t;    (** response HTTP headers *)
+  mutable version: Code.version; (** (** HTTP version, usually 1.1 *) *)
+  mutable status: Code.status_code; (** HTTP status code of the response *)
   mutable flush: bool;
 } with fields, sexp
-
-(** Retrieve response HTTP headers *)
-val headers : t -> Header.t
-
-(** Retrieve the transfer encoding of this HTTP response *)
-val encoding : t -> Transfer.encoding
-
-(** Retrieve HTTP version, usually 1.1 *)
-val version : t -> Code.version
-
-(** Retrieve HTTP status code of the response *)
-val status : t -> Code.status_code
 
 val make :
   ?version:Code.version -> 


### PR DESCRIPTION
I have a tiny preference for tightening up the mli's this way. Feel free to reject if you think that this is less noobie friendly however.
