### PR TITLE
Respect HEAD in cohttp_server_{lwt,async}

### DIFF
--- a/async/cohttp_async.mli
+++ b/async/cohttp_async.mli
@@ -142,7 +142,7 @@ module Server : sig
   val close_finished : (_, _) t -> unit Deferred.t
   val is_closed      : (_, _) t -> bool
 
-  type response with sexp_of
+  type response = Response.t * Body.t with sexp_of
 
   val respond :
     ?flush:bool ->

--- a/bin/cohttp_server.ml
+++ b/bin/cohttp_server.ml
@@ -100,3 +100,9 @@ let html_of_not_found path info = sprintf
   "<html><body><h2>Not Found</h2>
    <p><b>%s</b> was not found on this server</p>
    <hr />%s</body></html>" path info
+
+let html_of_method_not_allowed meth allowed path info = sprintf
+  "<html><body><h2>Method Not Allowed</h2>
+   <p><b>%s</b> is not an allowed method on <b>%s</b></p>
+   <p>Allowed methods on <b>%s</b> are <b>%s</b></p>
+   <hr />%s</body></html>" meth path path allowed info


### PR DESCRIPTION
I had to expose the representation of the `Cohttp_async.Server.response` type as a pair of response and body in order to write the `HEAD` postprocessor. I don't think this is a big deal but maybe there was a good reason that it was abstract.

I added 405 Method Not Allowed error functionality to the demonstration servers and `HEAD` support via response post-processing.

Fixes #316.