### PR TITLE
Fix whitespace handling and concatenation order in headers

### DIFF
--- a/lib/header.ml
+++ b/lib/header.ml
@@ -228,9 +228,9 @@ let get_location headers =
   | Some u -> Some (Uri.of_string u)
 
 let get_links headers =
-  List.fold_left
-    (fun list link_s -> (Link.of_string link_s)@list)
-    [] (get_multi headers "link")
+  List.rev (List.fold_left
+    (fun list link_s -> List.rev_append (Link.of_string link_s) list)
+    [] (get_multi headers "link"))
 
 let add_links headers links =
   add_multi headers "link" (List.map Link.to_string links)

--- a/lib/header_io.ml
+++ b/lib/header_io.ml
@@ -19,7 +19,7 @@
 
 let split_header str =
   match Stringext.split ~max:2 ~on:':' str with
-  | x::y::[] -> [x; Stringext.trim_left y]
+  | x::y::[] -> [x; String.trim y]
   | x -> x
 
 module Make(IO : S.IO) = struct

--- a/lib/header_io.ml
+++ b/lib/header_io.ml
@@ -27,11 +27,13 @@ module Make(IO : S.IO) = struct
 
   module Transfer_IO = Transfer_io.Make(IO)
 
+  let rev _k v = List.rev v
+
   let parse ic =
     (* consume also trailing "^\r\n$" line *)
     let rec parse_headers' headers =
       read_line ic >>= function
-      |Some "" | None -> return headers
+      |Some "" | None -> return (Header.map rev headers)
       |Some line -> begin
           match split_header line with
           | [hd;tl] ->

--- a/lib_test/test_header.ml
+++ b/lib_test/test_header.ml
@@ -388,6 +388,14 @@ let link_ext_star () =
     };
   ]) (H.get_links headers)
 
+let trim_ws () =
+  let resp = get_resp ["Age: 281   "] in
+  let headers = headers_of_response "trim whitespace" resp in
+  assert_equal
+    ~printer:(function
+      | None -> "None"
+      | Some x -> "\"" ^ x ^ "\"") (H.get headers "age") (Some "281")
+
 ;;
 Printexc.record_backtrace true;
 Alcotest.run "test_header" [
@@ -426,5 +434,6 @@ Alcotest.run "test_header" [
   ];
   "Header", [
     "get list valued", `Quick, list_valued_header;
+    "trim whitespace", `Quick, trim_ws;
   ];
 ]

--- a/lib_test/test_header.ml
+++ b/lib_test/test_header.ml
@@ -396,6 +396,15 @@ let trim_ws () =
       | None -> "None"
       | Some x -> "\"" ^ x ^ "\"") (H.get headers "age") (Some "281")
 
+let test_cachecontrol_concat () =
+  let resp = get_resp ["Cache-Control: public";
+                       "Cache-Control: max-age:86400"] in
+  let  h = headers_of_response "concat Cache-Control" resp in
+  assert_equal
+    ~printer:(function
+      | None -> "None"
+      | Some x -> x) (Some "public,max-age:86400") (H.get h "Cache-Control")
+
 ;;
 Printexc.record_backtrace true;
 Alcotest.run "test_header" [
@@ -431,6 +440,9 @@ Alcotest.run "test_header" [
     "none", `Quick, Content_range.none;
     "content-length", `Quick, Content_range.content_length;
     "content-range", `Quick, Content_range.content_range;
+  ];
+  "Cache Control", [
+    "concat", `Quick, test_cachecontrol_concat
   ];
   "Header", [
     "get list valued", `Quick, list_valued_header;


### PR DESCRIPTION
Cohttp concatenated header values in reverse order, with this patch we have the correct order.