### PR TITLE
Preserve header case WIP

### DIFF
--- a/lib_test/test_header.ml
+++ b/lib_test/test_header.ml
@@ -99,14 +99,14 @@ let large_header () =
   let sbuf = Cohttp.String_io.open_in ibuf in
   let header_printer h =
     Printf.sprintf "[length %d]%s"
-     (List.length (H.to_list h)) 
-     (String.concat "\n" (List.map (fun (k,v) -> Printf.sprintf "%s: %s" k v) (H.to_list h))) in 
+     (List.length (H.to_list h))
+     (String.concat "\n" (List.map (fun (k,v) -> Printf.sprintf "%s: %s" k v) (H.to_list h))) in
   assert_equal ~cmp:(fun a b -> H.compare a b = 0) ~printer:header_printer (HIO.parse sbuf) h
 
 let many_headers () =
   let size = 1000000 in
   let rec add_header num h =
-    match num with 
+    match num with
     | 0 -> h
     | n ->
        let k = sprintf "h%d" n in
@@ -117,7 +117,7 @@ let many_headers () =
   let h = add_header size (H.init ()) in
   assert_equal ~printer:string_of_int
     (List.length (H.to_list h)) size
-    
+
 module Content_range = struct
   let h1 = H.of_list [("Content-Length", "123")]
   let h2 = H.of_list [("Content-Range", "bytes 200-300/1000")]

--- a/lib_test/test_parser.ml
+++ b/lib_test/test_parser.ml
@@ -246,7 +246,7 @@ let write_req expected req =
 let make_simple_req () =
   let open Cohttp in
   let open Cohttp_lwt_unix in
-  let expected = "POST /foo/bar HTTP/1.1\r\nfoo: bar\r\nhost: localhost\r\ntransfer-encoding: chunked\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n" in
+  let expected = "POST /foo/bar HTTP/1.1\r\nFoo: bar\r\nhost: localhost\r\ntransfer-encoding: chunked\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n" in
   let req = Request.make ~encoding:Transfer.Chunked ~meth:`POST ~headers:(Header.init_with "Foo" "bar") (Uri.of_string "/foo/bar") in
   write_req expected req
 


### PR DESCRIPTION
Use a case ignoring comparison function rather than lowecasing header
keys in header map.

@SGrondin does this work for you?

@avsm Is this approach ok?

This is still WIP b/c LString remains useless and we shouldn't make
is_header_with_list_value inefficient like this.