### PR TITLE
Added Header.add_multi

### DIFF
--- a/lib/header.ml
+++ b/lib/header.ml
@@ -57,6 +57,12 @@ let add h k v =
   try StringMap.add k (v::(StringMap.find k h)) h
   with Not_found -> StringMap.add k [v] h
 
+let add_list h l =
+  List.fold_left (fun h (k, v) -> add h k v) h l
+
+let add_multi h k l =
+  List.fold_left (fun h v -> add h k v) h l
+
 let add_opt h k v =
   match h with
   |None -> init_with k v

--- a/lib/header.mli
+++ b/lib/header.mli
@@ -29,6 +29,12 @@ val init_with  : string -> string -> t
 (** Add a key and value to an existing header map *)
 val add : t -> string -> string -> t
 
+(** Add multiple key and value pairs to an existing header map *)
+val add_list : t -> (string * string) list -> t
+
+(** Add multiple values to a key in an existing header map *)
+val add_multi : t -> string -> string list -> t
+
 (** Given an optional header, either update the existing one with
     a key and value, or construct a fresh header with those values if
     the header is [None] *)


### PR DESCRIPTION
I think it's cleaner than lines of
```ocaml
let headers = Header.init ()
  |> fun h -> Header.add h "something" "something"
  |> fun h -> Header.add h "something" "something"
  |> fun h -> Header.add h "something" "something"
(* etc *)
```
when adding multiple headers at once.

Discuss?