### PR TITLE
Fix handling of 1xx/204/304: there is no message body

### DIFF
--- a/lib/response.ml
+++ b/lib/response.ml
@@ -64,7 +64,11 @@ module Make(IO : S.IO) = struct
        let flush = false in
        return (`Ok { encoding; headers; version; status; flush })
 
-  let has_body {encoding} = Transfer.has_body encoding
+  let has_body {status; encoding} =
+    (* rfc7230#section-5.7.1 *)
+    match status with
+    | #Code.informational_status | `No_content | `Not_modified -> `No
+    | #Code.status_code -> Transfer.has_body encoding
   let make_body_reader {encoding} ic = Transfer_IO.make_reader encoding ic
   let read_body_chunk = Transfer_IO.read
 


### PR DESCRIPTION
Similar to the fix for the HEAD method.
See http://tools.ietf.org/html/rfc7230#section-5.7.1

To test run `cohttp-proxy-lwt -v` set your proxy to localhost 8080 in Firefox  and open `http://www.example.com` (yes really that site itself), then press F5 as few times.
You'll notice that it hangs at `Waiting for www.example.com`.
Now apply the patch, restart the proxy and repeat the test, browser should no longer hang.