### PR TITLE
Attempt to test #357

### DIFF
--- a/lib_test/test_async_integration.ml
+++ b/lib_test/test_async_integration.ml
@@ -15,7 +15,7 @@ let response_bodies = [ "Testing"
 let ok s = Server.respond `OK ~body:(Body.of_string s)
 
 let chunk size = String.init ~f:(Fn.const 'X') size
-let chunk_size = 30000
+let chunk_size = 33_000
 let chunks = 3
 
 let server =


### PR DESCRIPTION
Large chunks in chunked encoding being truncated. This test attempts to
reproduce the behavior.

@vbmithr this is the after mentioned test. What's surprising is that it passed
even before your revert.