### PR TITLE
closing fd's is sometimes helpful

### DIFF
--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -155,6 +155,10 @@ module Client = struct
     | `Ok res ->
       (* Build a response pipe for the body *)
       let rd = pipe_of_body (Response.read_body_chunk res) ic oc in
+      don't_wait_for (
+        Pipe.closed rd >>= fun () ->
+        Deferred.all_ignore [Reader.close ic; Writer.close oc]
+      );
       return (res, `Pipe rd)
 
   let get ?interrupt ?headers uri =


### PR DESCRIPTION
We don't have connection pooling for the client anyway so at least don't
be so buggy and close fd's after every request.
