### PR TITLE
Actually installs binaries fixing regression in bd626e for #252

### DIFF
--- a/cohttp.install
+++ b/cohttp.install
@@ -1,7 +1,16 @@
 bin: [
-  "?cohttp-server-async"
-  "?cohttp-server-lwt"
-  "?cohttp-curl-async"
-  "?cohttp-curl-lwt"
-  "?cohttp-proxy-lwt"
+  "?cohttp_server_async.byte"   { "cohttp-server-async" }
+  "?cohttp_server_async.native" { "cohttp-server-async" }
+
+  "?cohttp_server_lwt.byte"     { "cohttp-server-lwt" }
+  "?cohttp_server_lwt.native"   { "cohttp-server-lwt" }
+
+  "?cohttp_curl_async.byte"     { "cohttp-curl-async" }
+  "?cohttp_curl_async.native"   { "cohttp-curl-async" }
+
+  "?cohttp_curl_lwt.byte"       { "cohttp-curl-lwt" }
+  "?cohttp_curl_lwt.native"     { "cohttp-curl-lwt" }
+
+  "?cohttp_proxy_lwt.byte"      { "cohttp-proxy-lwt" }
+  "?cohttp_proxy_lwt.native"    { "cohttp-proxy-lwt" }
 ]


### PR DESCRIPTION
The previous version of `cohttp.install` broke binary installation. This fixes it for me, at least.