### PR TITLE
Add cancel API for Lwt unix.

### DIFF
--- a/bin/cohttp_curl_lwt.ml
+++ b/bin/cohttp_curl_lwt.ml
@@ -26,7 +26,7 @@ let client uri ofile meth' =
   debug (fun d -> d "Client with URI %s\n" (Uri.to_string uri));
   let meth = Cohttp.Code.method_of_string meth' in
   debug (fun d -> d "Client %s issued\n" meth');
-  Client.call meth uri >>= fun (resp, body) ->
+  Client.call meth uri >>= fun (resp, body, _) ->
   let status = Response.status resp in
   debug (fun d ->
     d "Client %s returned: %s\n" meth' (Code.string_of_status status)

--- a/bin/cohttp_proxy_lwt.ml
+++ b/bin/cohttp_proxy_lwt.ml
@@ -40,7 +40,7 @@ let handler ~verbose (ch,conn) req body =
   in
   (* Fetch the remote URI *)
   let meth = Request.meth req in
-  Client.call ~headers ~body meth uri >>= fun (resp, body) ->
+  Client.call ~headers ~body meth uri >>= fun (resp, body, _) ->
   if verbose then
     eprintf "<-- %s %s\n%!"
       (Uri.to_string (Request.uri req))

--- a/examples/doc/client_lwt.ml
+++ b/examples/doc/client_lwt.ml
@@ -3,7 +3,7 @@ open Cohttp
 open Cohttp_lwt_unix
 
 let body =
-  Client.get (Uri.of_string "http://www.reddit.com/") >>= fun (resp, body) ->
+  Client.get (Uri.of_string "http://www.reddit.com/") >>= fun (resp, body, _) ->
   let code = resp |> Response.status |> Code.code_of_status in
   Printf.printf "Response code: %d\n" code;
   Printf.printf "Headers: %s\n" (resp |> Response.headers |> Header.to_string);

--- a/lwt-core/cohttp_lwt_s.ml
+++ b/lwt-core/cohttp_lwt_s.ml
@@ -31,6 +31,8 @@ module type Client = sig
   type ctx with sexp_of
   val default_ctx : ctx
 
+  type abort = unit -> unit
+
   (** [call ?ctx ?headers ?body ?chunked meth uri] will resolve the
     [uri] to a concrete network endpoint using the resolver initialized
     in [ctx].  It will then issue an HTTP request with method [meth],
@@ -48,7 +50,7 @@ module type Client = sig
     ?body:Cohttp_lwt_body.t ->
     ?chunked:bool ->
     Cohttp.Code.meth ->
-    Uri.t -> (Response.t * Cohttp_lwt_body.t) Lwt.t
+    Uri.t -> (Response.t * Cohttp_lwt_body.t * abort) Lwt.t
 
   val head :
     ?ctx:ctx ->
@@ -58,47 +60,47 @@ module type Client = sig
   val get :
     ?ctx:ctx ->
     ?headers:Cohttp.Header.t ->
-    Uri.t -> (Response.t * Cohttp_lwt_body.t) Lwt.t
+    Uri.t -> (Response.t * Cohttp_lwt_body.t * abort) Lwt.t
 
   val delete :
     ?ctx:ctx ->
     ?body:Cohttp_lwt_body.t ->
     ?chunked:bool ->
     ?headers:Cohttp.Header.t ->
-    Uri.t -> (Response.t * Cohttp_lwt_body.t) Lwt.t
+    Uri.t -> (Response.t * Cohttp_lwt_body.t * abort) Lwt.t
 
   val post :
     ?ctx:ctx ->
     ?body:Cohttp_lwt_body.t ->
     ?chunked:bool ->
     ?headers:Cohttp.Header.t ->
-    Uri.t -> (Response.t * Cohttp_lwt_body.t) Lwt.t
+    Uri.t -> (Response.t * Cohttp_lwt_body.t * abort) Lwt.t
 
   val put :
     ?ctx:ctx ->
     ?body:Cohttp_lwt_body.t ->
     ?chunked:bool ->
     ?headers:Cohttp.Header.t ->
-    Uri.t -> (Response.t * Cohttp_lwt_body.t) Lwt.t
+    Uri.t -> (Response.t * Cohttp_lwt_body.t * abort) Lwt.t
 
   val patch :
     ?ctx:ctx ->
     ?body:Cohttp_lwt_body.t ->
     ?chunked:bool ->
     ?headers:Cohttp.Header.t ->
-    Uri.t -> (Response.t * Cohttp_lwt_body.t) Lwt.t
+    Uri.t -> (Response.t * Cohttp_lwt_body.t * abort) Lwt.t
 
   val post_form :
     ?ctx:ctx ->
     ?headers:Cohttp.Header.t ->
     params:(string * string list) list ->
-    Uri.t -> (Response.t * Cohttp_lwt_body.t) Lwt.t
+    Uri.t -> (Response.t * Cohttp_lwt_body.t * abort) Lwt.t
 
   val callv :
     ?ctx:ctx ->
     Uri.t ->
     (Request.t * Cohttp_lwt_body.t) Lwt_stream.t ->
-    (Response.t * Cohttp_lwt_body.t) Lwt_stream.t Lwt.t
+    (Response.t * Cohttp_lwt_body.t * abort) Lwt_stream.t Lwt.t
 end
 
 (** The [Server] module implements a pipelined HTTP/1.1 server. *)


### PR DESCRIPTION
I was writing code to handle HTTP audio streams so I needed a `abort` API. This is a quick and dirty implementation. Would you guys be interested by a clean one? If so, how do you think it should/could be done?
