### PR TITLE
Add ocamlbuild as build dependency

### DIFF
--- a/opam
+++ b/opam
@@ -26,6 +26,7 @@ remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "base-bytes"
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "cmdliner" {build & >= "0.9.4"}
   "re"
   "uri" {>= "1.9.0"}


### PR DESCRIPTION
Not very useful given the long list of dependencies that surely include
ocamlbuild already but good practice