### PR TITLE
Close non-persistent async connections

### DIFF
--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -296,8 +296,9 @@ module Server = struct
                         "connection"
                         (if keep_alive then "keep-alive" else "close") in
         { res with Response.headers } in
-      Response.write ~flush (Body.write Response.write_body res_body) res wr >>= fun () ->
-      Writer.(if keep_alive then flushed else close ~force_close:(Deferred.never ())) wr
+      Response.write ~flush (Body.write Response.write_body res_body) res wr
+      >>= fun () ->
+      Writer.(if keep_alive then flushed else close ?force_close:None) wr
       >>= fun () ->
       Body.drain body
     ) >>= fun () ->

--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -297,7 +297,8 @@ module Server = struct
                         (if keep_alive then "keep-alive" else "close") in
         { res with Response.headers } in
       Response.write ~flush (Body.write Response.write_body res_body) res wr >>= fun () ->
-      Writer.flushed wr >>= fun () ->
+      Writer.(if keep_alive then flushed else close ~force_close:(Deferred.never ())) wr
+      >>= fun () ->
       Body.drain body
     ) >>= fun () ->
     Writer.close wr >>= fun () ->


### PR DESCRIPTION
According to RFC7230 section 6.6 the server must close the write-side of
its connection. Otherwise connections will hang if the client does not
conform to the spec either.  Here's a patch for async.

I used `~force_close:(Deferred.never ())` instead of `?force_close:None`
to keep the behavior of `Writer.flushed`, which would wait forever, too.
`Writer.close` has a timeout of 5s for inet sockets, forever for files.

@seliopou, @madroach let's proceed here.

I agree with @seliopou that replicating the behavior of Writer.flushed to block
forever is suspicious

EDIT: Could it make sense for some really large payloads and/or slow connections? I don't mind just following async's default until someone reports this as problematic. In which case we can think of either reverting this or making it configurable.