### PR TITLE
Fix descriptor leak on thread cancellation for the Lwt client

### DIFF
--- a/lwt-core/cohttp_lwt.ml
+++ b/lwt-core/cohttp_lwt.ml
@@ -75,6 +75,10 @@ module Make_client
           closefn ();
           return (res, `Empty)
       end
+  let read_response ~closefn ic oc meth =
+    let t = read_response ~closefn ic oc meth in
+    Lwt.on_termination t closefn;
+    t
 
   let is_meth_chunked = function
     | `HEAD -> false


### PR DESCRIPTION
I've been testing this patch on an internal project and haven't seen any leaks since it was applied.

Possibly related to https://github.com/mirage/ocaml-cohttp/pull/414.