### PR TITLE
Improve header handling

### DIFF
--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -252,7 +252,7 @@ module Server = struct
         let keep_alive = Request.is_keep_alive req in
         let flush = Response.flush res in
         let res =
-          let headers = Cohttp.Header.add
+          let headers = Cohttp.Header.add_unless_exists
               (Cohttp.Response.headers res)
               "connection"
               (if keep_alive then "keep-alive" else "close") in

--- a/lib/header.ml
+++ b/lib/header.ml
@@ -80,6 +80,11 @@ let get =
 
 let mem h k = StringMap.mem (LString.of_string k) h
 
+let add_unless_exists h k v =
+  if mem h k
+  then h
+  else add h k v
+
 let get_multi h k =
   let k = LString.of_string k in
   try StringMap.find k h with Not_found -> []
@@ -174,7 +179,7 @@ let add_transfer_encoding headers enc =
   (* Only add a header if one doesnt already exist, e.g. from the app *)
   match get_transfer_encoding headers, enc with
   |Fixed _,_  (* App has supplied a content length, so use that *)
-  |Chunked,_ -> headers (* TODO: this is a protocol violation *)
+  |Chunked, _ -> headers (* TODO: this is a protocol violation *)
   |Unknown, Chunked -> add headers "transfer-encoding" "chunked"
   |Unknown, Fixed len -> add headers "content-length" (Int64.to_string len)
   |Unknown, Unknown -> headers

--- a/lib/header.mli
+++ b/lib/header.mli
@@ -34,6 +34,10 @@ val add : t -> string -> string -> t
     the header is [None] *)
 val add_opt : t option -> string -> string -> t
 
+(** Given a header, update it with the key and value unless the key is
+    already present in the header *)
+val add_unless_exists : t -> string -> string -> t
+
 (** Remove a key from the header map and return a fresh header set.  The
     original header parameter is not modified. *)
 val remove : t -> string -> t

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -110,7 +110,7 @@ module Make(IO : S.IO) = struct
   let write_header req oc =
    let fst_line = Printf.sprintf "%s %s %s\r\n" (Code.string_of_method req.meth)
       (Uri.path_and_query req.uri) (Code.string_of_version req.version) in
-    let headers = Header.add req.headers "host"
+    let headers = Header.add_unless_exists req.headers "host"
         (Uri.host_with_default ~default:"localhost" req.uri ^
            match Uri.port req.uri with
            | Some p -> ":" ^ string_of_int p

--- a/lwt/cohttp_lwt.ml
+++ b/lwt/cohttp_lwt.ml
@@ -313,7 +313,7 @@ module Make_server(IO:Cohttp.S.IO with type 'a t = 'a Lwt.t)
     let headers =
       match headers with
       |None -> Header.init_with "location" (Uri.to_string uri)
-      |Some h -> Header.add h "location" (Uri.to_string uri)
+      |Some h -> Header.add_unless_exists h "location" (Uri.to_string uri)
     in
     respond ~headers ~status:`Found ~body:`Empty ()
 


### PR DESCRIPTION
`add_maybe` and `add_opt` are both bad names I feel. But it seems like enough people are already using `add_opt` https://github.com/search?q=add_opt+language%3AOCaml&type=Code&utf8=%E2%9C%93

Any suggestions for `add_maybe` though?

EDIT: there are a few cases remaining where I've allowed the old "overriding" behavior because the user can call it explicitly. E.g. `add_authorization{,_req}`.