### PR TITLE
Fd safety for Cohttp_async.Client.request

### DIFF
--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -167,47 +167,59 @@ module Client = struct
 
   let request ?interrupt ?ssl_config ?uri ?(body=`Empty) req =
     (* Connect to the remote side *)
-    let uri =
-      match uri with
+    let uri = match uri with
       | Some t -> t
-      | None -> Request.uri req in
-    Net.connect_uri ?interrupt uri
-    >>= fun (ic,oc) ->
-    Request.write (fun writer -> Body.write Request.write_body body writer) req oc
-    >>= fun () ->
-    read_request ic >>| fun (resp, body) ->
-    don't_wait_for (
-      Pipe.closed body >>= fun () ->
-      Deferred.all_ignore [Reader.close ic; Writer.close oc]);
-    (resp, `Pipe body)
+      | None -> Request.uri req
+    in
+    Net.connect_uri ?interrupt uri >>= fun (ic, oc) ->
+    Monitor.try_with
+      (fun () ->
+         Request.write (Body.write Request.write_body body) req oc >>= fun () ->
+         read_request ic >>| fun (resp, body) ->
+         don't_wait_for begin
+           Pipe.closed body >>= fun () ->
+           Deferred.all_ignore [Reader.close ic; Writer.close oc]
+         end;
+         (resp, `Pipe body)
+      ) >>= function
+    | Ok res -> return res
+    | Error exn ->
+        Deferred.all_unit [Reader.close ic; Writer.close oc] >>= fun () ->
+        raise exn
 
   let callv ?interrupt ?ssl_config uri reqs =
     let reqs_c = ref 0 in
     let resp_c = ref 0 in
-    Net.connect_uri ?interrupt ?ssl_config uri >>| fun (ic, oc) ->
-    reqs
-    |> Pipe.iter ~f:(fun (req, body) ->
-      incr reqs_c;
-      Request.write (fun writer -> Body.write Request.write_body body writer)
-        req oc)
-    |> don't_wait_for;
-    let last_body_drained = ref Deferred.unit in
-    let responses = Reader.read_all ic (fun ic ->
-      !last_body_drained >>= fun () ->
-      if Pipe.is_closed reqs && (!resp_c >= !reqs_c) then
-        return `Eof
-      else
-        ic |> read_request >>| fun (resp, body) ->
-        incr resp_c;
-        last_body_drained := Pipe.closed body;
-        `Ok (resp, `Pipe body)
-    ) in
-    don't_wait_for (
-      Pipe.closed reqs >>= fun () ->
-      Pipe.closed responses >>= fun () ->
-      Writer.close oc
-    );
-    responses
+    Net.connect_uri ?interrupt ?ssl_config uri >>= fun (ic, oc) ->
+    Monitor.try_with
+      (fun () ->
+         don't_wait_for @@ Pipe.iter reqs ~f:begin fun (req, body) ->
+           incr reqs_c;
+           Request.write (Body.write Request.write_body body) req oc
+         end;
+         let last_body_drained = ref Deferred.unit in
+         let responses = Reader.read_all ic (fun ic ->
+             !last_body_drained >>= fun () ->
+             if Pipe.is_closed reqs && (!resp_c >= !reqs_c) then
+               return `Eof
+             else
+               read_request ic >>| fun (resp, body) ->
+               incr resp_c;
+               last_body_drained := Pipe.closed body;
+               `Ok (resp, `Pipe body)
+           )
+         in
+         don't_wait_for (
+           Pipe.closed reqs >>= fun () ->
+           Pipe.closed responses >>= fun () ->
+           Writer.close oc
+         );
+         return responses
+      ) >>= function
+    | Ok res -> return res
+    | Error exn ->
+        Deferred.all_unit [Reader.close ic; Writer.close oc] >>= fun () ->
+        raise exn
 
   let call ?interrupt ?ssl_config ?headers ?(chunked=false) ?(body=`Empty) meth uri =
     (* Create a request, then make the request. Figure out an appropriate


### PR DESCRIPTION
If `request` raises, we should still take care to close ic and oc. We
don't close the fd's unconditionally at the end of request using
something like Monitor.protect because the success case should delay
closing the fd's until the body pipe is closed.
