### PR TITLE
Log uncaught exceptions from user callbacks

### DIFF
--- a/lwt-core/cohttp_lwt.ml
+++ b/lwt-core/cohttp_lwt.ml
@@ -275,7 +275,9 @@ module Make_server(IO:IO) = struct
         (fun () ->
            Lwt.catch
              (fun () -> callback (io_id, conn_id) req body)
-             (fun _exn -> respond_error ~body:"Internal Server Error" ()))
+             (fun exn ->
+               Format.eprintf "Error handling %a: %s\n%!" Request.pp_hum req (Printexc.to_string exn);
+               respond_error ~body:"Internal Server Error" ()))
         (fun () -> Body.drain_body body)
     ) req_stream
 

--- a/opam
+++ b/opam
@@ -29,8 +29,8 @@ depends: [
   "cmdliner" {build & >= "0.9.4"}
   "re"
   "uri" {>= "1.9.0"}
-  "fieldslib" {>= "109.20.00"}
-  "sexplib" {>= "109.53.00"}
+  "fieldslib" {>= "109.20.00" & < "113.01.00"}
+  "sexplib" {>= "109.53.00" & < "113.01.00"}
   "conduit" {>= "0.7.0"}
   "stringext"
   "base64" {>= "2.0.0"}


### PR DESCRIPTION
Before, the actual error was thrown away, making debugging difficult.

I've run into this a few times myself, and @mattgray reminded me of the problem last week.