### PR TITLE
Simplify the Net signature which needs to be provided for lwt servers

### DIFF
--- a/lwt/cohttp_lwt.ml
+++ b/lwt/cohttp_lwt.ml
@@ -219,9 +219,6 @@ module type Server = sig
   module Request : Request
   module Response : Response
 
-  type ctx with sexp_of
-  val default_ctx : ctx
-
   type conn = IO.conn * Cohttp.Connection.t
 
   type t
@@ -268,13 +265,10 @@ end
 module Make_server(IO:IO)
     (Request:Request with module IO=IO)
     (Response:Response with module IO=IO)
-    (Net:Net with module IO=IO) = struct
+= struct
   module IO = IO
   module Request = Request
   module Response = Response
-
-  type ctx = Net.ctx with sexp_of
-  let default_ctx = Net.default_ctx
 
   type conn = IO.conn * Cohttp.Connection.t
 

--- a/lwt/cohttp_lwt.mli
+++ b/lwt/cohttp_lwt.mli
@@ -163,9 +163,6 @@ module type Server = sig
   module Request : Request
   module Response : Response
 
-  type ctx with sexp_of
-  val default_ctx : ctx
-
   type conn = IO.conn * Cohttp.Connection.t
 
   type t
@@ -225,8 +222,6 @@ module Make_server
     (IO:IO)
     (Request:Request with module IO=IO)
     (Response:Response with module IO=IO)
-    (Net:Net with module IO = IO) :
-    Server with module IO = IO
+  : Server with module IO = IO
             and module Request = Request
             and module Response = Response
-            and type ctx = Net.ctx

--- a/lwt/cohttp_lwt_unix.ml
+++ b/lwt/cohttp_lwt_unix.ml
@@ -37,8 +37,8 @@ module Client = struct
   let custom_ctx = Cohttp_lwt_unix_net.custom_ctx
 end
 
-module Server_core = Cohttp_lwt.Make_server
-  (Cohttp_lwt_unix_io)(Request)(Response)(Cohttp_lwt_unix_net)
+module Server_core =
+  Cohttp_lwt.Make_server (Cohttp_lwt_unix_io)(Request)(Response)
 
 module Server = struct
   include Server_core
@@ -86,7 +86,7 @@ module Server = struct
          let body = Printexc.to_string exn in
          respond_error ~status:`Internal_server_error ~body ()
 
-  let create ?timeout ?stop ?(ctx=default_ctx) ?(mode=`TCP (`Port 8080)) spec =
+  let create ?timeout ?stop ?(ctx=Cohttp_lwt_unix_net.default_ctx) ?(mode=`TCP (`Port 8080)) spec =
     Conduit_lwt_unix.serve ?timeout ?stop ~ctx:ctx.Cohttp_lwt_unix_net.ctx ~mode
       (fun conn ic oc -> (callback spec) conn ic oc)
 end
@@ -96,7 +96,6 @@ module type S = sig
   include Cohttp_lwt.Server with module IO = Cohttp_lwt_unix_io
                              and module Request = Request
                              and module Response = Response
-                             and   type ctx = Cohttp_lwt_unix_net.ctx
 
   val resolve_file :
     docroot:string -> uri:Uri.t -> string

--- a/lwt/cohttp_lwt_unix.mli
+++ b/lwt/cohttp_lwt_unix.mli
@@ -63,7 +63,6 @@ module type S = sig
   include Cohttp_lwt.Server with module IO = Cohttp_lwt_unix_io
                              and module Request = Request
                              and module Response = Response
-                             and type ctx = Cohttp_lwt_unix_net.ctx
 
   val resolve_file : docroot:string -> uri:Uri.t -> string
 


### PR DESCRIPTION
Not sure to understand why the `Net` module needs to be passed as an argument of the server functor. It is not supposed to connect to anything (I think).