### PR TITLE
Do not return stacktrace in body on 500's

### DIFF
--- a/lib_test/test_sanity.ml
+++ b/lib_test/test_sanity.ml
@@ -27,6 +27,11 @@ let server =
     Server.respond_string ~status:`OK ~body:"three" ();
   ]
   |> List.map const
+  |> (fun tests ->
+    tests @ [
+      (fun _ body -> (* Returns 500 on bad file *)
+         Cohttp_lwt_body.to_string body >>= fun fname ->
+         Server.respond_file ~fname ())])
   |> response_sequence
 
 let ts =
@@ -52,8 +57,8 @@ let ts =
       Lwt_stream.iter_s (fun (r,rbody) ->
         rbody |> Body.to_string >|= fun rbody ->
         begin match !counter with
-          | 0 | 2 -> assert_equal ~printer ""   rbody
-          | _     -> assert_equal ~printer body rbody
+        | 0 | 2 -> assert_equal ~printer ""   rbody
+        | _     -> assert_equal ~printer body rbody
         end;
         incr counter
       ) resps >>= fun () ->
@@ -93,11 +98,29 @@ let ts =
       ) resps 0 >|= fun l ->
       assert_equal l 3
     in
+    let unreadable_file_500 () =
+      let fname = "unreadable500" in
+      Lwt.finalize (fun () ->
+        Lwt_io.open_file ~flags:[Lwt_unix.O_CREAT] ~perm:0o006
+          ~mode:Lwt_io.Output fname >>= fun oc ->
+        Lwt_io.write_line oc "never read" >>= fun () ->
+        Lwt_io.close oc >>= fun () ->
+        Client.post uri ~body:(Body.of_string fname)
+        >>= begin fun (resp, body) ->
+          assert_equal ~printer:Code.string_of_status
+            (Response.status resp) `Internal_server_error;
+          Body.to_string body
+        end >|= fun body ->
+        assert_equal ~printer:(fun x -> "'" ^ x ^ "'")
+          body "Error: Internal Server Error"
+      ) (fun () -> Lwt_unix.unlink fname)
+    in
     [ "sanity test", t
     ; "empty chunk test", empty_chunk
     ; "pipelined chunk test", pipelined_chunk
     ; "no body when response is not modified", not_modified_has_no_body
     ; "pipelined with interleaving requests", pipelined_interleave
+    ; "unreadable file returns 500", unreadable_file_500
     ]
   end
 

--- a/lwt-core/cohttp_lwt.ml
+++ b/lwt-core/cohttp_lwt.ml
@@ -272,7 +272,7 @@ module Make_server(IO:IO) = struct
         (fun () ->
            Lwt.catch
              (fun () -> callback (io_id, conn_id) req body)
-             (fun exn -> respond_error ~body:(Printexc.to_string exn) ()))
+             (fun _exn -> respond_error ~body:"Internal Server Error" ()))
         (fun () -> Body.drain_body body)
     ) req_stream
 

--- a/lwt/cohttp_lwt_unix.ml
+++ b/lwt/cohttp_lwt_unix.ml
@@ -74,17 +74,17 @@ module Server = struct
         ignore_result (Lwt_io.close ic));
       let body = Cohttp_lwt_body.of_stream stream in
       let mime_type = Magic_mime.lookup fname in
-      let headers = Cohttp.Header.add_opt_unless_exists headers "content-type" mime_type in
+      let headers = Cohttp.Header.add_opt_unless_exists
+                      headers "content-type" mime_type in
       let res = Cohttp.Response.make ~status:`OK ~encoding ~headers () in
       return (res, body)
     ) (function
       | Unix.Unix_error(Unix.ENOENT,_,_) | Isnt_a_file ->
         respond_not_found ()
-      | exn ->
-        let body = Printexc.to_string exn in
-        respond_error ~status:`Internal_server_error ~body ())
+      | exn -> Lwt.fail exn)
 
-  let create ?timeout ?stop ?(ctx=Cohttp_lwt_unix_net.default_ctx) ?(mode=`TCP (`Port 8080)) spec =
-    Conduit_lwt_unix.serve ?timeout ?stop ~ctx:ctx.Cohttp_lwt_unix_net.ctx ~mode
-      (callback spec)
+  let create ?timeout ?stop ?(ctx=Cohttp_lwt_unix_net.default_ctx)
+        ?(mode=`TCP (`Port 8080)) spec =
+    Conduit_lwt_unix.serve ?timeout ?stop ~ctx:ctx.Cohttp_lwt_unix_net.ctx
+      ~mode (callback spec)
 end


### PR DESCRIPTION
We need to think of another way to expose this kind of desired behavior when debugging but until then we should definitely err on the side of caution.

Also, respond_file no longer catches exceptions because they should just
be caught by the general 500 handler (mentioned above).

Any tips on how to test the respond_file change?