### PR TITLE
Fix nodrain server handler on Async backend

### DIFF
--- a/lib_test/test_net_async_server.ml
+++ b/lib_test/test_net_async_server.ml
@@ -41,6 +41,11 @@ let handler ~body sock req =
       <li><i>Files</i></li>
       %s</ul></body></html>" 
     |> Server.respond_with_string
+  | "/post" ->
+    Body.to_string body >>= fun body ->
+    Server.respond_with_string body
+  | "/postnodrain" ->
+    Server.respond_with_string "nodrain"
   | "/hello" ->
     Server.respond_with_string "hello world"
   | "/hellopipe" ->
@@ -62,7 +67,7 @@ let make_net_server ?mode port =
   Server.create ?mode ~on_handler_error:`Raise (Tcp.on_port port) handler
 
 let _ = 
-  let _server = make_net_server 8080 in
+  let _server = make_net_server 8081 in
   let mode = `OpenSSL (`Crt_file_path "server.crt", `Key_file_path "server.key") in
   let _ssl_server = make_net_server ~mode 8443 in
   let () = every (sec 3.0) (fun () ->

--- a/lib_test/test_post_with_curl.sh
+++ b/lib_test/test_post_with_curl.sh
@@ -36,3 +36,11 @@ if [ "$RES" != "$BODYND$BODYND$BODYND$BODYND$BODYND" ]; then
 else
   echo OK
 fi
+echo Testing large post no drained:
+RES=`head -c 100000 /dev/urandom | curl -sX POST -H Expect: --data-binary @- $URLND $URLND $URLND $URLND $URLND`
+if [ "$RES" != "$BODYND$BODYND$BODYND$BODYND$BODYND" ]; then
+  echo "$RES not $BODYND$BODYND$BODYND$BODYND$BODYND"
+  exit 1
+else
+  echo OK
+fi


### PR DESCRIPTION
Making a huge request to Async backend server that never drain the
request body causes the server handler stuck.

Expecting `Pipe.closed` is wrong in general because a server handler can
close the pipe without draing the request body.

This fix introduces a synchronization variable to make sure reading a
request header after draining the last request body, like Lwt backend
does.
