### PR TITLE
Lwt 2.4.7 renamed blit_bytes_string -> blit_to_bytes

### DIFF
--- a/lib_test/test_parser.ml
+++ b/lib_test/test_parser.ml
@@ -224,7 +224,7 @@ let res_chunked_parse () =
 let get_substring oc buf =
   let len = Int64.to_int (Lwt_io.position oc) in
   let b = String.create len in
-  Lwt_bytes.blit_bytes_string buf 0 b 0 len;
+  Lwt_bytes.blit_to_bytes buf 0 b 0 len;
   b
 
 let write_req expected req =


### PR DESCRIPTION
Thus tests fail to compile. This PR just updates to the new name. This probably also requires a version bump of Lwt im `_opam`, let me know if I should add it.