### PR TITLE
Allow DELETE requests to have bodies

### DIFF
--- a/lib/request.ml
+++ b/lib/request.ml
@@ -161,8 +161,8 @@ module Make(IO : S.IO) = struct
   (* Defined for method types in RFC7231 *)
   let has_body req =
     match req.meth with
-    | `GET | `HEAD | `DELETE | `CONNECT | `TRACE -> `No
-    | `POST | `PUT | `PATCH | `OPTIONS | `Other _ ->
+    | `GET | `HEAD | `CONNECT | `TRACE -> `No
+    | `DELETE | `POST | `PUT | `PATCH | `OPTIONS | `Other _ ->
       Transfer.has_body req.encoding
 
   let make_body_reader req ic = Transfer_IO.make_reader req.encoding ic

--- a/lwt-core/cohttp_lwt.ml
+++ b/lwt-core/cohttp_lwt.ml
@@ -80,6 +80,8 @@ module type Client = sig
 
   val delete :
     ?ctx:ctx ->
+    ?body:Cohttp_lwt_body.t ->
+    ?chunked:bool ->
     ?headers:Cohttp.Header.t ->
     Uri.t -> (Response.t * Cohttp_lwt_body.t) Lwt.t
 
@@ -190,7 +192,8 @@ module Make_client
     >|= fst
 
   let get ?ctx ?headers uri = call ?ctx ?headers `GET uri
-  let delete ?ctx ?headers uri = call ?ctx ?headers `DELETE uri
+  let delete ?ctx ?body ?chunked ?headers uri =
+    call ?ctx ?headers ?body ?chunked `DELETE uri
   let post ?ctx ?body ?chunked ?headers uri =
     call ?ctx ?headers ?body ?chunked `POST uri
   let put ?ctx ?body ?chunked ?headers uri =

--- a/lwt-core/cohttp_lwt.mli
+++ b/lwt-core/cohttp_lwt.mli
@@ -104,6 +104,8 @@ module type Client = sig
 
   val delete :
     ?ctx:ctx ->
+    ?body:Cohttp_lwt_body.t ->
+    ?chunked:bool ->
     ?headers:Cohttp.Header.t ->
     Uri.t -> (Response.t * Cohttp_lwt_body.t) Lwt.t
 


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7231#section-4.3.5 paragraph 5 does not disallow bodies for `DELETE` requests. We should give the user the option of sending and receiving bodies with `DELETE` requests.

I believe this patch adds this functionality and does not break previous functionality. I'm not 100% certain that pipelined DELETE requests work with/without body in all circumstances.