### PR TITLE
Supplying a `content-range` header in any client request overrides any other encoding preference.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,7 @@ Compatibility breaking interface changes:
   to make outgoing connections. (#274)
 
 New features and bug fixes:
-* Supplied a `content-range` or `content-range` header in any client
+* Supplying a `content-range` or `content-range` header in any client
   request will always override any other encoding preference (#281).
 * Add a `cohttp-lwt-proxy` to act as an HTTP proxy. (#248)
 * Extend `cohttp-server-async` file server to work with HTTPS (#277).

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ Compatibility breaking interface changes:
   to make outgoing connections. (#274)
 
 New features and bug fixes:
+* Supplied a `content-range` or `content-range` header in any client
+  request will always override any other encoding preference (#281).
 * Add a `cohttp-lwt-proxy` to act as an HTTP proxy. (#248)
 * Extend `cohttp-server-async` file server to work with HTTPS (#277).
 * Copy basic auth from `Uri.userinfo` into the Authorization header

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -44,14 +44,15 @@ let make ?(meth=`GET) ?(version=`HTTP_1_1) ?encoding ?headers uri =
     | _, _ -> headers
   in
   let encoding =
-    match encoding with
+    (* Check for a content-length in the supplied headers first *)
+    match Header.get_content_range headers with
+    | Some clen -> Transfer.Fixed clen
     | None -> begin
-        (* Check for a content-length in the supplied headers first *)
-        match Header.get_content_range headers with
-        | Some clen -> Transfer.Fixed clen
-        | None -> Transfer.Fixed Int64.zero
-      end
-    | Some e -> e
+       (* Otherwise look for an API-level encoding specification *)
+       match encoding with
+       | None -> Transfer.Fixed Int64.zero
+       | Some e -> e
+    end
   in
   { meth; version; headers; uri; encoding }
 


### PR DESCRIPTION
Previously, the `~encoding` label took precedence, which could be
overridden by intermediate calls like `Request.make_for_client`.
Now, the client-supplied headers always take effect over anything
else.

Partially addresses #281