### PR TITLE
Limited read buffer size in Async backend to 32K.

### DIFF
--- a/async/cohttp_async_io.ml
+++ b/async/cohttp_async_io.ml
@@ -49,14 +49,19 @@ let read_line =
        |`Eof -> eprintf "<<<EOF\n"; None
     )
 
+let create_buf len =
+  let len' = min len 0x8000 in
+  String.create len', len'
+
 let read ic len =
-  let buf = String.create len in
+  let buf, len = create_buf len in
   Reader.read ic ~len buf >>| function
-  | `Ok len' -> String.sub buf 0 len'
+  | `Ok len' ->
+    if len' = len then buf else String.sub buf 0 len'
   | `Eof -> ""
 
 let read_exactly ic len =
-  let buf = String.create len in
+  let buf, len = create_buf len in
   Reader.really_read ic ~pos:0 ~len buf >>|
   function
   |`Ok -> Some buf


### PR DESCRIPTION
There was unlimited buffer allocation in Async backend. It affected uploading of big files a lot. It was at least 10 times slower than downloading the same file. After the fix, uploading and downloading speeds seem to be on par.

Anyway, it is still not that good as new buffer is allocated for every single chunk. The buffer should be reused for all chunks for better performance.
