### PR TITLE
remove redundant definition of Cohttp_async.Server.close

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,7 +14,6 @@ Compatibility breaking interface changes:
 * Remove dependency on the Lwt Camlp4 syntax extension (#334).
 * Add `make github` target to push documentation to GitHub Pages
   (#338 from Jyotsna Prakash).
-* [async] Add `Cohttp_async.Server.close` to shutdown server (#337).
 * Add Async integration tests and consolidate Lwt tests using the
   new framework (#337).
 * Fix allocation of massive buffer when handling fixed size http bodies (#345)

--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -357,5 +357,4 @@ module Server = struct
     >>| fun server ->
     { server }
 
-  let close { server } = Tcp.Server.close server
 end

--- a/async/cohttp_async.mli
+++ b/async/cohttp_async.mli
@@ -197,6 +197,4 @@ module Server : sig
     ('address, 'listening_on) Tcp.Where_to_listen.t
     -> (body:Body.t -> 'address -> Request.t -> response Deferred.t)
     -> ('address, 'listening_on) t Deferred.t
-
-  val close : (_, _) t -> unit Deferred.t
 end


### PR DESCRIPTION
It was already defined further up in the module. The release note related to this was deleted as well since it's technically incorrect, as `close` was not introduced in that release.