### PR TITLE
Surround source copyright with fold markers

### DIFF
--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
-*)
+  }}}*)
 
 open Core.Std
 open Async.Std

--- a/async/cohttp_async.mli
+++ b/async/cohttp_async.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
-*)
+  }}}*)
 
 open Core.Std
 open Async.Std

--- a/async/cohttp_async_io.ml
+++ b/async/cohttp_async_io.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
-*)
+  }}}*)
 
 open Core.Std
 open Async.Std

--- a/async/cohttp_async_io.mli
+++ b/async/cohttp_async_io.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for
  * any purpose with or without fee is hereby granted, provided that the
@@ -12,7 +11,7 @@
  * OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
-*)
+  }}}*)
 
 open Async.Std
 

--- a/bin/cohttp_curl_async.ml
+++ b/bin/cohttp_curl_async.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
-*)
+  }}}*)
 
 open Core.Std
 open Async.Std

--- a/bin/cohttp_curl_lwt.ml
+++ b/bin/cohttp_curl_lwt.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Hannes Mehnert
+(*{{{ Copyright (c) 2014 Hannes Mehnert
  * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Lwt
 open Cohttp

--- a/bin/cohttp_proxy_lwt.ml
+++ b/bin/cohttp_proxy_lwt.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014-2015 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2014-2015 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2014 Romain Calascibetta <romain.calascibetta@gmail.com>
  * Copyright (c) 2014 David Sheets <sheets@alum.mit.edu>
  *
@@ -15,7 +14,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Printf
 

--- a/bin/cohttp_server.ml
+++ b/bin/cohttp_server.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014-2015 David Sheets <sheets@alum.mit.edu>
+(*{{{ Copyright (c) 2014-2015 David Sheets <sheets@alum.mit.edu>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (* This module contains I/O agnostic functions used by
    Cohttp_server_lwt and Cohttp_server_async. *)

--- a/bin/cohttp_server_async.ml
+++ b/bin/cohttp_server_async.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2014 David Sheets <sheets@alum.mit.edu>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Core.Std
 open Async.Std

--- a/bin/cohttp_server_lwt.ml
+++ b/bin/cohttp_server_lwt.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Romain Calascibetta <romain.calascibetta@gmail.com>
+(*{{{ Copyright (c) 2014 Romain Calascibetta <romain.calascibetta@gmail.com>
  * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2014 David Sheets <sheets@alum.mit.edu>
  *
@@ -15,7 +14,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Printf
 

--- a/examples/async/s3_cp.ml
+++ b/examples/async/s3_cp.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (C) 2015 Trevor Smith <trevorsummerssmith@gmail.com>
+(*{{{ Copyright (C) 2015 Trevor Smith <trevorsummerssmith@gmail.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (**
    This example is here to show how to get and put to s3 using the

--- a/js/cohttp_lwt_xhr.ml
+++ b/js/cohttp_lwt_xhr.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Andy Ray
+(*{{{ Copyright (c) 2014 Andy Ray
  * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 module C = Cohttp
 module CLB = Cohttp_lwt_body

--- a/js/cohttp_lwt_xhr.mli
+++ b/js/cohttp_lwt_xhr.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Andy Ray <andy.ray@ujamjar.com>
+(*{{{ Copyright (c) 2014 Andy Ray <andy.ray@ujamjar.com>
  * Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** HTTP client for JavaScript using XMLHttpRequest. *)
 

--- a/lib/accept.ml
+++ b/lib/accept.ml
@@ -1,5 +1,4 @@
-(*
-  Copyright (C) 2012, David Sheets <sheets@alum.mit.edu>
+(*{{{opyright (C) 2012, David Sheets <sheets@alum.mit.edu>
 
   Permission to use, copy, modify, and/or distribute this software for
   any purpose with or without fee is hereby granted, provided that the
@@ -14,7 +13,7 @@
   OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
   TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
   PERFORMANCE OF THIS SOFTWARE.
-*)
+  }}}*)
 (* TODO: handle exceptions better *)
 
 open Printf

--- a/lib/accept.mli
+++ b/lib/accept.mli
@@ -1,5 +1,4 @@
-(*
-  Copyright (C) 2012, David Sheets <sheets@alum.mit.edu>
+(*{{{ Copyright (C) 2012, David Sheets <sheets@alum.mit.edu>
 
   Permission to use, copy, modify, and/or distribute this software for
   any purpose with or without fee is hereby granted, provided that the
@@ -14,7 +13,7 @@
   OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
   TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
   PERFORMANCE OF THIS SOFTWARE.
-*)
+  }}}*)
 
 (** Accept-Encoding HTTP header parsing and generation *)
 

--- a/lib/accept_lexer.mll
+++ b/lib/accept_lexer.mll
@@ -1,5 +1,4 @@
-(*
-  Copyright (C) 2012, David Sheets <sheets@alum.mit.edu>
+(*{{{ Copyright (C) 2012, David Sheets <sheets@alum.mit.edu>
 
   Permission to use, copy, modify, and/or distribute this software for
   any purpose with or without fee is hereby granted, provided that the
@@ -14,7 +13,7 @@
   OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
   TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
   PERFORMANCE OF THIS SOFTWARE.
-*)
+}}}*)
 {
   open Accept_parser
 }

--- a/lib/accept_types.ml
+++ b/lib/accept_types.ml
@@ -1,5 +1,4 @@
-(*
-  Copyright (C) 2012, David Sheets <sheets@alum.mit.edu>
+(*{{{ Copyright (C) 2012, David Sheets <sheets@alum.mit.edu>
 
   Permission to use, copy, modify, and/or distribute this software for
   any purpose with or without fee is hereby granted, provided that the
@@ -14,7 +13,7 @@
   OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
   TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
   PERFORMANCE OF THIS SOFTWARE.
-*)
+  }}}*)
 
 (** Type definitions for the {!Accept} module *)
 

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Sexplib.Std
 open Printf

--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** HTTP Authentication and Authorization header parsing and generation *)
 

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Rudi Grinberg
+(*{{{ Copyright (c) 2014 Rudi Grinberg
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
-*)
+  }}}*)
 
 open Sexplib.Std
 

--- a/lib/body.mli
+++ b/lib/body.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Rudi Grinberg
+(*{{{ Copyright (c) 2014 Rudi Grinberg
  * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
-*)
+  }}}*)
 
 (** HTTP request and response body handling *)
 

--- a/lib/conf.mli
+++ b/lib/conf.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2015 Christophe Troestler <Christophe.Troestler@umons.ac.be>
+(*{{{ Copyright (c) 2015 Christophe Troestler <Christophe.Troestler@umons.ac.be>
  * Copyright (c) 2015 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** Compile-time configuration variables *)
 

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2013 Thomas Gazagnaire <thomas@gazagnaire.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 open Sexplib.Std
 
 type t = int with sexp

--- a/lib/connection.mli
+++ b/lib/connection.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2013 Thomas Gazagnaire <thomas@gazagnaire.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** Connection identifiers. *)
 

--- a/lib/cookie.ml
+++ b/lib/cookie.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (C) <2012> Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (C) <2012> Anil Madhavapeddy <anil@recoil.org>
  * Copyright (C) <2009> David Sheets <sheets@alum.mit.edu>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Sexplib.Std
 

--- a/lib/cookie.mli
+++ b/lib/cookie.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (C) <2012> Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (C) <2012> Anil Madhavapeddy <anil@recoil.org>
  * Copyright (C) <2009> David Sheets <sheets@alum.mit.edu>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** Functions for the HTTP Cookie and Set-Cookie header fields.
     Using the Set-Cookie header field, an HTTP server can pass name/value

--- a/lib/header.ml
+++ b/lib/header.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2011-2012 Martin Jambon <martin@mjambon.com>
  * Copyright (c) 2010 Mika Illouz
  *
@@ -15,7 +14,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 module LString : sig
   type t

--- a/lib/header.mli
+++ b/lib/header.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** Map of HTTP header key and value(s) associated with them.  Since HTTP
     headers can contain duplicate keys, this structure can return a list

--- a/lib/header_io.ml
+++ b/lib/header_io.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2011-2012 Martin Jambon <martin@mjambon.com>
  * Copyright (c) 2010 Mika Illouz
  *
@@ -15,7 +14,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 let split_header str =
   match Stringext.split ~max:2 ~on:':' str with

--- a/lib/header_io.mli
+++ b/lib/header_io.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 module Make(IO : S.IO) : sig
   val parse: IO.ic -> Header.t IO.t

--- a/lib/link.ml
+++ b/lib/link.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2015 David Sheets <sheets@alum.mit.edu>
+(*{{{ Copyright (c) 2015 David Sheets <sheets@alum.mit.edu>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Sexplib.Std
 

--- a/lib/link.mli
+++ b/lib/link.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2015 David Sheets <sheets@alum.mit.edu>
+(*{{{ Copyright (c) 2015 David Sheets <sheets@alum.mit.edu>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** RFC 5988 ("Web Linking") and RFC 5987 ("Character Set and Language
     Encoding for Hypertext Transfer Protocol (HTTP) Header Field Parameters") *)

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
-*)
+  }}}*)
 
 open Sexplib.Std
 

--- a/lib/request.mli
+++ b/lib/request.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** HTTP/1.1 request handling *)
 

--- a/lib/response.ml
+++ b/lib/response.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Sexplib.Std
 

--- a/lib/response.mli
+++ b/lib/response.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
-*)
+  }}}*)
 
 (** HTTP/1.1 response handling *)
 

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (C) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (C) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2014 Rudi Grinberg
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** Module type signatures for Cohttp components *)
 

--- a/lib/string_io.ml
+++ b/lib/string_io.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Andy Ray
+(*{{{ Copyright (c) 2014 Andy Ray
  * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
-*)
+  }}}*)
 
 (* input channel type - a string with a (file) position and length *)
 type buf =

--- a/lib/string_io.mli
+++ b/lib/string_io.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Andy Ray
+(*{{{ Copyright (c) 2014 Andy Ray
  * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
-*)
+  }}}*)
 
 (** IO implementation that uses strings to marshal and unmarshal HTTP *)
 

--- a/lib/transfer.ml
+++ b/lib/transfer.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Sexplib.Std
 

--- a/lib/transfer.mli
+++ b/lib/transfer.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** Read and write the HTTP/1.1 transfer-encoding formats.
     Currently supported are [chunked] and [content-length].

--- a/lib/transfer_io.ml
+++ b/lib/transfer_io.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Transfer
 

--- a/lib/transfer_io.mli
+++ b/lib/transfer_io.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Transfer
 module Make(IO : S.IO) : sig

--- a/lib_test/test_accept.ml
+++ b/lib_test/test_accept.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 David Sheets <sheets@alum.mit.edu>
+(*{{{ Copyright (c) 2012 David Sheets <sheets@alum.mit.edu>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open OUnit
 open Printf

--- a/lib_test/test_header.ml
+++ b/lib_test/test_header.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open OUnit
 open Printf

--- a/lib_test/test_net_async.ml
+++ b/lib_test/test_net_async.ml
@@ -1,6 +1,4 @@
-(*
- * Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
- *
+(*{{{ Copyright (c) 2011-2013 Anil Madhavapeddy <anil@recoil.org
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
@@ -13,7 +11,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Core.Std
 open Async.Std

--- a/lib_test/test_net_async_server.ml
+++ b/lib_test/test_net_async_server.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Core.Std
 

--- a/lib_test/test_net_lwt.ml
+++ b/lib_test/test_net_lwt.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open OUnit
 open Printf

--- a/lib_test/test_net_lwt_client_and_server.ml
+++ b/lib_test/test_net_lwt_client_and_server.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open OUnit
 open Printf

--- a/lib_test/test_net_lwt_google_custom_ctx.ml
+++ b/lib_test/test_net_lwt_google_custom_ctx.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 open Lwt
 
 let google_static_ip = Ipaddr.of_string_exn "213.104.143.99"

--- a/lib_test/test_net_lwt_server.ml
+++ b/lib_test/test_net_lwt_server.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open OUnit
 open Printf

--- a/lib_test/test_parser.ml
+++ b/lib_test/test_parser.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open OUnit
 open Printf

--- a/lib_test/test_parser_async.ml
+++ b/lib_test/test_parser_async.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2015 Daniel Patterson <dbp@dbpmail.net>
+(*{{{ Copyright (c) 2015 Daniel Patterson <dbp@dbpmail.net>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open OUnit
 open Printf

--- a/lib_test/test_xhr.ml
+++ b/lib_test/test_xhr.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Andy Ray <andy.ray@ujamjar.com>
+(*{{{ Copyright (c) 2014 Andy Ray <andy.ray@ujamjar.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (*
 

--- a/lwt-core/cohttp_lwt.ml
+++ b/lwt-core/cohttp_lwt.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Cohttp
 open Lwt

--- a/lwt-core/cohttp_lwt.mli
+++ b/lwt-core/cohttp_lwt.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2013-2014 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2013-2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 open Cohttp
 

--- a/lwt-core/cohttp_lwt_body.ml
+++ b/lwt-core/cohttp_lwt_body.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
-*)
+  }}}*)
 
 open Cohttp
 open Lwt

--- a/lwt-core/cohttp_lwt_body.mli
+++ b/lwt-core/cohttp_lwt_body.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
-*)
+  }}}*)
 
 type t = [
   | Cohttp.Body.t

--- a/lwt-core/string_io_lwt.ml
+++ b/lwt-core/string_io_lwt.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Andy Ray
+(*{{{ Copyright (c) 2014 Andy Ray
  * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 type 'a t = 'a Lwt.t
 let return = Lwt.return

--- a/lwt-core/string_io_lwt.mli
+++ b/lwt-core/string_io_lwt.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2014 Andy Ray
+(*{{{ Copyright (c) 2014 Andy Ray
  * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -14,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** Lwt IO implementation that uses strings to marshal and unmarshal HTTP *)
 

--- a/lwt/cohttp_lwt_unix.ml
+++ b/lwt/cohttp_lwt_unix.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 
 module Request = Cohttp_lwt.Make_request(Cohttp_lwt_unix_io)

--- a/lwt/cohttp_lwt_unix.mli
+++ b/lwt/cohttp_lwt_unix.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2013 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** HTTP client and server using the [Lwt_unix] interfaces. *)
 

--- a/lwt/cohttp_lwt_unix_debug.ml
+++ b/lwt/cohttp_lwt_unix_debug.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 let debug_active = ref false
 

--- a/lwt/cohttp_lwt_unix_debug.mli
+++ b/lwt/cohttp_lwt_unix_debug.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** Debugging output for Cohttp Unix *)
 

--- a/lwt/cohttp_lwt_unix_io.ml
+++ b/lwt/cohttp_lwt_unix_io.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012-2014 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 module CD = Cohttp_lwt_unix_debug
 let () = Sys.(set_signal sigpipe Signal_ignore)

--- a/lwt/cohttp_lwt_unix_io.mli
+++ b/lwt/cohttp_lwt_unix_io.mli
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 include Cohttp.S.IO
  with type 'a t = 'a Lwt.t

--- a/lwt/cohttp_lwt_unix_net.ml
+++ b/lwt/cohttp_lwt_unix_net.ml
@@ -1,5 +1,4 @@
- (*
- * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+(*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (* Miscellaneous net-helpers used by Cohttp. Ideally, these will disappear
  * into some connection-management framework such as andrenth/release *)

--- a/lwt/cohttp_lwt_unix_net.mli
+++ b/lwt/cohttp_lwt_unix_net.mli
@@ -1,5 +1,4 @@
- (*
- * Copyright (c) 2015 David Sheets <sheets@alum.mit.edu>
+(*{{{ Copyright (c) 2015 David Sheets <sheets@alum.mit.edu>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,7 +12,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- *)
+  }}}*)
 
 (** Basic satisfaction of {! Cohttp_lwt.Net } *)
 

--- a/scripts/generate.ml
+++ b/scripts/generate.ml
@@ -1,5 +1,4 @@
-(*
- * Copyright (c) 2013 Thomas Gazagnaire <thomas@gazagnaire.org>
+(*{{{ Copyright (c) 2013 Thomas Gazagnaire <thomas@gazagnaire.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -12,7 +11,7 @@
  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *)
+  }}}*)
 
 module Uutf = struct
 


### PR DESCRIPTION
Vim and emacs can fold these by default and just display the first line
of the copyright.

learned this nice trick from the merlin source