### PR TITLE
opam: depend explicitly on stringext

### DIFF
--- a/opam
+++ b/opam
@@ -17,6 +17,7 @@ depends: [
   "fieldslib" {>= "109.20.00"}
   "sexplib" {>= "109.53.00"}
   "conduit"
+  "stringext"
 ]
 depopts: [
   "async"


### PR DESCRIPTION
Closes ocaml/opam-repository#2001
