### PR TITLE
remove `server` type synonym

### DIFF
--- a/lwt/cohttp_lwt.ml
+++ b/lwt/cohttp_lwt.ml
@@ -194,23 +194,13 @@ module Make_client
     return resps
 end
 
-type server = {
-  callback :
-    Cohttp.Connection.t ->
-    Cohttp.Request.t ->
-    Cohttp_lwt_body.t ->
-    (Cohttp.Response.t * Cohttp_lwt_body.t) Lwt.t;
-  conn_closed:
-    Cohttp.Connection.t -> unit -> unit;
-}
-
 (** Configuration of servers. *)
 module type Server = sig
   module IO : IO.S
   module Request : Request
   module Response : Response
 
-  type t = server = {
+  type t = {
     callback :
       Cohttp.Connection.t ->
       Cohttp.Request.t ->
@@ -260,7 +250,7 @@ module Make_server(IO:Cohttp.IO.S with type 'a t = 'a Lwt.t)
   module Request = Request
   module Response = Response
 
-  type t = server = {
+  type t = {
     callback :
       Cohttp.Connection.t ->
       Cohttp.Request.t ->

--- a/lwt/cohttp_lwt.mli
+++ b/lwt/cohttp_lwt.mli
@@ -125,22 +125,12 @@ module Make_client
     (Net:Net with module IO = IO) :
     Client with module IO=IO and module Request=Request and module Response=Response
 
-type server = {
-  callback :
-    Cohttp.Connection.t ->
-    Cohttp.Request.t ->
-    Cohttp_lwt_body.t ->
-    (Cohttp.Response.t * Cohttp_lwt_body.t) Lwt.t;
-  conn_closed:
-    Cohttp.Connection.t -> unit -> unit;
-}
-
 (** The [Server] module implements a pipelined HTTP/1.1 server. *)
 module type Server = sig
   module IO : IO.S
   module Request : Request
   module Response : Response
-  type t = server = {
+  type t = {
     callback :
       Cohttp.Connection.t ->
       Cohttp.Request.t ->
@@ -179,7 +169,7 @@ module type Server = sig
   val respond_not_found :
     ?uri:Uri.t -> unit -> (Response.t * Cohttp_lwt_body.t) Lwt.t
 
-  val callback : server -> IO.ic -> IO.oc -> unit Lwt.t
+  val callback : t -> IO.ic -> IO.oc -> unit Lwt.t
 
 end
 


### PR DESCRIPTION
not sure why it was added in the first place but i can't see the benefit
of having it.
