### PR TITLE
Transfer_io: read until EOF when body size is unknown

### DIFF
--- a/_tags
+++ b/_tags
@@ -555,3 +555,4 @@ true: annot, bin_annot
 <examples/async/receive_post.{native,byte}>: custom
 # OASIS_STOP
 true: principal, strict_sequence, debug, short_paths
+true: annot

--- a/lib/code.mli
+++ b/lib/code.mli
@@ -29,8 +29,10 @@ type success_status =
 
 type redirection_status =
   [ `Multiple_choices (** multiple options for the resource delivered *)
-  | `Moved_permanently (** this and all future requests directed to the given URI *)
-  | `Found (** temporary response to request found via alternative URI *)
+  | `Moved_permanently (** this and all future requests directed to the
+                           URI provided as the "Location" header. *)
+  | `Found (** temporary response to request found via alternative URI
+               provided by the "Location" header. *)
   | `See_other (** permanent response to request found via alternative URI *)
   | `Not_modified (** resource has not been modified since last requested *)
   | `Use_proxy (** content located elsewhere, retrieve from there *)

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -63,7 +63,7 @@ module type IO = sig
   (** [read_exactly ic len] will block until exactly [len] characters
       are read from the input channel [ic].  If EOF or some other
       error condition is reached, then {!None} is returned. *)
-  val read_exactly : ic -> int -> string option t 
+  val read_exactly : ic -> int -> string option t
 
   (** [write oc s] will block until the complete [s] string is
       written to the output channel [oc]. *)

--- a/lib/transfer_io.ml
+++ b/lib/transfer_io.ml
@@ -74,10 +74,12 @@ module Make(IO : S.IO) = struct
   end
 
   module Unknown = struct
-    (* If we have no idea, then read one chunk and return it.
-     * TODO should this be a read with an explicit timeout? *)
+    (* If we have no idea, then read until EOF (connection shutdown by
+       the remote party). *)
     let read ic () =
-      read ic 16384 >>= fun buf -> return (Final_chunk buf)
+      read ic 4096 >>= fun buf ->
+      if buf = "" then return(Done)
+      else return (Chunk buf)
 
     let write oc buf =
       write oc buf


### PR DESCRIPTION
Fixes https://github.com/mirage/ocaml-cohttp/issues/239