### PR TITLE
bin/cohttp_server: redirect bare directories to their slashed counterpart

### DIFF
--- a/bin/cohttp_server_async.ml
+++ b/bin/cohttp_server_async.ml
@@ -67,7 +67,10 @@ let rec handler ~info ~docroot ~verbose ~index ~body sock req =
       >>= function
       | `Yes -> (* Serve the index file directly *)
         let uri = Uri.with_path uri (path / index) in
-        serve_file ~docroot ~uri
+        let path_len = String.length path in
+        if path_len <> 0 && path.[path_len - 1] <> '/'
+        then Server.respond_with_redirect (Uri.with_path uri (path^"/"))
+        else serve_file ~docroot ~uri
       | `No | `Unknown -> (* Do a directory listing *)
         Sys.ls_dir file_name
         >>= Deferred.List.map ~f:(fun f ->

--- a/bin/cohttp_server_lwt.ml
+++ b/bin/cohttp_server_lwt.ml
@@ -71,7 +71,10 @@ let rec handler ~info ~docroot ~verbose ~index sock req body =
     | Unix.S_DIR -> begin
       match Sys.file_exists (file_name / index) with
       | true -> let uri = Uri.with_path uri (path / index) in
-                serve_file ~docroot ~uri
+                let path_len = String.length path in
+                if path_len <> 0 && path.[path_len - 1] <> '/'
+                then Server.respond_redirect (Uri.with_path uri (path^"/")) ()
+                else serve_file ~docroot ~uri
       | false ->
         ls_dir file_name
         >>= Lwt_list.map_s (fun f ->


### PR DESCRIPTION
Not a requirement or even a good idea... just conformance with common
servers. `dir` and `dir/` should almost certainly be collapsed but `dir`
-> `dir/` is common and `dir/` -> `dir` isn't (but is more aesthetic).
