### PR TITLE
Expose [Reader.t] and [Writer.t] via [`Switching_protocols] for websockets

### DIFF
--- a/cohttp-async/src/server.ml
+++ b/cohttp-async/src/server.ml
@@ -17,9 +17,22 @@ type ('address, 'listening_on) t = {
 
 type response = Response.t * Body.t [@@deriving sexp_of]
 
+type response_action =
+  [ `Expert of Cohttp.Response.t * (Io.ic -> Io.oc -> unit Deferred.t)
+  | `Response of response
+  ]
+
+type 'r respond_t =
+  ?flush      : bool
+  -> ?headers : Cohttp.Header.t
+  -> ?body    : Body.t
+  -> Cohttp.Code.status_code
+  -> 'r Deferred.t
+
 let close t = Tcp.Server.close t.server
 let close_finished t = Tcp.Server.close_finished t.server
 let is_closed t = Tcp.Server.is_closed t.server
+let listening_on t = Tcp.Server.listening_on t.server
 
 let read_body req rd =
   match Request.has_body req with
@@ -30,38 +43,75 @@ let read_body req rd =
     let pipe = Body_raw.pipe_of_body Request.read_body_chunk reader in
     (`Pipe pipe, Pipe.closed pipe)
 
+let collect_errors writer ~f =
+  let monitor = Writer.monitor writer in
+  (* don't propagate errors up, we handle them here *)
+  Monitor.detach_and_get_error_stream monitor |> (ignore : exn Stream.t -> unit);
+  choose [
+    choice (Monitor.get_next_error monitor)
+      (fun e -> Error (Exn.Reraised ("Cohttp_async.Server.collect_errors", e)));
+    choice (try_with ~name:"Cohttp_async.Server.collect_errors" f) Fn.id;
+  ]
+;;
+
 let handle_client handle_request sock rd wr =
+  collect_errors wr ~f:(fun () ->
   let last_body_pipe_drained = ref Deferred.unit in
-  let requests_pipe =
-    Reader.read_all rd (fun rd ->
-        !last_body_pipe_drained >>= fun () ->
-        Request.read rd >>| function
-        | `Eof | `Invalid _ -> `Eof
-        | `Ok req ->
-          let body, finished = read_body req rd in
-          last_body_pipe_drained := finished;
-          `Ok (req, body)
-      ) in
-  Pipe.iter requests_pipe ~f:(fun (req, body) ->
-      handle_request ~body sock req
-      >>= fun (res, res_body) ->
-      let keep_alive = Request.is_keep_alive req in
-      let flush = Response.flush res in
-      let res =
-        let headers = Cohttp.Header.add_unless_exists
-            (Cohttp.Response.headers res)
-            "connection"
-            (if keep_alive then "keep-alive" else "close") in
-        { res with Response.headers } in
-      Response.write ~flush (Body_raw.write_body Response.write_body res_body)
-        res wr
-      >>= fun () ->
-      Writer.(if keep_alive then flushed else close ?force_close:None) wr
-      >>= fun () ->
-      Body.drain body
-    ) >>= fun () ->
-  Writer.close wr >>= fun () ->
+    let requests_pipe =
+      Reader.read_all rd (fun rd ->
+        !last_body_pipe_drained
+        >>= fun () ->
+        (* [`Expert] responses may close the [Reader.t] *)
+        if Reader.is_closed rd
+        then return `Eof
+        else begin
+          Request.read rd
+          >>= function
+          | `Eof | `Invalid _ -> return `Eof
+          | `Ok req ->
+            let body, finished = read_body req rd in
+            handle_request ~body sock req
+            >>| function
+            | `Expert (headers, io_handler) ->
+              let expert_finished = Ivar.create () in
+              last_body_pipe_drained := Deferred.all_unit [Ivar.read expert_finished; finished];
+              `Ok (`Expert (headers, io_handler, body, expert_finished))
+            | `Response r ->
+              last_body_pipe_drained := finished;
+              `Ok (`Response (req, body, r))
+        end
+      )
+    in
+    Pipe.iter ~continue_on_error:false requests_pipe ~f:(function
+      | `Expert (response, io_handler, body, finished) ->
+        Response.write ~flush:true (Body_raw.write_body Response.write_body Body.empty) response wr
+        >>= fun () ->
+        io_handler rd wr
+        >>= fun () ->
+        Body.drain body >>| fun () ->
+        Ivar.fill_if_empty finished ()
+      | `Response(req, body, (res, res_body)) ->
+        let keep_alive = Request.is_keep_alive req in
+        let flush = Response.flush res in
+        let res =
+          let headers = Cohttp.Header.add_unless_exists
+              (Cohttp.Response.headers res)
+              "connection"
+              (if keep_alive then "keep-alive" else "close") in
+          { res with Response.headers } in
+        Response.write ~flush (Body_raw.write_body Response.write_body res_body) res wr
+        >>= fun () ->
+        Writer.(if keep_alive then flushed else close ?force_close:None) wr
+        >>= fun () ->
+        Body.drain body
+    )
+  )
+  >>= fun res ->
+  Writer.close wr
+  >>= fun () ->
   Reader.close rd
+  >>| fun () ->
+  Result.ok_exn res
 
 let respond ?(flush=true) ?(headers=Cohttp.Header.init ())
     ?(body=`Empty) status : response Deferred.t =
@@ -71,9 +121,6 @@ let respond ?(flush=true) ?(headers=Cohttp.Header.init ())
 
 let respond_with_pipe ?flush ?headers ?(code=`OK) body =
   respond ?flush ?headers ~body:(`Pipe body) code
-
-let respond_with_string ?flush ?headers ?(code=`OK) body =
-  respond ?flush ?headers ~body:(`String body) code
 
 let respond_string ?flush ?headers ?(status=`OK) body =
   respond ?flush ?headers ~body:(`String body) status
@@ -104,10 +151,36 @@ let respond_with_file ?flush ?headers ?(error_body=error_body_default) filename 
   |Ok res -> return res
   |Error _exn -> respond_string ~status:`Not_found error_body
 
-let create ?max_connections ?buffer_age_limit ?(mode=`TCP)
+type mode = Conduit_async.server
+
+let create_raw ?max_connections ?backlog ?buffer_age_limit ?(mode=`TCP)
     ~on_handler_error where_to_listen handle_request =
-  Conduit_async.serve ?max_connections
+  Conduit_async.serve ?max_connections ?backlog
     ?buffer_age_limit ~on_handler_error mode
     where_to_listen (handle_client handle_request)
   >>| fun server ->
   { server }
+
+
+let create_expert ?max_connections ?backlog
+      ?buffer_age_limit ?(mode=`TCP) ~on_handler_error where_to_listen handle_request =
+  create_raw ?max_connections ?backlog
+    ?buffer_age_limit ~on_handler_error ~mode where_to_listen
+    handle_request
+
+let create
+      ?max_connections
+      ?backlog
+      ?buffer_age_limit
+      ?(mode = `TCP)
+      ~on_handler_error
+      where_to_listen
+      handle_request =
+  let handle_request ~body address request =
+    handle_request ~body address request >>| fun r -> `Response r
+  in
+  create_raw ?max_connections ?backlog
+    ?buffer_age_limit ~on_handler_error ~mode where_to_listen
+    handle_request
+
+

--- a/cohttp-async/src/server.mli
+++ b/cohttp-async/src/server.mli
@@ -74,8 +74,8 @@ val create_expert :
 (** Build a HTTP server, based on the [Tcp.Server] interface *)
 val create :
   ?max_connections:int ->
-  ?buffer_age_limit: Writer.buffer_age_limit ->
   ?backlog:int ->
+  ?buffer_age_limit: Writer.buffer_age_limit ->
   ?mode:Conduit_async.server ->
   on_handler_error:[ `Call of 'address -> exn  -> unit
                    | `Ignore

--- a/cohttp-async/src/server.mli
+++ b/cohttp-async/src/server.mli
@@ -8,13 +8,23 @@ val close          : (_, _) t -> unit Deferred.t
 val close_finished : (_, _) t -> unit Deferred.t
 val is_closed      : (_, _) t -> bool
 
+val listening_on   : (_, 'listening_on) t -> 'listening_on
+
 type response = Response.t * Body.t [@@deriving sexp_of]
 
-val respond :
+type 'r respond_t =
   ?flush:bool ->
   ?headers:Cohttp.Header.t ->
   ?body:Body.t ->
-  Cohttp.Code.status_code -> response Deferred.t
+  Cohttp.Code.status_code -> 'r Deferred.t
+
+type response_action =
+  (* The connection is not closed in the [`Expert] case until the [unit
+     Deferred.t] becomes determined. *)
+  [ `Expert of Cohttp.Response.t * (Reader.t -> Writer.t -> unit Deferred.t)
+  | `Response of response ]
+
+val respond : response respond_t
 
 (** Resolve a URI and a docroot into a concrete local filename. *)
 val resolve_local_file : docroot:string -> uri:Uri.t -> string
@@ -25,13 +35,6 @@ val respond_with_pipe :
   ?flush:bool ->
   ?headers:Cohttp.Header.t -> ?code:Cohttp.Code.status_code ->
   string Pipe.Reader.t -> response Deferred.t
-
-(** Respond with a static [string]
-    @param code Default is HTTP 200 `OK *)
-val respond_with_string :
-  ?flush:bool ->
-  ?headers:Cohttp.Header.t -> ?code:Cohttp.Code.status_code ->
-  string -> response Deferred.t [@@deprecated "please use respond_string instead"]
 
 val respond_string :
   ?flush:bool ->
@@ -51,10 +54,28 @@ val respond_with_file :
   ?headers:Cohttp.Header.t -> ?error_body:string ->
   string -> response Deferred.t
 
+type mode = Conduit_async.server
+
+(** Build a HTTP server and expose the [IO.ic] and [IO.oc]s, based on the
+    [Tcp.Server] interface. *)
+val create_expert :
+  ?max_connections:int ->
+  ?backlog:int ->
+  ?buffer_age_limit:Writer.buffer_age_limit ->
+  ?mode:mode ->
+  on_handler_error:[ `Call of 'address -> exn  -> unit
+                   | `Ignore
+                   | `Raise ] ->
+  ('address, 'listening_on) Tcp.Where_to_listen.t
+  -> (body:Body.t -> 'address -> Request.t -> response_action Deferred.t)
+  -> ('address, 'listening_on) t Deferred.t
+
+
 (** Build a HTTP server, based on the [Tcp.Server] interface *)
 val create :
   ?max_connections:int ->
   ?buffer_age_limit: Writer.buffer_age_limit ->
+  ?backlog:int ->
   ?mode:Conduit_async.server ->
   on_handler_error:[ `Call of 'address -> exn  -> unit
                    | `Ignore


### PR DESCRIPTION
This allows CoHTTP to hand off the raw reader and writer to a handler.
