### PR TITLE
Cohttp.Auth: Rename `resp` to `credential` and `req` to `challenge`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,9 +2,10 @@
 
 Compatibility breaking interface changes:
 
-* Rename `Cohttp.Auth.t` to `Cohttp.Auth.resp` to make it match the
-  existing `Cohttp.Auth.req` type.  Also expose an `Other` variant
-  to make it more extensible for unknown authentication types.
+* Rename `Cohttp.Auth.t` to `Cohttp.Auth.credential` and `Cohttp.Auth.req`
+  to `Cohttp.Auth.challenge`.  Also expose an `Other` variant
+  to make it more extensible for unknown authentication types. The
+  `Cohttp.Auth` functions using these types have also been renamed accordingly.
 * Rename `Cohttp.Transfer.encoding_to_string` to `string_of_encoding`
   for consistency with the rest of Cohttp's APIs.
 * The `has_body` function in the Request and Response modules now

--- a/cohttp/auth.ml
+++ b/cohttp/auth.ml
@@ -18,22 +18,22 @@
 open Sexplib.Std
 open Printf
 
-type req = [
+type challenge = [
  | `Basic of string (* realm *)
 ] with sexp
 
-type resp = [
+type credential = [
  | `Basic of string * string (* username, password *)
  | `Other of string
 ]  with sexp
 
-let string_of_resp (resp:resp) =
-  match resp with
+let string_of_credential (cred:credential) =
+  match cred with
   | `Basic (user, pass) ->
     "Basic " ^ (Base64.encode (sprintf "%s:%s" user pass))
   | `Other buf -> buf
 
-let resp_of_string (buf:string) : resp =
+let credential_of_string (buf:string) : credential =
   try
     let b64 = Scanf.sscanf buf "Basic %s" (fun b -> b) in
     match Stringext.split ~on:':' (Base64.decode b64) ~max:2 with
@@ -41,6 +41,6 @@ let resp_of_string (buf:string) : resp =
     |_ -> `Other buf
   with _ -> `Other buf
 
-let string_of_req (ty:req) =
+let string_of_challenge (ty:challenge) =
   match ty with
   |`Basic realm -> sprintf "Basic realm=\"%s\"" realm

--- a/cohttp/auth.mli
+++ b/cohttp/auth.mli
@@ -15,34 +15,37 @@
  *
  *)
 
-(** HTTP Authentication header parsing and generation *)
+(** HTTP Authentication and Authorization header parsing and generation *)
 
-(** HTTP authentication request types *)
-type req = [
- | `Basic of string (* Basic authorization with a realm *)
+(** HTTP authentication challenge types *)
+type challenge = [
+ | `Basic of string (** Basic authentication within a realm *)
 ] with sexp
 
-(** HTTP authentication response types *)
-type resp = [
-  | `Basic of string * string (** Basic authorization with a username and password *)
-  | `Other of string (* An unknown response header that will be passed straight through to the HTTP layer *)
+(** HTTP authorization credential types *)
+type credential = [
+  | `Basic of string * string
+  (** Basic authorization with a username and password *)
+  | `Other of string
+  (** An unknown credential type that will be passed straight through
+      to the application layer *)
 ] with sexp
 
-(** [string_of_resp] converts the {!resp} to a string compatible
-    with the HTTP/1.1 wire format for responses *)
-val string_of_resp : resp -> string
+(** [string_of_credential] converts the {!credential} to a string compatible
+    with the HTTP/1.1 wire format for authorization credentials ("responses") *)
+val string_of_credential : credential -> string
 
-(** [resp_of_string resp] converts a HTTP response to an authorization
-    request into a {!resp}.  If the response is not recognized, [None]
-    is returned. *)
-val resp_of_string : string -> resp
+(** [credential_of_string cred_s] converts an HTTP response to an
+    authentication challenge into a {!credential}.  If the credential is not
+    recognized, [`Other cred_s] is returned. *)
+val credential_of_string : string -> credential
 
-(** [string_of_req req] converts the {!req} to a string compatible with
-    the HTTP/1.1 wire format for authorization requests.
+(** [string_of_challenge challenge] converts the {!challenge} to a string
+    compatible with the HTTP/1.1 wire format for authentication challenges.
 
-    For example, a {!Basic} request with realm ["foo"] will be 
+    For example, a [`Basic] challenge with realm ["foo"] will be
     marshalled to ["Basic realm=foo"], which can then be combined
     with a [www-authenticate] HTTP header and sent back to the
     client.  There is a helper function {!Header.add_authorization_req}
     that does just this. *)
-val string_of_req : req -> string
+val string_of_challenge : challenge -> string

--- a/cohttp/header.ml
+++ b/cohttp/header.ml
@@ -177,16 +177,16 @@ let add_transfer_encoding headers enc =
   |Unknown, Fixed len -> add headers "content-length" (Int64.to_string len)
   |Unknown, Unknown -> headers
 
-let add_authorization_req headers req =
-  add headers "www-authenticate" (Auth.string_of_req req)
+let add_authorization_req headers challenge =
+  add headers "www-authenticate" (Auth.string_of_challenge challenge)
 
-let add_authorization headers auth =
-  add headers "authorization" (Auth.string_of_resp auth)
+let add_authorization headers cred =
+  add headers "authorization" (Auth.string_of_credential cred)
 
 let get_authorization headers =
   match get headers "authorization" with
   |None -> None
-  |Some v -> Some (Auth.resp_of_string v)
+  |Some v -> Some (Auth.credential_of_string v)
 
 let is_form headers =
   get_media_type headers = (Some "application/x-www-form-urlencoded")

--- a/cohttp/header.mli
+++ b/cohttp/header.mli
@@ -68,9 +68,9 @@ val get_acceptable_encodings : t -> Accept.encoding Accept.qlist
 val get_acceptable_languages : t -> Accept.language Accept.qlist
 val get_transfer_encoding : t -> Transfer.encoding
 val add_transfer_encoding : t -> Transfer.encoding -> t
-val add_authorization : t -> Auth.resp -> t
-val get_authorization : t -> Auth.resp option
-val add_authorization_req : t -> Auth.req -> t
+val add_authorization : t -> Auth.credential -> t
+val get_authorization : t -> Auth.credential option
+val add_authorization_req : t -> Auth.challenge -> t
 val is_form : t -> bool
 
 val user_agent : string

--- a/lwt/cohttp_lwt.ml
+++ b/lwt/cohttp_lwt.ml
@@ -251,7 +251,8 @@ module type Server = sig
 
   val respond_need_auth :
     ?headers:Cohttp.Header.t ->
-    auth:Cohttp.Auth.req -> unit -> (Cohttp.Response.t * Cohttp_lwt_body.t) Lwt.t
+    auth:Cohttp.Auth.challenge ->
+    unit -> (Cohttp.Response.t * Cohttp_lwt_body.t) Lwt.t
 
   val respond_not_found :
     ?uri:Uri.t -> unit -> (Cohttp.Response.t * Cohttp_lwt_body.t) Lwt.t

--- a/lwt/cohttp_lwt.mli
+++ b/lwt/cohttp_lwt.mli
@@ -195,7 +195,7 @@ module type Server = sig
 
   val respond_need_auth :
     ?headers:Cohttp.Header.t ->
-    auth:Cohttp.Auth.req -> unit -> (Response.t * Cohttp_lwt_body.t) Lwt.t
+    auth:Cohttp.Auth.challenge -> unit -> (Response.t * Cohttp_lwt_body.t) Lwt.t
 
   val respond_not_found :
     ?uri:Uri.t -> unit -> (Response.t * Cohttp_lwt_body.t) Lwt.t


### PR DESCRIPTION
Also update docs and rename functions exposed in `Auth` accordingly.
Fixes #194.
