### PR TITLE
Fd safety for Cohttp_async.Client.request

### DIFF
--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -171,15 +171,23 @@ module Client = struct
       match host with
       | Some t -> t
       | None -> Request.uri req in
-    Net.connect_uri ?interrupt host
-    >>= fun (ic,oc) ->
-    Request.write (fun writer -> Body.write Request.write_body body writer) req oc
-    >>= fun () ->
-    read_request ic >>| fun (resp, body) ->
-    don't_wait_for (
-      Pipe.closed body >>= fun () ->
-      Deferred.all_ignore [Reader.close ic; Writer.close oc]);
-    (resp, `Pipe body)
+    Net.connect_uri ?interrupt host >>= begin fun (ic, oc) ->
+      try_with (fun () ->
+          Request.write (fun writer -> Body.write Request.write_body body writer) req oc
+          >>= fun () ->
+          read_request ic >>| fun (resp, body) ->
+          don't_wait_for (
+            Pipe.closed body >>= fun () ->
+            Deferred.all_ignore [Reader.close ic; Writer.close oc]);
+          (resp, `Pipe body)
+        ) >>= (function
+          | Ok p -> return p
+          | Error e ->
+            don't_wait_for (Reader.close ic);
+            don't_wait_for (Writer.close oc);
+            raise e
+        )
+    end
 
   let callv ?interrupt ?ssl_config uri reqs =
     let reqs_c = ref 0 in


### PR DESCRIPTION
If `request` raises, we should still take care to close ic and oc. We
don't close the fd's unconditionally at the end of request using
something like Monitor.protect because the success case should delay
closing the fd's until the body pipe is closed.

Fix #444
