### PR TITLE
Better Request handling of transfer-encoding

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ New features and bug fixes:
   RFC7231 forbids from having one (`HEAD`, `GET` and `DELETE`).
 * `Request.make` does not inject a `transfer-encoding` header if there
   is no body present in the request (#246).
+* `Server.respond` no longer overrides user-supplied headers that
+  specify the `content-length` or `transfer-encoding` headers (#268).
 
 0.15.2 (2015-02-15):
 * When transfer encoding is unknown, read until EOF when body size is unknown. (#241)

--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,10 @@ New features and bug fixes:
   an override wasn't supplied, and to initialise a fresh Header value
   if none is present.
 * Do not override user-supplied headers in `post_form` or `redirect`.
+* `Request.has_body` does not permit a body to be set for methods that
+  RFC7231 forbids from having one (`HEAD`, `GET` and `DELETE`).
+* `Request.make` does not inject a `transfer-encoding` header if there
+  is no body present in the request (#246).
 
 0.15.2 (2015-02-15):
 * When transfer encoding is unknown, read until EOF when body size is unknown. (#241)

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,11 @@ generate:
 clean:
 	ocamlbuild -clean
 	rm -f setup.data setup.log setup.bin
+
+revdep:
+	opam switch system || true
+	opam switch remove -y cohttp-revdeps || true
+	opam switch -A system cohttp-revdeps
+	opam pin -y add cohttp .
+	for i in `opam list -s --rec --depends-on=cohttp`; do opam install -y -j 4 $$i; done
+	opam switch system

--- a/lwt/cohttp_lwt.ml
+++ b/lwt/cohttp_lwt.ml
@@ -298,7 +298,14 @@ module Make_server(IO:IO)
     Filename.concat docroot rel_path
 
   let respond ?headers ?(flush=true) ~status ~body () =
-    let encoding = Cohttp_lwt_body.transfer_encoding body in
+    let encoding = 
+      match headers with
+      | None -> Cohttp_lwt_body.transfer_encoding body
+      | Some headers ->
+         match Header.get_transfer_encoding headers with
+         | Transfer.Unknown -> Cohttp_lwt_body.transfer_encoding body
+         | t -> t
+    in
     let res = Response.make ~status ~flush ~encoding ?headers () in
     return (res, body)
 

--- a/lwt/cohttp_lwt.mli
+++ b/lwt/cohttp_lwt.mli
@@ -181,7 +181,11 @@ module type Server = sig
   (** [respond ?headers ?flush ~status ~body] will respond to an HTTP
     request with the given [status] code and response [body].  If
     [flush] is true, then every response chunk will be flushed to
-    the network rather than being buffered. [flush] is true by default. *)
+    the network rather than being buffered. [flush] is true by default. 
+    The transfer encoding will be detected from the [body] value and
+    set to chunked encoding if it cannot be determined immediately.
+    You can override the encoding by supplying an appropriate [Content-length]
+    or [Transfer-encoding] in the [headers] parameter. *)
   val respond :
     ?headers:Cohttp.Header.t ->
     ?flush:bool ->

--- a/opam
+++ b/opam
@@ -33,7 +33,7 @@ depends: [
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}
   "re"
-  "uri" {>= "1.5.0"}
+  "uri" {>= "1.8.0"}
   "fieldslib" {>= "109.20.00"}
   "sexplib" {>= "109.53.00"}
   "conduit" {>= "0.7.0"}


### PR DESCRIPTION
* `Request.has_body` does not permit a body to be set for methods that RFC7231 forbids from having one (`HEAD`, `GET` and `DELETE`). 
* `Request.make` does not inject a `transfer-encoding` header if there
is no body present in the request (#246).