### PR TITLE
Fix issue #448 after breakage from PR #447

### DIFF
--- a/lwt-core/cohttp_lwt.ml
+++ b/lwt-core/cohttp_lwt.ml
@@ -75,7 +75,8 @@ module Make_client
       end
     end
     |> fun t ->
-    Lwt.on_termination t closefn;
+    Lwt.on_cancel t closefn;
+    Lwt.on_failure t (fun _exn -> closefn ());
     t
 
   let is_meth_chunked = function


### PR DESCRIPTION
Don't close ic/oc immediately as they may still be in use when reading body content.