### PR TITLE
fixes #144

### DIFF
--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -205,15 +205,12 @@ module Server = struct
   let handle_client handle_request sock rd wr =
     let requests_pipe =
       Reader.read_all rd (fun rd ->
-          Request.read rd
-          >>| function
-          | `Eof | `Invalid _ -> `Eof
-          | `Ok req ->
-            let body = read_body req rd wr in
-            if not (Request.is_keep_alive req)
-            then don't_wait_for (Reader.close rd);
-            `Ok (req, body)
-        ) in
+        Request.read rd >>| function
+        | `Eof | `Invalid _ -> `Eof
+        | `Ok req ->
+          let body = read_body req rd wr in
+          `Ok (req, body)
+      ) in
     Pipe.iter requests_pipe ~f:(fun (req, body) ->
         handle_request ~body sock req >>= fun (res, body) ->
         let keep_alive = Request.is_keep_alive req in


### PR DESCRIPTION
Seems like we are closing the reader too eagerly. We can delay closing
it until after we've processed the client's requests.

@avsm I'm not sure why the old behavior was there, perhaps as an optimization? I will merge this because we're blocking @ericbmerritt .We can figure out what we actually want to do after.
