### PR TITLE
Fix net tests to print with async's logger

### DIFF
--- a/lib_test/test_net_async.ml
+++ b/lib_test/test_net_async.ml
@@ -18,7 +18,8 @@ open Async.Std
 open Cohttp_async
 
 let show_headers h =
-  Cohttp.Header.iter (fun k v -> List.iter v ~f:(Printf.eprintf "%s: %s\n%!" k)) h
+  Cohttp.Header.iter (fun k v ->
+    List.iter v ~f:(Log.Global.info "%s: %s\n%!" k)) h
 
 let make_net_req () =
   let headers = Cohttp.Header.of_list [ "connection", "close" ] in

--- a/lib_test/test_net_async_multi_get.ml
+++ b/lib_test/test_net_async_multi_get.ml
@@ -12,7 +12,7 @@ let fetch uri =
   printf "%s -> %d bytes\n" uri (String.length b)
 
 let rec perform_get n =
-  Printf.printf "%d\n%!" n;
+  Log.Global.info "%d\n%!" n;
   don't_wait_for (fetch "http://twitter.com");
   don't_wait_for (fetch "http://lastminute.com");
   don't_wait_for (fetch "http://www.bbc.co.uk");
@@ -25,5 +25,5 @@ let rec perform_get n =
 
 let _ =
   let _ = perform_get 0 in
-  Printf.printf "start\n%!";
+  Log.Global.info "start\n%!";
   Scheduler.go ()


### PR DESCRIPTION
Newer async's don't allow you to use *printf by default since it's
blocking. It's cleaner just to log here anyway.