### PR TITLE
fix leak on head client requests

### DIFF
--- a/lwt-core/cohttp_lwt.ml
+++ b/lwt-core/cohttp_lwt.ml
@@ -71,7 +71,7 @@ module Make_client
           Gc.finalise gcfn stream;
           let body = Body.of_stream stream in
           return (res, body)
-        | `No -> return (res, `Empty)
+        | `No -> closefn (); return (res, `Empty)
       end
     end
     |> fun t ->


### PR DESCRIPTION
I had this bugfix on a branch of mine (the branch itself is not yet ready for integration), but this bugfix is useful on its own.

otherwise Client requests fail with a resolver error or time out due
to running out of file descriptors

test with ./test_net_lwt_client_and_server.native