### PR TITLE
has_body:t -> bool should return [`Yes|`No|`Unknown]

### DIFF
--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -189,8 +189,9 @@ module Server = struct
 
   let read_body req rd wr =
     match Request.has_body req with
-    | false -> `Empty
-    | true -> (* Create a Pipe for the body *)
+    (* TODO maybe attempt to read body *)
+    | `No | `Unknown -> `Empty
+    | `Yes -> (* Create a Pipe for the body *)
       let read_chunk = Request.read_body_chunk req in
       `Pipe (pipe_of_body read_chunk rd wr)
 

--- a/cohttp/request.ml
+++ b/cohttp/request.ml
@@ -64,7 +64,7 @@ module type S = sig
   module IO : IO.S
 
   val read : IO.ic -> [ `Eof | `Invalid of string | `Ok of t ] IO.t
-  val has_body : t -> bool
+  val has_body : t -> [ `No | `Unknown | `Yes ]
   val read_body_chunk :
     t -> IO.ic -> Transfer.chunk IO.t
 

--- a/cohttp/request.mli
+++ b/cohttp/request.mli
@@ -50,7 +50,7 @@ module type S = sig
   module IO : IO.S
 
   val read : IO.ic -> [ `Eof | `Invalid of string | `Ok of t ] IO.t
-  val has_body : t -> bool
+  val has_body : t -> [ `No | `Unknown | `Yes ]
   val read_body_chunk : t -> IO.ic -> Transfer.chunk IO.t
 
   val write_header : t -> IO.oc -> unit IO.t

--- a/cohttp/response.ml
+++ b/cohttp/response.ml
@@ -33,7 +33,7 @@ module type S = sig
   module IO : IO.S
 
   val read : IO.ic -> [ `Eof | `Invalid of string | `Ok of t ] IO.t
-  val has_body : t -> bool
+  val has_body : t -> [ `No | `Unknown | `Yes ]
   val read_body_chunk : t -> IO.ic -> Transfer.chunk IO.t
 
   val is_form: t -> bool

--- a/cohttp/response.mli
+++ b/cohttp/response.mli
@@ -47,7 +47,7 @@ module type S = sig
   module IO : IO.S
 
   val read : IO.ic -> [ `Eof | `Invalid of string | `Ok of t ] IO.t
-  val has_body : t -> bool
+  val has_body : t -> [ `No | `Unknown | `Yes ]
   val read_body_chunk : t -> IO.ic -> Transfer.chunk IO.t
 
   val is_form: t -> bool

--- a/cohttp/transfer.ml
+++ b/cohttp/transfer.ml
@@ -35,8 +35,8 @@ let encoding_to_string =
 
 let has_body =
   function
-  | Chunked -> true
-  | Fixed 0 -> false
-  | Unknown -> false
-  | Fixed _ -> true
+  | Fixed 0 -> `No
+  | Chunked
+  | Fixed _ -> `Yes
+  | Unknown -> `Unknown
 

--- a/cohttp/transfer.mli
+++ b/cohttp/transfer.mli
@@ -37,4 +37,4 @@ with sexp
 (** Convert the encoding format to a human-readable string *)
 val encoding_to_string : encoding -> string
 
-val has_body : encoding -> bool
+val has_body : encoding -> [ `No | `Unknown | `Yes ]


### PR DESCRIPTION
The convention that is being copied is core's Sys.is_file/directory
function. This fixes the issue where the lwt client will not read
responses that don't specify the content length.

I'm not thrilled about this change but it's fixing a bug for an actual users so I think we should definitely do something here. Ideally, I'd much rather not expose `has_body` outside the library at all (or at least we figure out the story for this better) but I don't know how to do this since hiding it in the mli hides it for our own use as well.
