### PR TITLE
signature golfing the client api

### DIFF
--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -114,7 +114,7 @@ end
 
 module Client = struct
 
-  type response_and_body = (Response.t * Body.t) Deferred.t
+  type response_with_body = (Response.t * Body.t) Deferred.t
 
   type 'response request =
     ?interrupt:unit Deferred.t

--- a/async/cohttp_async.mli
+++ b/async/cohttp_async.mli
@@ -46,7 +46,7 @@ end
 module Client : sig
 
   (** Full response consisting of headers, status code, and body *)
-  type response_and_body = (Response.t * Body.t) Deferred.t
+  type response_with_body = (Response.t * Body.t) Deferred.t
 
   (** Basic http request that returns [response] *)
   type 'response request =
@@ -60,29 +60,29 @@ module Client : sig
   type 'response with_body = ?chunked:bool -> ?body:Body.t -> 'response
 
   (** Send an HTTP GET request *)
-  val get : response_and_body request
+  val get : response_with_body request
 
   (** Send an HTTP HEAD request *)
   val head : Response.t Deferred.t request
 
   (** Send an HTTP DELETE request *)
-  val delete : response_and_body request
+  val delete : response_with_body request
 
   (** Send an HTTP POST request.  *)
-  val post : response_and_body request with_body
+  val post : response_with_body request with_body
 
   (** Send an HTTP PUT request.  *)
-  val put : response_and_body request with_body
+  val put : response_with_body request with_body
 
   (** Send an HTTP PATCH request.  *)
-  val patch : response_and_body request with_body
+  val patch : response_with_body request with_body
 
   (** Send an HTTP request with arbitrary method and a body *)
   val call : (?interrupt:unit Deferred.t
               -> ?headers:Cohttp.Header.t
               -> Cohttp.Code.meth
               -> Uri.t
-              -> response_and_body) with_body
+              -> response_with_body) with_body
 
 end
 


### PR DESCRIPTION
I know this is borderline too cute but the goal is to make the documentation a little more terse and yet still exhaustive. Any name changes/suggestions are all welcome. We also don't have to go all the way and choose a middle ground. I went as far as I could here.

Testing the waters with changes like these. I know I found all these typedefs annoying at first but began to appreciate them. Perhaps we can reuse some of these types with the lwt client?

P.S. `call` could be golfed to `(Cohttp.Status.meth -> full_response) request with_body` if we flip `Uri.t` and `Cohttp.Status.meth` but I don't think it's worth creating churn over stuff like that.
