### PR TITLE
Fix #345

### DIFF
--- a/lib/transfer_io.ml
+++ b/lib/transfer_io.ml
@@ -65,15 +65,15 @@ module Make(IO : S.IO) = struct
     let read ~remaining ic () =
       (* TODO functorise string to a bigbuffer *)
       match !remaining with
-      |0L -> return Done
-      |len ->
+      | 0L -> return Done
+      | len ->
         read ic (Int64.to_int len) >>= function
         | "" -> return Done
         | buf ->
           remaining := Int64.sub !remaining (Int64.of_int (String.length buf));
           return (match !remaining with
-                  | 0L -> Final_chunk buf
-                  | _ -> Chunk buf)
+            | 0L -> Final_chunk buf
+            | _  -> Chunk buf)
 
     (* TODO enforce that the correct length is written? *)
     let write oc buf =

--- a/lib/transfer_io.ml
+++ b/lib/transfer_io.ml
@@ -67,7 +67,9 @@ module Make(IO : S.IO) = struct
       match !remaining with
       | 0L -> return Done
       | len ->
-        read ic (Int64.to_int len) >>= function
+        let len' = Int64.to_int len in
+        let read_len = min len' 0x8000 in
+        read ic read_len >>= function
         | "" -> return Done
         | buf ->
           remaining := Int64.sub !remaining (Int64.of_int (String.length buf));


### PR DESCRIPTION
Fix buffer allocation Transfer_io.Fixed.read

Transfer_io.Fixed.read attempted to allocate a single, content-length sized
buffer for reading a body. Since such a body can be quite large, it should
be read in chunks rather than all at once.  This commit introduces a
maximum chunk size for reading fixed content length bodies.

@eras could you please check if this PR fixes your issue?