### PR TITLE
Link header: add sexp converters, clean up interface

### DIFF
--- a/lib/link.ml
+++ b/lib/link.ml
@@ -61,6 +61,47 @@ module Rel = struct
     | Working_copy
     | Working_copy_of
   with sexp
+
+  let extension uri = Extension uri
+  let alternate = Alternate
+  let appendix = Appendix
+  let bookmark = Bookmark
+  let chapter = Chapter
+  let contents = Contents
+  let copyright = Copyright
+  let current = Current
+  let described_by = Described_by
+  let edit = Edit
+  let edit_media = Edit_media
+  let enclosure = Enclosure
+  let first = First
+  let glossary = Glossary
+  let help = Help
+  let hub = Hub
+  let index = Index
+  let last = Last
+  let latest_version = Latest_version
+  let license = License
+  let next = Next
+  let next_archive = Next_archive
+  let payment = Payment
+  let predecessor_version = Predecessor_version
+  let prev = Prev
+  let prev_archive = Prev_archive
+  let related = Related
+  let replies = Replies
+  let section = Section
+  let self = Self
+  let service = Service
+  let start = Start
+  let stylesheet = Stylesheet
+  let subsection = Subsection
+  let successor_version = Successor_version
+  let up = Up
+  let version_history = Version_history
+  let via = Via
+  let working_copy = Working_copy
+  let working_copy_of = Working_copy_of
 end
 
 module Language = struct

--- a/lib/link.mli
+++ b/lib/link.mli
@@ -18,74 +18,100 @@
 (** RFC 5988 ("Web Linking") and RFC 5987 ("Character Set and Language
     Encoding for Hypertext Transfer Protocol (HTTP) Header Field Parameters") *)
 
-type rel =
-  | Extension of Uri.t
-  | Alternate
-  | Appendix
-  | Bookmark
-  | Chapter
-  | Contents
-  | Copyright
-  | Current
-  | Described_by
-  | Edit
-  | Edit_media
-  | Enclosure
-  | First
-  | Glossary
-  | Help
-  | Hub
-  | Index
-  | Last
-  | Latest_version
-  | License
-  | Next
-  | Next_archive
-  | Payment
-  | Predecessor_version
-  | Prev
-  | Prev_archive
-  | Related
-  | Replies
-  | Section
-  | Self
-  | Service
-  | Start
-  | Stylesheet
-  | Subsection
-  | Successor_version
-  | Up
-  | Version_history
-  | Via
-  | Working_copy
-  | Working_copy_of
+module Rel : sig
+  type t =
+    | Extension of Uri.t
+    | Alternate
+    | Appendix
+    | Bookmark
+    | Chapter
+    | Contents
+    | Copyright
+    | Current
+    | Described_by
+    | Edit
+    | Edit_media
+    | Enclosure
+    | First
+    | Glossary
+    | Help
+    | Hub
+    | Index
+    | Last
+    | Latest_version
+    | License
+    | Next
+    | Next_archive
+    | Payment
+    | Predecessor_version
+    | Prev
+    | Prev_archive
+    | Related
+    | Replies
+    | Section
+    | Self
+    | Service
+    | Start
+    | Stylesheet
+    | Subsection
+    | Successor_version
+    | Up
+    | Version_history
+    | Via
+    | Working_copy
+    | Working_copy_of
+  with sexp
+end
 
-type language = string
+module Language : sig
+  type t = private string with sexp
 
-type charset = string
+  val to_string : t -> string
+  val of_string : string -> t
+end
 
-type 'a ext = {
-  charset : charset;
-  language : language;
-  value : 'a;
-}
+module Charset : sig
+  type t = private string with sexp
 
-type arc = {
-  reverse : bool;
-  relation : rel list;
-  hreflang : string option;
-  media : string option;
-  title : string option;
-  title_ext : string ext option;
-  media_type : (string * string) option;
-  extensions : (string * string) list;
-  extension_exts : (string * string ext) list;
-}
+  val to_string : t -> string
+  val of_string : string -> t
+end
 
-type t = { context : Uri.t; arc : arc; target : Uri.t; }
+module Ext : sig
+  type 'a t with sexp
+
+  val charset : 'a t -> Charset.t
+  val language : 'a t -> Language.t
+  val value : 'a t -> 'a
+
+  val make : ?charset:Charset.t -> ?language:Language.t -> 'a -> 'a t
+
+  val map : ('a -> 'b) -> 'a t -> 'b t
+end
+
+module Arc : sig
+  type t = {
+    reverse : bool;
+    relation : Rel.t list;
+    hreflang : string option;
+    media : string option;
+    title : string option;
+    title_ext : string Ext.t option;
+    media_type : (string * string) option;
+    extensions : (string * string) list;
+    extension_exts : (string * string Ext.t) list;
+  }
+
+  val empty : t
+end
+
+type t = {
+  context : Uri.t;
+  arc : Arc.t;
+  target : Uri.t;
+} with sexp
 
 val empty : t
-val empty_arc : arc
 
 val of_string : string -> t list
 

--- a/lib/link.mli
+++ b/lib/link.mli
@@ -19,48 +19,48 @@
     Encoding for Hypertext Transfer Protocol (HTTP) Header Field Parameters") *)
 
 module Rel : sig
-  type t =
-    | Extension of Uri.t
-    | Alternate
-    | Appendix
-    | Bookmark
-    | Chapter
-    | Contents
-    | Copyright
-    | Current
-    | Described_by
-    | Edit
-    | Edit_media
-    | Enclosure
-    | First
-    | Glossary
-    | Help
-    | Hub
-    | Index
-    | Last
-    | Latest_version
-    | License
-    | Next
-    | Next_archive
-    | Payment
-    | Predecessor_version
-    | Prev
-    | Prev_archive
-    | Related
-    | Replies
-    | Section
-    | Self
-    | Service
-    | Start
-    | Stylesheet
-    | Subsection
-    | Successor_version
-    | Up
-    | Version_history
-    | Via
-    | Working_copy
-    | Working_copy_of
-  with sexp
+  type t with sexp
+
+  val extension : Uri.t -> t
+  val alternate : t
+  val appendix : t
+  val bookmark : t
+  val chapter : t
+  val contents : t
+  val copyright : t
+  val current : t
+  val described_by : t
+  val edit : t
+  val edit_media : t
+  val enclosure : t
+  val first : t
+  val glossary : t
+  val help : t
+  val hub : t
+  val index : t
+  val last : t
+  val latest_version : t
+  val license : t
+  val next : t
+  val next_archive : t
+  val payment : t
+  val predecessor_version : t
+  val prev : t
+  val prev_archive : t
+  val related : t
+  val replies : t
+  val section : t
+  val self : t
+  val service : t
+  val start : t
+  val stylesheet : t
+  val subsection : t
+  val successor_version : t
+  val up : t
+  val version_history : t
+  val via : t
+  val working_copy : t
+  val working_copy_of : t
 end
 
 module Language : sig

--- a/lib_test/test_header.ml
+++ b/lib_test/test_header.ml
@@ -117,7 +117,7 @@ let link_simple () =
   let printer = links_printer in
   assert_equal ~printer Link.([{
     context = empty_uri;
-    arc = { empty_arc with relation=[Next] };
+    arc = Arc.({ empty with relation=Rel.([Next]) });
     target = Uri.of_string next_tgt;
   }]) (H.get_links headers)
 
@@ -128,7 +128,7 @@ let link_multi_rel () =
   let printer = links_printer in
   assert_equal ~printer Link.([{
     context = empty_uri;
-    arc = { empty_arc with relation=[Next; Last] };
+    arc = Arc.({ empty with relation=Rel.([Next; Last]) });
     target = Uri.of_string next_tgt;
   }]) (H.get_links headers)
 
@@ -144,12 +144,12 @@ let link_multi_line () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = { empty_arc with relation=[Next] };
+      arc = Arc.({ empty with relation=Rel.([Next]) });
       target = Uri.of_string next_tgt;
     };
     {
       context = empty_uri;
-      arc = { empty_arc with relation=[Self] };
+      arc = Arc.({ empty with relation=Rel.([Self]) });
       target = Uri.of_string self_tgt;
     };
   ]) (H.get_links headers)
@@ -165,12 +165,12 @@ let link_multi_multi () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = { empty_arc with relation=[Next] };
+      arc = Arc.({ empty with relation=Rel.([Next]) });
       target = Uri.of_string next_tgt;
     };
     {
       context = empty_uri;
-      arc = { empty_arc with relation=[Last] };
+      arc = Arc.({ empty with relation=Rel.([Last]) });
       target = Uri.of_string last_tgt;
     };
   ]) (H.get_links headers)
@@ -186,13 +186,13 @@ let link_rel_uri () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = { empty_arc with
-              relation = [
-                Next;
-                Extension (Uri.of_string uri_s);
-              ];
-              hreflang = Some "en";
-            };
+      arc = Arc.({ empty with
+                   relation = Rel.([
+                     Next;
+                     Extension (Uri.of_string uri_s);
+                   ]);
+                   hreflang = Some "en";
+                 });
       target = Uri.of_string uri_tgt;
     };
   ]) (H.get_links headers)
@@ -208,11 +208,11 @@ let link_anchor () =
   assert_equal ~printer Link.([
     {
       context = Uri.of_string anchor;
-      arc = { empty_arc with
-              relation = [
-                Prev;
-              ];
-            };
+      arc = Arc.({ empty with
+                   relation = Rel.([
+                     Prev;
+                   ]);
+                 });
       target = Uri.of_string target;
     };
   ]) (H.get_links headers)
@@ -227,12 +227,12 @@ let link_rev () =
   assert_equal ~printer Link.([
     {
       context = Uri.of_string anchor;
-      arc = { empty_arc with
-              reverse = true;
-              relation = [
-                Prev;
-              ];
-            };
+      arc = Arc.({ empty with
+                   reverse = true;
+                   relation = Rel.([
+                     Prev;
+                   ]);
+                 });
       target = empty_uri;
     };
   ]) (H.get_links headers)
@@ -247,9 +247,9 @@ let link_media () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = { empty_arc with
-              media = Some "screen";
-            };
+      arc = Arc.({ empty with
+                   media = Some "screen";
+                 });
       target = Uri.of_string target;
     };
   ]) (H.get_links headers)
@@ -264,9 +264,9 @@ let link_media_complex () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = { empty_arc with
-              media = Some "screen, print and dpi < 200";
-            };
+      arc = Arc.({ empty with
+                   media = Some "screen, print and dpi < 200";
+                 });
       target = Uri.of_string target;
     };
   ]) (H.get_links headers)
@@ -281,10 +281,10 @@ let link_title () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = { empty_arc with
-              relation = [ Next ];
-              title = Some "Next!";
-            };
+      arc = Arc.({ empty with
+                   relation = Rel.([ Next ]);
+                   title = Some "Next!";
+                 });
       target = Uri.of_string target;
     };
   ]) (H.get_links headers)
@@ -299,14 +299,14 @@ let link_title_star () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = { empty_arc with
-              relation = [ Next ];
-              title_ext = Some {
-                charset="UTF-8";
-                language="en";
-                value = "Next!";
-              };
-            };
+      arc = Arc.({ empty with
+                   relation = Rel.([ Next ]);
+                   title_ext = Some
+                       (Ext.make
+                          ~charset:(Charset.of_string "UTF-8")
+                          ~language:(Language.of_string "en")
+                          "Next!");
+                 });
       target = Uri.of_string target;
     };
   ]) (H.get_links headers)
@@ -321,10 +321,10 @@ let link_type_token () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = { empty_arc with
-              relation = [ Next ];
-              media_type = Some ("text", "html");
-            };
+      arc = Arc.({ empty with
+                   relation = Rel.([ Next ]);
+                   media_type = Some ("text", "html");
+                 });
       target = Uri.of_string target;
     };
   ]) (H.get_links headers)
@@ -339,10 +339,10 @@ let link_type_quoted () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = { empty_arc with
-              relation = [ Next ];
-              media_type = Some ("text", "html");
-            };
+      arc = Arc.({ empty with
+                   relation = Rel.([ Next ]);
+                   media_type = Some ("text", "html");
+                 });
       target = Uri.of_string target;
     };
   ]) (H.get_links headers)
@@ -357,10 +357,10 @@ let link_ext () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = { empty_arc with
-              relation = [ Next ];
-              extensions = ["see", "saw"];
-            };
+      arc = Arc.({ empty with
+                   relation = Rel.([ Next ]);
+                   extensions = ["see", "saw"];
+                 });
       target = Uri.of_string target;
     };
   ]) (H.get_links headers)
@@ -375,14 +375,15 @@ let link_ext_star () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = { empty_arc with
-              relation = [ Next ];
-              extension_exts = ["zig", {
-                charset = "";
-                language = "";
-                value="zag";
-              }];
-            };
+      arc = Arc.({ empty with
+                   relation = Rel.([ Next ]);
+                   extension_exts = ["zig",
+                                     Ext.make
+                                       ~charset:(Charset.of_string "")
+                                       ~language:(Language.of_string "")
+                                       "zag"
+                                    ];
+                 });
       target = Uri.of_string target;
     };
   ]) (H.get_links headers)

--- a/lib_test/test_header.ml
+++ b/lib_test/test_header.ml
@@ -117,7 +117,7 @@ let link_simple () =
   let printer = links_printer in
   assert_equal ~printer Link.([{
     context = empty_uri;
-    arc = Arc.({ empty with relation=Rel.([Next]) });
+    arc = Arc.({ empty with relation=Rel.([next]) });
     target = Uri.of_string next_tgt;
   }]) (H.get_links headers)
 
@@ -128,7 +128,7 @@ let link_multi_rel () =
   let printer = links_printer in
   assert_equal ~printer Link.([{
     context = empty_uri;
-    arc = Arc.({ empty with relation=Rel.([Next; Last]) });
+    arc = Arc.({ empty with relation=Rel.([next; last]) });
     target = Uri.of_string next_tgt;
   }]) (H.get_links headers)
 
@@ -144,12 +144,12 @@ let link_multi_line () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = Arc.({ empty with relation=Rel.([Next]) });
+      arc = Arc.({ empty with relation=Rel.([next]) });
       target = Uri.of_string next_tgt;
     };
     {
       context = empty_uri;
-      arc = Arc.({ empty with relation=Rel.([Self]) });
+      arc = Arc.({ empty with relation=Rel.([self]) });
       target = Uri.of_string self_tgt;
     };
   ]) (H.get_links headers)
@@ -165,12 +165,12 @@ let link_multi_multi () =
   assert_equal ~printer Link.([
     {
       context = empty_uri;
-      arc = Arc.({ empty with relation=Rel.([Next]) });
+      arc = Arc.({ empty with relation=Rel.([next]) });
       target = Uri.of_string next_tgt;
     };
     {
       context = empty_uri;
-      arc = Arc.({ empty with relation=Rel.([Last]) });
+      arc = Arc.({ empty with relation=Rel.([last]) });
       target = Uri.of_string last_tgt;
     };
   ]) (H.get_links headers)
@@ -188,8 +188,8 @@ let link_rel_uri () =
       context = empty_uri;
       arc = Arc.({ empty with
                    relation = Rel.([
-                     Next;
-                     Extension (Uri.of_string uri_s);
+                     next;
+                     extension (Uri.of_string uri_s);
                    ]);
                    hreflang = Some "en";
                  });
@@ -210,7 +210,7 @@ let link_anchor () =
       context = Uri.of_string anchor;
       arc = Arc.({ empty with
                    relation = Rel.([
-                     Prev;
+                     prev;
                    ]);
                  });
       target = Uri.of_string target;
@@ -230,7 +230,7 @@ let link_rev () =
       arc = Arc.({ empty with
                    reverse = true;
                    relation = Rel.([
-                     Prev;
+                     prev;
                    ]);
                  });
       target = empty_uri;
@@ -282,7 +282,7 @@ let link_title () =
     {
       context = empty_uri;
       arc = Arc.({ empty with
-                   relation = Rel.([ Next ]);
+                   relation = Rel.([ next ]);
                    title = Some "Next!";
                  });
       target = Uri.of_string target;
@@ -300,7 +300,7 @@ let link_title_star () =
     {
       context = empty_uri;
       arc = Arc.({ empty with
-                   relation = Rel.([ Next ]);
+                   relation = Rel.([ next ]);
                    title_ext = Some
                        (Ext.make
                           ~charset:(Charset.of_string "UTF-8")
@@ -322,7 +322,7 @@ let link_type_token () =
     {
       context = empty_uri;
       arc = Arc.({ empty with
-                   relation = Rel.([ Next ]);
+                   relation = Rel.([ next ]);
                    media_type = Some ("text", "html");
                  });
       target = Uri.of_string target;
@@ -340,7 +340,7 @@ let link_type_quoted () =
     {
       context = empty_uri;
       arc = Arc.({ empty with
-                   relation = Rel.([ Next ]);
+                   relation = Rel.([ next ]);
                    media_type = Some ("text", "html");
                  });
       target = Uri.of_string target;
@@ -358,7 +358,7 @@ let link_ext () =
     {
       context = empty_uri;
       arc = Arc.({ empty with
-                   relation = Rel.([ Next ]);
+                   relation = Rel.([ next ]);
                    extensions = ["see", "saw"];
                  });
       target = Uri.of_string target;
@@ -376,7 +376,7 @@ let link_ext_star () =
     {
       context = empty_uri;
       arc = Arc.({ empty with
-                   relation = Rel.([ Next ]);
+                   relation = Rel.([ next ]);
                    extension_exts = ["zig",
                                      Ext.make
                                        ~charset:(Charset.of_string "")


### PR DESCRIPTION
Moved some types into submodules and abstracted some (Language, Charset).
Added getters/setters.


The record fields are still exposed for pattern matching. I'm not sure about the `Rel.t` type. Should there be an `Other of string` constructor? Should it just be a `private variant` with a normalized string constructor and an `Extension of Uri.t` constructor?