### PR TITLE
Remove IO.read_exactly

### DIFF
--- a/async/cohttp_async_io.ml
+++ b/async/cohttp_async_io.ml
@@ -55,13 +55,6 @@ let read ic len =
   | `Ok len' -> String.sub buf 0 len'
   | `Eof -> ""
 
-let read_exactly ic len =
-  let buf = String.create len in
-  Reader.really_read ic ~pos:0 ~len buf >>|
-  function
-  |`Ok -> Some buf
-  |`Eof _ -> None
-
 let write =
   check_debug
     (fun oc buf ->

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -60,11 +60,6 @@ module type IO = sig
       request. *)
   val read : ic -> int -> string t
 
-  (** [read_exactly ic len] will block until exactly [len] characters
-      are read from the input channel [ic].  If EOF or some other
-      error condition is reached, then {!None} is returned. *)
-  val read_exactly : ic -> int -> string option t
-
   (** [write oc s] will block until the complete [s] string is
       written to the output channel [oc]. *)
   val write : oc -> string -> unit t

--- a/lib/string_io.ml
+++ b/lib/string_io.ml
@@ -74,8 +74,6 @@ module M = struct
       Some s
     end
 
-  let read_exactly x n = return (read_exactly' x n)
-
   let read x n =
     match read_exactly' x n with
     | None when x.pos >= x.len -> raise End_of_file

--- a/lwt/cohttp_lwt_unix_io.ml
+++ b/lwt/cohttp_lwt_unix_io.ml
@@ -51,28 +51,6 @@ let read ic count =
   else
     try_read ()
 
-let read_exactly ic buf off len =
-  let try_read () =
-    Lwt.try_bind (fun () -> Lwt_io.read_into_exactly ic buf off len)
-      (fun () -> Lwt.return_true)
-      (function
-        | End_of_file -> Lwt.return_false
-        | x -> Lwt.fail x) in
-  if !CD.debug_active then
-    try_read () >>= fun rd ->
-    (match rd with
-    | true -> CD.debug_print "<<< %S" (String.sub buf off len)
-    | false -> CD.debug_print "<<< <EOF>\n");
-    return rd
-  else
-    try_read ()
-
-let read_exactly ic len =
-  let buf = Bytes.create len in
-  read_exactly ic buf 0 len >>= function
-    | true -> return (Some buf)
-    | false -> Lwt.return_none
-
 let write oc buf =
   if !CD.debug_active then
     (CD.debug_print ">>> %s" buf; Lwt_io.write oc buf)

--- a/lwt/string_io_lwt.ml
+++ b/lwt/string_io_lwt.ml
@@ -27,7 +27,6 @@ type conn = Cohttp.String_io.M.conn
 let iter = Lwt_list.iter_s
 let read_line ic = return (Cohttp.String_io.M.read_line ic)
 let read ic n = return (Cohttp.String_io.M.read ic n)
-let read_exactly ic n = return (Cohttp.String_io.M.read_exactly ic n)
 
 let write oc str = return (Cohttp.String_io.M.write oc str)
 let flush oc = return (Cohttp.String_io.M.flush oc)


### PR DESCRIPTION
It's not being used anywhere as of #360.

Are there any good cases for keeping it? The main problem with this function
was how it sneaked in allocations of very large buffers into cohttp's code
base.

We could of course fix it by making sure it checks its argument and raises when
its above the maximum threshold. But in that case the user is just better off
using `read`. Since he will have to handle buffers larger than `read_exactly`
can handle using `read` anyway

@vbmithr Rather than fixing this function by raising when it try to raise large
buffers we can simply get rid of it.

cc @avsm @samoht

PS I don't consider this as a breaking change because IO is not officially part of the interface we expose.