### PR TITLE
Add Header.to_string

### DIFF
--- a/lib/header.ml
+++ b/lib/header.ml
@@ -111,6 +111,18 @@ let of_list l = List.fold_left (fun h (k,v) -> add h k v) (init ()) l
 let to_list h = List.rev (fold (fun k v acc -> (k,v)::acc) h [])
 let header_line k v = Printf.sprintf "%s: %s\r\n" k v
 let to_lines h = List.rev (fold (fun k v acc -> (header_line k v)::acc) h [])
+let to_string h =
+  let b = Buffer.create 128 in
+  h |> iter (fun k v ->
+    v |> List.iter (fun v ->
+      Buffer.add_string b k;
+      Buffer.add_string b ": ";
+      Buffer.add_string b v;
+      Buffer.add_string b "\r\n"
+    );
+  );
+  Buffer.add_string b "\r\n";
+  Buffer.contents b
 
 let parse_content_range s =
   try

--- a/lib/header.mli
+++ b/lib/header.mli
@@ -77,6 +77,7 @@ val fold : (string -> string -> 'a -> 'a) -> t -> 'a -> 'a
 val of_list : (string * string) list -> t
 val to_list : t -> (string * string) list
 val to_lines : t -> string list
+val to_string : t -> string
 
 val get_content_range : t -> Int64.t option
 val get_media_type : t -> string option

--- a/lib/header_io.ml
+++ b/lib/header_io.ml
@@ -49,6 +49,5 @@ module Make(IO : S.IO) = struct
     return (Uri.query_of_encoded body)
 
   let write headers oc =
-    iter (IO.write oc) (Header.to_lines headers) >>= fun () ->
-    IO.write oc "\r\n"
+    IO.write oc (Header.to_string headers)
 end


### PR DESCRIPTION
This is mostly just a useful utility function but it seems like it's likely to
perform better than how we writing headers before so I've changed
Header_io.write to use it as well.