### PR TITLE
Add Header.to_frames and comment Header.to_lines

### DIFF
--- a/js/cohttp_lwt_xhr.ml
+++ b/js/cohttp_lwt_xhr.ml
@@ -185,6 +185,7 @@ module Make_client_sync(P : Params) = Make_api(struct
 
     let call ?headers ?body meth uri =
       let xml = XmlHttpRequest.create () in
+      xml ##. withCredentials := (Js.bool P.with_credentials) ;
       let () = xml##(_open (Js.string (C.Code.string_of_method meth))
                           (Js.string (Uri.to_string uri))
                           (Js._false))  (* synchronous call *)

--- a/lib/header.ml
+++ b/lib/header.ml
@@ -112,6 +112,11 @@ let of_list l = List.fold_left (fun h (k,v) -> add h k v) (init ()) l
 let to_list h = List.rev (fold (fun k v acc -> (k,v)::acc) h [])
 let header_line k v = Printf.sprintf "%s: %s\r\n" k v
 let to_lines h = List.rev (fold (fun k v acc -> (header_line k v)::acc) h [])
+
+let to_frames =
+  let to_frame k v acc = (Printf.sprintf "%s: %s" k v) :: acc in
+  fun h -> List.rev (fold to_frame h [])
+
 let to_string h =
   let b = Buffer.create 128 in
   h |> iter (fun k v ->

--- a/lib/header.mli
+++ b/lib/header.mli
@@ -78,7 +78,14 @@ val map : (string -> string list -> string list) -> t -> t
 val fold : (string -> string -> 'a -> 'a) -> t -> 'a -> 'a
 val of_list : (string * string) list -> t
 val to_list : t -> (string * string) list
+
+(** Return header fieds as a list of lines. Beware that each line
+  ends with "\r\n" characters. *)
 val to_lines : t -> string list
+
+(** Same as {!to_lines} but lines do not end with "\r\n" characters. *)
+val to_frames : t -> string list
+
 val to_string : t -> string
 
 val get_content_range : t -> Int64.t option


### PR DESCRIPTION
And also add a line which should have been added in https://github.com/mirage/ocaml-cohttp/pull/480 (see https://github.com/mirage/ocaml-cohttp/pull/514).