### PR TITLE
Added explicit reader and writer types to API

### DIFF
--- a/cohttp/header_io.ml
+++ b/cohttp/header_io.ml
@@ -44,6 +44,7 @@ module Make(IO : S.IO) = struct
   let parse_form headers ic =
     (* If the form is query-encoded, then extract those parameters also *)
     let encoding = Header.get_transfer_encoding headers in
-    Transfer_IO.to_string encoding ic >>= fun body ->
+    let reader = Transfer_IO.make_reader encoding ic in
+    Transfer_IO.to_string reader >>= fun body ->
     return (Uri.query_of_encoded body)
 end

--- a/cohttp/s.mli
+++ b/cohttp/s.mli
@@ -36,19 +36,23 @@ end
 
 module type Http_io = sig
   type t
+  type reader
+  type writer
   module IO : IO
 
   val read : IO.ic -> [ `Eof | `Invalid of string | `Ok of t ] IO.t
   val has_body : t -> [ `No | `Unknown | `Yes ]
-  val read_body_chunk : t -> IO.ic -> Transfer.chunk IO.t
+  val make_body_reader : t -> IO.ic -> reader
+  val read_body_chunk : reader -> Transfer.chunk IO.t
 
   val is_form: t -> bool
   val read_form : t -> IO.ic -> (string * string list) list IO.t
 
   val write_header : t -> IO.oc -> unit IO.t
-  val write_body : t -> IO.oc -> string -> unit IO.t
+  val make_body_writer : t -> IO.oc -> writer
+  val write_body : writer -> string -> unit IO.t
   val write_footer : t -> IO.oc -> unit IO.t
-  val write : (t -> IO.oc -> unit IO.t) -> t -> IO.oc -> unit IO.t
+  val write : (writer -> unit IO.t) -> t -> IO.oc -> unit IO.t
 end
 
 module type Request = sig

--- a/cohttp/transfer_io.mli
+++ b/cohttp/transfer_io.mli
@@ -17,8 +17,13 @@
 
 open Transfer
 module Make(IO : S.IO) : sig
-  val read : encoding -> IO.ic -> chunk IO.t
-  val write : encoding -> IO.oc -> string -> unit IO.t 
-  val to_string : encoding -> IO.ic -> string IO.t
-end
+  type reader
+  type writer
 
+  val make_reader : encoding -> IO.ic -> reader
+  val make_writer : encoding -> IO.oc -> writer
+
+  val read : reader -> chunk IO.t
+  val write : writer -> string -> unit IO.t 
+  val to_string : reader -> string IO.t
+end

--- a/lwt/cohttp_lwt.ml
+++ b/lwt/cohttp_lwt.ml
@@ -135,7 +135,8 @@ module Make_client
     | `Ok res -> begin
         match Response.has_body res with
         | `Yes | `Unknown ->
-          let stream = Cohttp_lwt_body.create_stream (Response.read_body_chunk res) ic in
+          let reader = Response.make_body_reader res ic in
+          let stream = Cohttp_lwt_body.create_stream Response.read_body_chunk reader in
           (match closefn with
            |Some fn ->
              Lwt_stream.on_terminate stream fn;
@@ -157,16 +158,16 @@ module Make_client
     match chunked with
     | true ->
       let req = Request.make_for_client ~headers ~chunked meth uri in
-      Request.write (fun req oc ->
-          Cohttp_lwt_body.write_body (Request.write_body req oc) body) req oc
+      Request.write (fun writer ->
+          Cohttp_lwt_body.write_body (Request.write_body writer) body) req oc
       >>= fun () ->
       read_response ~closefn ic oc
     | false ->
       (* If chunked is not allowed, then obtain the body length and insert header *)
       lwt (body_length, buf) = Cohttp_lwt_body.length body in
       let req = Request.make_for_client ~headers ~chunked ~body_length meth uri in
-      Request.write (fun req oc ->
-          Cohttp_lwt_body.write_body (Request.write_body req oc) buf) req oc
+      Request.write (fun writer ->
+          Cohttp_lwt_body.write_body (Request.write_body writer) buf) req oc
       >>= fun () ->
       read_response ~closefn ic oc
 
@@ -191,8 +192,8 @@ module Make_client
     lwt (conn, ic, oc) = Net.connect_uri ~ctx uri in
     (* Serialise the requests out to the wire *)
     let _ = Lwt_stream.iter_s (fun (req,body) ->
-        Request.write (fun req oc ->
-            Cohttp_lwt_body.write_body (Request.write_body req oc) body) req oc)
+        Request.write (fun writer ->
+            Cohttp_lwt_body.write_body (Request.write_body writer) body) req oc)
         reqs in
     (* Read the responses. For each response, ensure that the previous response
      * has consumed the body before continuing to the next response, since HTTP/1.1
@@ -345,7 +346,8 @@ module Make_server(IO:Cohttp.S.IO with type 'a t = 'a Lwt.t)
                 (* Ensure the input body has been fully read before reading again *)
                 match Request.has_body req with
                 | `Yes ->
-                  let body_stream = Cohttp_lwt_body.create_stream (Request.read_body_chunk req) ic in
+                  let reader = Request.make_body_reader req ic in
+                  let body_stream = Cohttp_lwt_body.create_stream Request.read_body_chunk reader in
                   Lwt_stream.on_terminate body_stream (fun () -> Lwt_mutex.unlock read_m);
                   let body = Cohttp_lwt_body.of_stream body_stream in
                   (* The read_m remains locked until the caller reads the body *)
@@ -378,8 +380,8 @@ module Make_server(IO:Cohttp.S.IO with type 'a t = 'a Lwt.t)
           else
             fun () -> return_unit
         in
-        Response.write (fun res oc ->
-          Cohttp_lwt_body.write_body ~flush (Response.write_body res oc) body
+        Response.write (fun writer ->
+          Cohttp_lwt_body.write_body ~flush (Response.write_body writer) body
         ) res oc
       done
     in daemon_callback


### PR DESCRIPTION
When reading data from a stream using the Fixed encoding, we need to
maintain state (bytes remaining) so we know when to finish. Previously,
this state was created by partially applying the read function, but this
behaviour is non-obvious.

Note: this is a backwards-incompatible change.
