### PR TITLE
Remove Request/Response in functors

### DIFF
--- a/lwt/cohttp_lwt.ml
+++ b/lwt/cohttp_lwt.ml
@@ -56,8 +56,6 @@ end
 
 module type Client = sig
   module IO : IO
-  module Request : Request
-  module Response : Response
 
   type ctx with sexp_of
   val default_ctx : ctx
@@ -121,13 +119,11 @@ end
 
 module Make_client
     (IO:IO)
-    (Request:Request with module IO = IO)
-    (Response:Response with module IO = IO)
     (Net:Net with module IO = IO) = struct
 
   module IO = IO
-  module Request = Request
-  module Response = Response
+  module Response = Make_response(IO)
+  module Request = Make_request(IO)
 
   type ctx = Net.ctx with sexp_of
   let default_ctx = Net.default_ctx
@@ -243,8 +239,6 @@ end
 (** Configuration of servers. *)
 module type Server = sig
   module IO : IO
-  module Request : Request
-  module Response : Response
 
   type conn = IO.conn * Cohttp.Connection.t
 
@@ -289,13 +283,10 @@ module type Server = sig
 end
 
 
-module Make_server(IO:IO)
-    (Request:Request with module IO=IO)
-    (Response:Response with module IO=IO)
-= struct
+module Make_server(IO:IO) = struct
   module IO = IO
-  module Request = Request
-  module Response = Response
+  module Request = Make_request(IO)
+  module Response = Make_response(IO)
 
   type conn = IO.conn * Cohttp.Connection.t
 

--- a/lwt/cohttp_lwt.mli
+++ b/lwt/cohttp_lwt.mli
@@ -69,8 +69,6 @@ module Make_response(IO:IO) : Response with module IO = IO
     up, but this can take some additional time to happen. *)
 module type Client = sig
   module IO : IO
-  module Request : Request
-  module Response : Response
 
   type ctx with sexp_of
   val default_ctx : ctx
@@ -144,24 +142,15 @@ module type Client = sig
 end
 
 (** The [Make_client] functor glues together a {! Cohttp.S.IO } implementation
-    with {! Cohttp.Request } and {! Cohttp.Response } to send requests down
-    a connection that is established by the  {! Net } module.
-    The resulting module satisfies the {! Client } module type. *)
-module Make_client
-    (IO:IO)
-    (Request:Request with module IO = IO)
-    (Response:Response with module IO = IO)
-    (Net:Net with module IO = IO) : Client
+    to send requests down a connection that is established by the  {! Net }
+    module.  The resulting module satisfies the {! Client } module type. *)
+module Make_client (IO:IO) (Net:Net with module IO = IO) : Client
     with module IO=IO
-     and module Request=Request
-     and module Response=Response
      and type ctx = Net.ctx
 
 (** The [Server] module implements a pipelined HTTP/1.1 server. *)
 module type Server = sig
   module IO : IO
-  module Request : Request
-  module Response : Response
 
   type conn = IO.conn * Cohttp.Connection.t
 
@@ -215,13 +204,6 @@ module type Server = sig
 end
 
 (** The [Make_server] functor glues together a {! Cohttp.S.IO } implementation
-    with {! Cohttp.Request } and {! Cohttp.Response } to send requests down
-    a connection that is established by the  {! Net } module.
-    The resulting module satisfies the {! Server } module type. *)
-module Make_server
-    (IO:IO)
-    (Request:Request with module IO=IO)
-    (Response:Response with module IO=IO)
-  : Server with module IO = IO
-            and module Request = Request
-            and module Response = Response
+    to send requests down a connection that is established by the  {! Net }
+    module.  The resulting module satisfies the {! Server } module type. *)
+module Make_server (IO:IO) : Server with module IO = IO

--- a/lwt/cohttp_lwt_unix.ml
+++ b/lwt/cohttp_lwt_unix.ml
@@ -22,8 +22,6 @@ module Response = Cohttp_lwt.Make_response(Cohttp_lwt_unix_io)
 module type C = sig
   include Cohttp_lwt.Client
     with module IO = Cohttp_lwt_unix_io
-     and module Request = Request
-     and module Response = Response
      and type ctx = Cohttp_lwt_unix_net.ctx
   val custom_ctx: ?ctx:Conduit_lwt_unix.ctx -> ?resolver:Resolver_lwt.t -> unit -> ctx
 
@@ -32,13 +30,12 @@ end
 module Client = struct
   include
     Cohttp_lwt.Make_client
-      (Cohttp_lwt_unix_io)(Request)(Response)(Cohttp_lwt_unix_net)
+      (Cohttp_lwt_unix_io)(Cohttp_lwt_unix_net)
 
   let custom_ctx = Cohttp_lwt_unix_net.init
 end
 
-module Server_core =
-  Cohttp_lwt.Make_server (Cohttp_lwt_unix_io)(Request)(Response)
+module Server_core = Cohttp_lwt.Make_server (Cohttp_lwt_unix_io)
 
 module Server = struct
   include Server_core
@@ -92,10 +89,7 @@ module Server = struct
 end
 
 module type S = sig
-
   include Cohttp_lwt.Server with module IO = Cohttp_lwt_unix_io
-                             and module Request = Request
-                             and module Response = Response
 
   val resolve_file :
     docroot:string -> uri:Uri.t -> string

--- a/lwt/cohttp_lwt_unix.mli
+++ b/lwt/cohttp_lwt_unix.mli
@@ -37,8 +37,6 @@ module type C = sig
 
   include Cohttp_lwt.Client
     with module IO = Cohttp_lwt_unix_io
-     and module Request = Request
-     and module Response = Response
      and type ctx = Cohttp_lwt_unix_net.ctx
 
   (** [custom_ctx ?ctx ?resolver ()] will return a context that is the
@@ -59,10 +57,7 @@ end
   primarily filesystem functions, and also {! create} to actually bind
   the server to a socket and respond to incoming requests. *)
 module type S = sig
-
   include Cohttp_lwt.Server with module IO = Cohttp_lwt_unix_io
-                             and module Request = Request
-                             and module Response = Response
 
   val resolve_file : docroot:string -> uri:Uri.t -> string
 


### PR DESCRIPTION
Exposing these modules on every functor application is not necessary.
The underlying {Request.Response}.t is always the same and there's no
need to expose the low level IO operations used.

@avsm @samoht Was there a particular reason these were exported? I looked for
a reason by trying to remove them and it looks like I've succeeded. The less
stuff we expose, the better right?