### PR TITLE
Split Fixed uploads into chunks

### DIFF
--- a/cohttp/request.ml
+++ b/cohttp/request.ml
@@ -102,7 +102,7 @@ module Make(IO : S.IO) = struct
       return (`Ok { headers; meth; uri; version; encoding })
 
   let has_body req = Transfer.has_body req.encoding
-  let read_body_chunk req ic = Transfer_IO.read req.encoding ic
+  let read_body_chunk req = Transfer_IO.read req.encoding
 
   let write_header req oc =
    let fst_line = Printf.sprintf "%s %s %s\r\n" (Code.string_of_method req.meth)


### PR DESCRIPTION
Instead of reading the entire upload into a single string, we now return one chunk each time the underlying [read] call returns some data. This avoids using large amounts of RAM, hitting the 16 MB string limit on 32-bit systems. It also allows the application to begin processing the data before it has all arrived.

Fixes #153.

Possibly we should also adjust `Chunked` to stream the individual chunks rather than using the uploader's chunk size too, but this is enough to make it work with `curl -T`.
