### PR TITLE
Fix request path parsing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.16.1 (trunk):
+New features and bug fixes:
+* Fix handling of request paths starting with multiple slashes (#308)
+
 0.16.0 (2015-03-23):
 
 Compatibility breaking interface changes:

--- a/_tags
+++ b/_tags
@@ -655,5 +655,4 @@ true: annot, bin_annot
 <examples/async/*.ml{,i,y}>: use_cohttp_async
 <examples/async/receive_post.{native,byte}>: custom
 # OASIS_STOP
-true: principal, strict_sequence, debug, short_paths
-true: annot
+true: principal, strict_sequence, debug

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -108,14 +108,15 @@ module Make(IO : S.IO) = struct
     | `Invalid reason as r -> return r
     | `Ok (meth, path, version) ->
       Header_IO.parse ic >>= fun headers ->
+      let empty = Uri.of_string "" in
       let uri =
         match Header.get headers "host" with
-        | None -> Uri.of_string path
+        | None -> Uri.with_path empty path
         | Some host ->
-           Uri.of_string ("//"^host) |> fun host_uri ->
-           Uri.of_string path |> fun uri ->
-           Uri.with_host uri (Uri.host host_uri) |> fun uri ->
-           Uri.with_port uri (Uri.port host_uri)
+          let host_uri = Uri.of_string ("//"^host) in
+          let uri = Uri.with_path empty path in
+          let uri = Uri.with_host uri (Uri.host host_uri) in
+          Uri.with_port uri (Uri.port host_uri)
       in
       let encoding = Header.get_transfer_encoding headers in
       return (`Ok { headers; meth; uri; version; encoding })

--- a/lib_test/test_request.ml
+++ b/lib_test/test_request.ml
@@ -38,8 +38,12 @@ let parse_request_uri_ r uri name =
   String_io.M.(
     StringRequest.read (String_io.open_in r)
     >>= function
-    | `Ok pr ->
-      assert_equal pr.Request.uri uri
+    | `Ok { Request.uri = ruri } ->
+      let msg =
+        Printf.sprintf "expected path %s got %s"
+          (Uri.path uri) (Uri.path ruri)
+      in
+      assert_equal ~msg ruri uri
     | _ -> assert_failure (name^" parse failed")
   )
 

--- a/lib_test/test_request.ml
+++ b/lib_test/test_request.ml
@@ -2,6 +2,8 @@ open OUnit
 open Printf
 open Cohttp
 
+module StringRequest = Request.Make(String_io.M)
+
 let uri_userinfo = Uri.of_string "http://foo:bar@ocaml.org"
 
 let header_auth =
@@ -32,10 +34,57 @@ let auth_uri _ =
     (r |> Request.headers |> Header.get_authorization)
     (Some (`Basic ("foo", "bar")))
 
+let parse_request_uri_ r uri name =
+  String_io.M.(
+    StringRequest.read (String_io.open_in r)
+    >>= function
+    | `Ok pr ->
+      assert_equal pr.Request.uri uri
+    | _ -> assert_failure (name^" parse failed")
+  )
+
+let parse_request_uri _ =
+  let r = "GET / HTTP/1.1\r\n\r\n" in
+  let uri = Uri.of_string "/" in
+  parse_request_uri_ r uri "parse_request_uri"
+
+let parse_request_uri_double_slash _ =
+  let r = "GET // HTTP/1.1\r\n\r\n" in
+  let uri = Uri.with_path (Uri.of_string "") "//" in
+  parse_request_uri_ r uri "parse_request_uri_double_slash"
+
+let parse_request_uri_triple_slash _ =
+  let r = "GET /// HTTP/1.1\r\n\r\n" in
+  let uri = Uri.with_path (Uri.of_string "") "///" in
+  parse_request_uri_ r uri "parse_request_uri_triple_slash"
+
+let parse_request_uri_host _ =
+  let r = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n" in
+  let uri = Uri.of_string "//example.com/" in
+  parse_request_uri_ r uri "parse_request_uri_host"
+
+let parse_request_uri_host_double_slash _ =
+  let r = "GET // HTTP/1.1\r\nHost: example.com\r\n\r\n" in
+  let uri = Uri.of_string "//example.com//" in
+  parse_request_uri_ r uri "parse_request_uri_host_double_slash"
+
+let parse_request_uri_host_triple_slash _ =
+  let r = "GET /// HTTP/1.1\r\nHost: example.com\r\n\r\n" in
+  let uri = Uri.of_string "//example.com///" in
+  parse_request_uri_ r uri "parse_request_uri_host_triple_slash"
+
 let _ =
   ("Request" >:::
    [ "Test header has auth" >:: header_has_auth
    ; "Test uri has user info" >:: uri_has_userinfo
    ; "Auth from Uri - do not override" >:: auth_uri_no_override
    ; "Auth from Uri" >:: auth_uri
+   ; "Parse simple request URI" >:: parse_request_uri
+   ; "Parse request URI double slash" >:: parse_request_uri_double_slash
+   ; "Parse request URI triple slash" >:: parse_request_uri_triple_slash
+   ; "Parse request URI with host" >:: parse_request_uri_host
+   ; "Parse request URI double slash with host"
+     >:: parse_request_uri_host_double_slash
+   ; "Parse request URI triple slash with host"
+     >:: parse_request_uri_host_triple_slash
    ]) |> run_test_tt_main


### PR DESCRIPTION
Addresses #308.

Perhaps we should parse auth headers here and reconstruct the actual request URI for the request record?

I tried to write some request parsing tests in  c429f5e but encountered what appears to be a long-standing compiler bug:

```
Fatal error: exception File "typing/printtyp.ml", line 583, characters 12-18: Assertion failed
```

which occurs with any of these `parse_request_uri_*` test cases on 4.01.0, 4.02.1, and 4.03.0+trunk. I'll report that to Mantis as soon as Travis fails.

This probably shouldn't be merged until we can confirm this bugfix works as expected and we can work-around the compiler bug.