### PR TITLE
eta-contract Response.read_body_chunk as we already have for Request.rea...

### DIFF
--- a/cohttp/response.ml
+++ b/cohttp/response.ml
@@ -63,7 +63,7 @@ module Make(IO : S.IO) = struct
        return (`Ok { encoding; headers; version; status; flush })
 
   let has_body {encoding} = Transfer.has_body encoding
-  let read_body_chunk {encoding} ic = Transfer_IO.read encoding ic
+  let read_body_chunk {encoding} = Transfer_IO.read encoding
 
   let write_header res oc =
     write oc (Printf.sprintf "%s %s\r\n" (Code.string_of_version res.version) 


### PR DESCRIPTION
...d_body_chunk

This allows a streaming download loop like the following:

```
  let reader = Response.read_body_chunk response in
  (* the remaining length reference cell is now captured in 'reader' *)
  let rec loop () =
    reader ic
    >>= function
    | Cohttp.Transfer.Chunk x ->
      Buffer.add_string body x;
      loop ()
    | Cohttp.Transfer.Final_chunk x  ->
      Buffer.add_string body x;
      return (Buffer.contents body)
    | Cohttp.Transfer.Done ->
      return (Buffer.contents body) in
  loop () >>= fun body ->
```

Without this, every call to reader ic generates a fresh reference cell and the
download never completes.

This mirrors the API in #154

Signed-off-by: David Scott dave.scott@eu.citrix.com
