### PR TITLE
Fix warnings when compiling with ppx

### DIFF
--- a/bin/cohttp_curl_lwt.ml
+++ b/bin/cohttp_curl_lwt.ml
@@ -76,16 +76,16 @@ let verb =
 let ofile =
   let doc = "Output filename to store the URI into." in
   Arg.(value & opt (some string) None & info ["o"] ~docv:"FILE" ~doc)
- 
+
 let cmd =
   let doc = "retrieve a remote URI contents" in
   let man = [
     `S "DESCRIPTION";
-    `P "$(tname) fetches the remote $(i,URI) and prints it to standard output.
-        The output file can also be specified with the $(b,-o) option, and more
-        verbose debugging out obtained via the $(b,-v) option.";
+    `P "$(tname) fetches the remote $(i,URI) and prints it to standard output. \
+        The output file can also be specified with the $(b,-o) option, and \
+        more verbose debugging out obtained via the $(b,-v) option.";
     `S "BUGS";
-    `P "Report them via e-mail to <mirageos-devel@lists.xenproject.org>, or
+    `P "Report them via e-mail to <mirageos-devel@lists.xenproject.org>, or \
         on the issue tracker at <https://github.com/mirage/ocaml-cohttp/issues>";
     `S "SEE ALSO";
     `P "$(b,curl)(1), $(b,wget)(1)" ]

--- a/bin/cohttp_proxy_lwt.ml
+++ b/bin/cohttp_proxy_lwt.ml
@@ -98,7 +98,7 @@ let cmd =
     `S "DESCRIPTION";
     `P "$(tname) sets up a simple http proxy with lwt as backend";
     `S "BUGS";
-    `P "Report them via e-mail to <mirageos-devel@lists.xenproject.org>, or
+    `P "Report them via e-mail to <mirageos-devel@lists.xenproject.org>, or \
         on the issue tracker at <https://github.com/mirage/ocaml-cohttp/issues>";
   ] in
   Term.(pure lwt_start_proxy $ port $ host $ verb $ ssl_cert $ ssl_key),

--- a/bin/cohttp_server.ml
+++ b/bin/cohttp_server.ml
@@ -80,28 +80,32 @@ let html_of_listing uri path listing info =
     | None -> sprintf "<li>Error with file: %s</li>" f
   ) (sort listing) in
   let contents = String.concat "\n" html in
-  sprintf
-    "<html>
-       <body>
-         <h2>Directory Listing for <em>%s</em></h2>
-         <ul>%s</ul>
-         <hr />%s
-       </body>
-</html>"
+  sprintf "<html><body>\
+           <h2>Directory Listing for <em>%s</em></h2><ul>%s</ul>\
+           <hr />%s\
+           </body></html>"
     (Uri.pct_decode path) contents info
 
-let html_of_forbidden_unnormal path info = sprintf
-  "<html><body><h2>Forbidden</h2>
-   <p><b>%s</b> is not a normal file or directory</p>
-   <hr />%s</body></html>" path info
+let html_of_forbidden_unnormal path info =
+  sprintf "<html><body>\
+           <h2>Forbidden</h2>\
+           <p><b>%s</b>is not a normal file or directory</p>\
+           <hr/>%s\
+           </body></html>"
+    path info
 
-let html_of_not_found path info = sprintf
-  "<html><body><h2>Not Found</h2>
-   <p><b>%s</b> was not found on this server</p>
-   <hr />%s</body></html>" path info
+let html_of_not_found path info =
+  sprintf "<html><body>\
+           <h2>Not Found</h2><p><b>%s</b>was not found on this server</p>\
+           <hr />%s\
+           </body></html>" path info
 
-let html_of_method_not_allowed meth allowed path info = sprintf
-  "<html><body><h2>Method Not Allowed</h2>
-   <p><b>%s</b> is not an allowed method on <b>%s</b></p>
-   <p>Allowed methods on <b>%s</b> are <b>%s</b></p>
-   <hr />%s</body></html>" meth path path allowed info
+let html_of_method_not_allowed meth allowed path info =
+  sprintf
+    "<html><body>\
+     <h2>Method Not Allowed</h2>\
+     <p><b>%s</b>is not an allowed method on <b>%s</b>\
+     </p><p>Allowed methods on <b>%s</b> are <b>%s</b></p>\
+     <hr />%s\
+     </body></html>"
+    meth path path allowed info

--- a/bin/cohttp_server_lwt.ml
+++ b/bin/cohttp_server_lwt.ml
@@ -126,7 +126,7 @@ let lwt_start_server docroot port host index verbose cert key =
 
 open Cmdliner
 
-let host = 
+let host =
   let doc = "IP address to listen on." in
   Arg.(value & opt string "0.0.0.0" & info ["s"] ~docv:"HOST" ~doc)
 
@@ -150,7 +150,7 @@ let ssl_key =
   let doc = "SSL key file." in
   Arg.(value & opt (some string) None & info ["k"] ~docv:"SSL_KEY" ~doc)
 
-let doc_root = 
+let doc_root =
   let doc = "Serving directory." in
   Arg.(value & pos 0 dir "." & info [] ~docv:"DOCROOT" ~doc)
 
@@ -160,7 +160,7 @@ let cmd =
     `S "DESCRIPTION";
     `P "$(tname) sets up a simple http server with lwt as backend";
     `S "BUGS";
-    `P "Report them via e-mail to <mirageos-devel@lists.xenproject.org>, or
+    `P "Report them via e-mail to <mirageos-devel@lists.xenproject.org>, or \
         on the issue tracker at <https://github.com/mirage/ocaml-cohttp/issues>";
   ] in
   Term.(pure lwt_start_server $ doc_root $ port $ host $ index $ verb $ ssl_cert $ ssl_key),


### PR DESCRIPTION
When compiling against the ppx versions of the type_conv packages, we
get warnings of this kind:

```
Warning 29: unescaped end-of-line in a string constant (non-portable code)
File "bin/cohttp_curl_lwt.ml", line 1
```

We fix these warnings here by removing the eol's.

I can also add the newlines explicitly if that's preferred.