### PR TITLE
Make Uri "optional"

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -20,9 +20,7 @@ PKG re
 PKG re.emacs
 PKG stringext
 PKG fieldslib
-PKG pa_fields_conv
 PKG sexplib
-PKG pa_sexp_conv
 PKG ipaddr
 PKG ipaddr.unix
 PKG conduit

--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -165,13 +165,13 @@ module Client = struct
       let pipe = pipe_of_body Response.read_body_chunk reader in
       (res, pipe)
 
-  let request ?interrupt ?ssl_config ?target ?(body=`Empty) req =
+  let request ?interrupt ?ssl_config ?host ?(body=`Empty) req =
     (* Connect to the remote side *)
-    let target =
-      match target with
+    let host =
+      match host with
       | Some t -> t
       | None -> Request.uri req in
-    Net.connect_uri ?interrupt target
+    Net.connect_uri ?interrupt host
     >>= fun (ic,oc) ->
     Request.write (fun writer -> Body.write Request.write_body body writer) req oc
     >>= fun () ->
@@ -225,7 +225,7 @@ module Client = struct
             Request.make_for_client ?headers ~chunked:true meth uri
         end
     in
-    req >>= request ?interrupt ?ssl_config ~body ~target:uri
+    req >>= request ?interrupt ?ssl_config ~body ~host:uri
 
   let get ?interrupt ?ssl_config ?headers uri =
     call ?interrupt ?ssl_config ?headers ~chunked:false `GET uri

--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -165,8 +165,12 @@ module Client = struct
       let pipe = pipe_of_body Response.read_body_chunk reader in
       (res, pipe)
 
-  let request ?interrupt ?ssl_config ?(body=`Empty) ~target req =
+  let request ?interrupt ?ssl_config ?target ?(body=`Empty) req =
     (* Connect to the remote side *)
+    let target =
+      match target with
+      | Some t -> t
+      | None -> Request.uri req in
     Net.connect_uri ?interrupt target
     >>= fun (ic,oc) ->
     Request.write (fun writer -> Body.write Request.write_body body writer) req oc

--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -165,9 +165,9 @@ module Client = struct
       let pipe = pipe_of_body Response.read_body_chunk reader in
       (res, pipe)
 
-  let request ?interrupt ?ssl_config ?(body=`Empty) req =
+  let request ?interrupt ?ssl_config ?(body=`Empty) ~target req =
     (* Connect to the remote side *)
-    Net.connect_uri ?interrupt ?ssl_config req.Request.uri
+    Net.connect_uri ?interrupt target
     >>= fun (ic,oc) ->
     Request.write (fun writer -> Body.write Request.write_body body writer) req oc
     >>= fun () ->
@@ -221,7 +221,7 @@ module Client = struct
             Request.make_for_client ?headers ~chunked:true meth uri
         end
     in
-    req >>= request ?interrupt ?ssl_config ~body
+    req >>= request ?interrupt ?ssl_config ~body ~target:uri
 
   let get ?interrupt ?ssl_config ?headers uri =
     call ?interrupt ?ssl_config ?headers ~chunked:false `GET uri

--- a/async/cohttp_async.mli
+++ b/async/cohttp_async.mli
@@ -43,8 +43,8 @@ module Client : sig
   val request :
     ?interrupt:unit Deferred.t ->
     ?ssl_config:Conduit_async.Ssl.config ->
+    ?target:Uri.t ->
     ?body:Body.t ->
-    target:Uri.t ->
     Request.t ->
     (Response.t * Body.t) Deferred.t
 

--- a/async/cohttp_async.mli
+++ b/async/cohttp_async.mli
@@ -43,7 +43,7 @@ module Client : sig
   val request :
     ?interrupt:unit Deferred.t ->
     ?ssl_config:Conduit_async.Ssl.config ->
-    ?target:Uri.t ->
+    ?host:Uri.t ->
     ?body:Body.t ->
     Request.t ->
     (Response.t * Body.t) Deferred.t

--- a/async/cohttp_async.mli
+++ b/async/cohttp_async.mli
@@ -44,6 +44,7 @@ module Client : sig
     ?interrupt:unit Deferred.t ->
     ?ssl_config:Conduit_async.Ssl.config ->
     ?body:Body.t ->
+    target:Uri.t ->
     Request.t ->
     (Response.t * Body.t) Deferred.t
 

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -180,7 +180,7 @@ module Make(IO : S.IO) = struct
     let fst_line =
       Printf.sprintf "%s %s %s\r\n"
         (Code.string_of_method req.meth)
-        req.path
+        (if req.path = "" then "/" else req.path)
         (Code.string_of_version req.version) in
     let headers = req.headers in
     let headers =

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -57,6 +57,16 @@ let make ?(meth=`GET) ?(version=`HTTP_1_1) ?encoding ?headers uri =
   in
   { meth; version; headers; path=(Uri.path_and_query uri); encoding }
 
+let create ?headers ?(version=`HTTP_1_1) ?(encoding=Transfer.Fixed Int64.zero)
+      ~meth ~path () =
+  { headers = (match headers with
+      | None -> Header.init ()
+      | Some h -> h)
+  ; encoding
+  ; version
+  ; meth
+  ; path }
+
 let is_keep_alive { version; headers; _ } =
   not (version = `HTTP_1_0 ||
        (match Header.connection headers with

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -53,13 +53,6 @@ let make ?(meth=`GET) ?(version=`HTTP_1_1) ?encoding ?headers uri =
   let encoding = guess_encoding ?encoding headers in
   { meth; version; headers; path=(Uri.path_and_query uri); encoding }
 
-let create ?headers ?(version=`HTTP_1_1) ?(encoding=fixed_zero) ~meth ~path () =
-  { headers = (match headers with | None -> Header.init () | Some h -> h)
-  ; encoding
-  ; version
-  ; meth
-  ; path }
-
 let is_keep_alive { version; headers; _ } =
   not (version = `HTTP_1_0 ||
        (match Header.connection headers with

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -97,6 +97,14 @@ module type Request = sig
 
   val uri : t -> Uri.t
 
+  val create : ?headers:Header.t
+    -> ?version:Code.version
+    -> ?encoding:Transfer.encoding
+    -> meth:Code.meth
+    -> path:string
+    -> unit
+    -> t
+
   val make_for_client:
     ?headers:Header.t ->
     ?chunked:bool ->

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -84,7 +84,7 @@ module type Request = sig
   type t = {
     headers: Header.t;    (** HTTP request headers *)
     meth: Code.meth;      (** HTTP request method *)
-    uri: Uri.t;           (** Full HTTP request uri *)
+    path: string;         (** Request path and query *)
     version: Code.version; (** HTTP version, usually 1.1 *)
     encoding: Transfer.encoding; (** transfer encoding of this HTTP request *)
   } [@@deriving fields, sexp]
@@ -94,6 +94,8 @@ module type Request = sig
     Uri.t -> t
   (** Return true whether the connection should be reused *)
   val is_keep_alive : t -> bool
+
+  val uri : t -> Uri.t
 
   val make_for_client:
     ?headers:Header.t ->

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -97,14 +97,6 @@ module type Request = sig
 
   val uri : t -> Uri.t
 
-  val create : ?headers:Header.t
-    -> ?version:Code.version
-    -> ?encoding:Transfer.encoding
-    -> meth:Code.meth
-    -> path:string
-    -> unit
-    -> t
-
   val make_for_client:
     ?headers:Header.t ->
     ?chunked:bool ->


### PR DESCRIPTION
This is my personal fork that allows you to set request paths directly as a
string. The main motivation being that I need a special way of encoding query
params to access amazon cloudsearch.

Not all of these commits are relevant but it's a good sketch of where I'm
taking this

@avsm @dsheets What do you think?