### PR TITLE
bin/cohttp_server: index files should be served directly, not redirected

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@
 * Improve `cohttp_server_lwt` and `cohttp_server_async` directory listings (#158)
 * Fix `Cohttp_async.resolve_local_file` directory traversal vulnerability (#158)
 * `cohttp_server_lwt` and `cohttp_server_async` now return better errors (#158)
+* `cohttp_server_lwt` and `cohttp_server_async` now serve indexes directly (#162)
 
 0.11.2 (2014-04-21)
 * Fix build by add a missing build-deps in _oasis.

--- a/bin/cohttp_server_async.ml
+++ b/bin/cohttp_server_async.ml
@@ -67,7 +67,7 @@ let rec handler ~info ~docroot ~verbose ~index ~body sock req =
       >>= function
       | `Yes -> (* Serve the index file directly *)
         let uri = Uri.with_path uri (path / index) in
-        Server.respond_with_redirect uri
+        serve_file ~docroot ~uri
       | `No | `Unknown -> (* Do a directory listing *)
         Sys.ls_dir file_name
         >>= Deferred.List.map ~f:(fun f ->

--- a/bin/cohttp_server_lwt.ml
+++ b/bin/cohttp_server_lwt.ml
@@ -71,7 +71,7 @@ let rec handler ~info ~docroot ~verbose ~index sock req body =
     | Unix.S_DIR -> begin
       match Sys.file_exists (file_name / index) with
       | true -> let uri = Uri.with_path uri (path / index) in
-                Server.respond_redirect uri ()
+                serve_file ~docroot ~uri
       | false ->
         ls_dir file_name
         >>= Lwt_list.map_s (fun f ->


### PR DESCRIPTION
This is the expected behavior of nginx, apache, etc.
