### PR TITLE
Remove mutability of request/response

### DIFF
--- a/lib/request.ml
+++ b/lib/request.ml
@@ -18,11 +18,11 @@
 open Sexplib.Std
 
 type t = {
-  mutable headers: Header.t;
-  mutable meth: Code.meth;
-  mutable uri: Uri.t;
-  mutable version: Code.version;
-  mutable encoding: Transfer.encoding;
+  headers: Header.t;
+  meth: Code.meth;
+  uri: Uri.t;
+  version: Code.version;
+  encoding: Transfer.encoding;
 } with fields, sexp
 
 let make ?(meth=`GET) ?(version=`HTTP_1_1) ?encoding ?headers uri =

--- a/lib/response.ml
+++ b/lib/response.ml
@@ -18,11 +18,11 @@
 open Sexplib.Std
 
 type t = {
-  mutable encoding: Transfer.encoding;
-  mutable headers: Header.t;
-  mutable version: Code.version;
-  mutable status: Code.status_code;
-  mutable flush: bool;
+  encoding: Transfer.encoding;
+  headers: Header.t;
+  version: Code.version;
+  status: Code.status_code;
+  flush: bool;
 } with fields, sexp
 
 let make ?(version=`HTTP_1_1) ?(status=`OK) ?(flush=false) ?(encoding=Transfer.Chunked) ?headers () =

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -98,11 +98,11 @@ end
 
 module type Request = sig
   type t = {
-    mutable headers: Header.t;    (** HTTP request headers *)
-    mutable meth: Code.meth;      (** HTTP request method *)
-    mutable uri: Uri.t;           (** Full HTTP request uri *)
-    mutable version: Code.version; (** HTTP version, usually 1.1 *)
-    mutable encoding: Transfer.encoding; (** transfer encoding of this HTTP request *)
+    headers: Header.t;    (** HTTP request headers *)
+    meth: Code.meth;      (** HTTP request method *)
+    uri: Uri.t;           (** Full HTTP request uri *)
+    version: Code.version; (** HTTP version, usually 1.1 *)
+    encoding: Transfer.encoding; (** transfer encoding of this HTTP request *)
   } with fields, sexp
 
   val make : ?meth:Code.meth -> ?version:Code.version ->
@@ -120,11 +120,11 @@ end
 
 module type Response = sig
   type t = {
-    mutable encoding: Transfer.encoding; (** Transfer encoding of this HTTP response *)
-    mutable headers: Header.t;    (** response HTTP headers *)
-    mutable version: Code.version; (** (** HTTP version, usually 1.1 *) *)
-    mutable status: Code.status_code; (** HTTP status code of the response *)
-    mutable flush: bool;
+    encoding: Transfer.encoding; (** Transfer encoding of this HTTP response *)
+    headers: Header.t;    (** response HTTP headers *)
+    version: Code.version; (** (** HTTP version, usually 1.1 *) *)
+    status: Code.status_code; (** HTTP status code of the response *)
+    flush: bool;
   } with fields, sexp
 
   val make :

--- a/lib_test/test_parser.ml
+++ b/lib_test/test_parser.ml
@@ -268,7 +268,7 @@ let mutate_simple_req () =
   let open Cohttp_lwt_unix in
   let expected = "POST /foo/bar HTTP/1.1\r\nfoo: bar\r\nhost: localhost\r\ntransfer-encoding: chunked\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n" in
   let req = Request.make ~encoding:Transfer.Chunked ~headers:(Header.init_with "foo" "bar") (Uri.of_string "/foo/bar") in
-  Request.set_meth req `POST;
+  let req = Fieldslib.Field.fset Request.Fields.meth req `POST in
   write_req expected req
 
 let make_simple_res () =


### PR DESCRIPTION
Mutability of request/response really isn't buying anything over just using a ref when it's actually needed. I think we should just get rid of it unless we can justify it with an actual use case.

The purpose of this PR is to really just discuss the possibility and see
if/how many downstream projects rely on it.