### PR TITLE
Add `Cohttp.Header.mem` to check if a header exists

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.15.2 (trunk):
 * Add some missing documentation to `Cohttp.S.IO` signature (#233)
+* Add `Cohttp.Header.mem` to check if a header exists.
 
 0.15.1 (2015-01-10):
 * Lwt 2.4.7 renamed `blit_bytes_string` to `blit_to_bytes`, so depend

--- a/lib/header.ml
+++ b/lib/header.ml
@@ -78,6 +78,8 @@ let get =
         else Some (List.hd v)
     with Not_found | Failure _ -> None
 
+let mem h k = StringMap.mem (LString.of_string k) h
+
 let get_multi h k =
   let k = LString.of_string k in
   try StringMap.find k h with Not_found -> []

--- a/lib/header.mli
+++ b/lib/header.mli
@@ -42,6 +42,9 @@ val remove : t -> string -> t
     header parameter is not modified. *)
 val replace : t -> string -> string -> t
 
+(** Check if a key exists in the header. *)
+val mem : t -> string -> bool
+
 (** Retrieve a key from a header.  If the header is one of the set of
     headers defined to have list values, then all of the values are
     concatenated into a single string separated by commas and returned.


### PR DESCRIPTION
This is quicker than retrieving the header, which constructs a
list of values.