### PR TITLE
pipe_of_body should not close any handles

### DIFF
--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -147,8 +147,6 @@ let pipe_of_body read_chunk ic oc =
       ) in
   don't_wait_for (
     finished >>= fun () ->
-    Writer.close oc >>= fun () ->
-    Reader.close ic >>= fun () ->
     return (Pipe.close wr)
   );
   rd
@@ -322,8 +320,8 @@ module Server = struct
         Body.write body res wr >>= fun () ->
         Response.write_footer res wr
       )
-    >>= fun () ->
-    Writer.close wr
+    >>= fun () -> Writer.close wr
+    >>= fun () -> Reader.close rd
 
   let respond ?(flush=false) ?(headers=Cohttp.Header.init ())
       ?(body=`Empty) status : response Deferred.t =


### PR DESCRIPTION
In keep alive mode connection is persistent. The closing logic is moved
to after the requests pipe has been cleared.

Fixes #105

This bug is probably my fault from my rote copying of the logic in pipe_of_body when I was cleaning it up to make it ready to support keep alive.
