### PR TITLE
Added the call_request function so that client code can use custom Reque...

### DIFF
--- a/async/cohttp_async.mli
+++ b/async/cohttp_async.mli
@@ -116,6 +116,12 @@ module Client : sig
     Uri.t ->
     (Response.t * Body.t) Deferred.t
 
+  val call_request:
+    ?interrupt:unit Deferred.t ->
+    ?body:Body.t ->
+    Request.t ->
+    (Response.t * Body.t) Deferred.t
+
   (** Send an HTTP POST request in form format *)
   val post_form:
     ?interrupt:unit Deferred.t ->


### PR DESCRIPTION
This pull request adds call_request. It doesn't break interface and just adds one function. 

I have tested this code and it works when using Amazon S3 Version 4 Signature based API.

Thank you to @trevorsummerssmith's commit for the similiar idea ed1a543ca5dc6430476c32ed3d889eaeb4899eb2