### PR TITLE
Simplify lwt server

### DIFF
--- a/bin/cohttp_server_lwt.ml
+++ b/bin/cohttp_server_lwt.ml
@@ -136,7 +136,7 @@ let string_of_sockaddr = function
 let start_server docroot port host index verbose cert key () =
   printf "Listening for HTTP request on: %s %d\n" host port;
   let info = sprintf "Served by Cohttp/Lwt listening on %s:%d" host port in
-  let conn_closed (ch,conn) () =
+  let conn_closed (ch,conn) =
     printf "connection %s closed\n%!"
       (Sexplib.Sexp.to_string_hum (Conduit_lwt_unix.sexp_of_flow ch)) in
   let callback = handler ~info ~docroot ~verbose ~index in

--- a/lib_test/test_net_lwt_client_and_server.ml
+++ b/lib_test/test_net_lwt_client_and_server.ml
@@ -40,11 +40,10 @@ let make_server () =
        Server.respond_string ~status:`OK ~body:"nodrain" ()
     |_ -> exit 0
   in
-  let conn_closed _ () = () in
   lwt ctx = Conduit_lwt_unix.init ~src:address () in
   let ctx = Cohttp_lwt_unix_net.init ~ctx () in
   let mode = `TCP (`Port port) in
-  let config = Server.make ~callback ~conn_closed in
+  let config = Server.make ~callback in
   Server.create ~ctx ~mode config
 
 let not_none n t fn =

--- a/lib_test/test_net_lwt_server.ml
+++ b/lib_test/test_net_lwt_server.ml
@@ -91,7 +91,7 @@ let make_server () =
        let fname = Server.resolve_file ~docroot:"." ~uri:(Request.uri req) in
        Server.respond_file ~fname ()
   in
-  let conn_closed (ch,conn_id) () =
+  let conn_closed (ch,conn_id) =
     Printf.eprintf "conn %s closed\n%!" (Connection.to_string conn_id)
   in
   let config = Server.make ~callback ~conn_closed in

--- a/lwt/cohttp_lwt.mli
+++ b/lwt/cohttp_lwt.mli
@@ -165,7 +165,7 @@ module type Server = sig
 
   type t
 
-  val make : ?conn_closed:(conn -> unit -> unit)
+  val make : ?conn_closed:(conn -> unit)
     -> callback:(conn -> Cohttp.Request.t -> Cohttp_lwt_body.t
                  -> (Cohttp.Response.t * Cohttp_lwt_body.t) Lwt.t)
     -> t


### PR DESCRIPTION
- simplify signatures with some aliases
- make Server.t abstract and expose constructor (`make`)
- Remove seemingly redundant `unit` arg in `conn_closed`

these are breaking changes but trivial imo.
