### PR TITLE
Lwt_unix_io: Split large reads

### DIFF
--- a/lwt/cohttp_lwt_unix_io.ml
+++ b/lwt/cohttp_lwt_unix_io.ml
@@ -37,6 +37,7 @@ let read_line ic =
     Lwt_io.read_line_opt ic
 
 let read ic count =
+ let count = min count Sys.max_string_length in
  if !CD.debug_active then
    (lwt buf =
        try_lwt Lwt_io.read ~count ic


### PR DESCRIPTION
With the Lwt backend, reads hang if trying to fetch more than
Sys.max_string_length due to a byte allocation failure in
Lwt_io.read. Problematic for large uploads, etc.

Upper layer callers (eg, Transfer_io) seem to handle recombining
these split reads without any issues.