### PR TITLE
Rename Cohttp_Async.Server.respond_with_string

### DIFF
--- a/async/cohttp_async.ml
+++ b/async/cohttp_async.ml
@@ -337,6 +337,9 @@ module Server = struct
   let respond_with_string ?flush ?headers ?(code=`OK) body =
     respond ?flush ?headers ~body:(`String body) code
 
+  let respond_string ?flush ?headers ?(status=`OK) body =
+    respond ?flush ?headers ~body:(`String body) status
+
   let respond_with_redirect ?headers uri =
     let headers = Cohttp.Header.add_opt_unless_exists headers "location" (Uri.to_string uri) in
     respond ~flush:false ~headers `Found
@@ -361,7 +364,7 @@ module Server = struct
       )
     >>= function
     |Ok res -> return res
-    |Error exn -> respond_with_string ~code:`Not_found error_body
+    |Error exn -> respond_string ~status:`Not_found error_body
 
   let create ?max_connections ?buffer_age_limit ?on_handler_error
         ?(mode=`TCP) where_to_listen handle_request =

--- a/async/cohttp_async.mli
+++ b/async/cohttp_async.mli
@@ -170,6 +170,12 @@ module Server : sig
   val respond_with_string :
     ?flush:bool ->
     ?headers:Cohttp.Header.t -> ?code:Cohttp.Code.status_code ->
+    string -> response Deferred.t [@@deprecated "please use respond_string instead"]
+
+  val respond_string :
+    ?flush:bool ->
+    ?headers:Cohttp.Header.t ->
+    ?status:Cohttp.Code.status_code ->
     string -> response Deferred.t
 
   (** Respond with a redirect to an absolute [uri]

--- a/bin/cohttp_server_async.ml
+++ b/bin/cohttp_server_async.ml
@@ -59,13 +59,13 @@ let serve ~info ~docroot ~index uri path =
           ) >>| function Ok v -> v | Error _ -> (None, 0L, f))
         >>= fun listing ->
         html_of_listing uri path (sort ((Some `Directory,0L,"..")::listing)) info
-      |> Server.respond_with_string
+      |> Server.respond_string
     end
     (* Serve the local file contents *)
     | `File -> serve_file ~docroot ~uri
     (* Any other file type is simply forbidden *)
     | `Socket | `Block | `Fifo | `Char | `Link ->
-      Server.respond_with_string ~code:`Forbidden
+      Server.respond_string ~status:`Forbidden
         (html_of_forbidden_unnormal path info)
   )
   >>= (function
@@ -74,7 +74,7 @@ let serve ~info ~docroot ~index uri path =
     begin match Monitor.extract_exn exn with
     | Unix.Unix_error (Unix.ENOENT, "stat", p) ->
       if p = ("((filename "^file_name^"))") (* Really? *)
-      then Server.respond_with_string ~code:`Not_found
+      then Server.respond_string ~status:`Not_found
         (html_of_not_found path info)
       else raise exn
     | _ -> raise exn
@@ -97,7 +97,7 @@ let rec handler ~info ~docroot ~index ~body sock req =
     let meth = Cohttp.Code.string_of_method meth in
     let allowed = "GET, HEAD" in
     let headers = Cohttp.Header.of_list ["allow", allowed] in
-    Server.respond_with_string ~headers ~code:`Method_not_allowed
+    Server.respond_string ~headers ~status:`Method_not_allowed
       (html_of_method_not_allowed meth allowed path info)
 
 let determine_mode cert_file_path key_file_path =

--- a/examples/async/hello_world.ml
+++ b/examples/async/hello_world.ml
@@ -15,9 +15,9 @@ let handler ~body:_ _sock req =
        Uri.get_query_param uri "hello"
     |> Option.map ~f:(fun v -> "hello: " ^ v)
     |> Option.value ~default:"No param hello supplied"
-    |> Server.respond_with_string
+    |> Server.respond_string
   | _ ->
-    Server.respond_with_string ~code:`Not_found "Route not found"
+    Server.respond_string ~status:`Not_found "Route not found"
 
 let start_server port () =
   eprintf "Listening for HTTP on port %d\n" port;

--- a/lib_test/test_async_integration.ml
+++ b/lib_test/test_async_integration.ml
@@ -22,11 +22,11 @@ let server =
   [ (* empty_chunk *)
     const @@ Server.respond `OK ~body:(Body.of_string_list chunk_body);
     (* large response *)
-    const @@ Server.respond_with_string large_string;
+    const @@ Server.respond_string large_string;
     (* large request *)
     (fun _ body ->
        body |> Body.to_string >>| String.length >>= fun len ->
-       Server.respond_with_string (Int.to_string len));
+       Server.respond_string (Int.to_string len));
   ] @ (* pipelined_chunk *)
   (response_bodies |> List.map ~f:(Fn.compose const ok))
   @ [ (* large response chunked *)

--- a/lib_test/test_net_async_server.ml
+++ b/lib_test/test_net_async_server.ml
@@ -39,14 +39,14 @@ let handler ~body sock req =
       <li><a href='/timer'>timer</a></li>\r\n\
       <li><i>Files</i></li>\r\n\
       %s</ul></body></html>"
-    |> Server.respond_with_string
+    |> Server.respond_string
   | "/post" ->
     Body.to_string body >>= fun body ->
-    Server.respond_with_string body
+    Server.respond_string body
   | "/postnodrain" ->
-    Server.respond_with_string "nodrain"
+    Server.respond_string "nodrain"
   | "/hello" ->
-    Server.respond_with_string "hello world"
+    Server.respond_string "hello world"
   | "/hellopipe" ->
     let body = Pipe.of_list ["hello";"world"] in
     Server.respond_with_pipe body

--- a/lwt-core/cohttp_lwt.ml
+++ b/lwt-core/cohttp_lwt.ml
@@ -201,8 +201,8 @@ module Make_server(IO:IO) = struct
     let res = Response.make ~status ~flush ~encoding ?headers () in
     return (res, body)
 
-  let respond_string ?headers ~status ~body () =
-    let res = Response.make ~status
+  let respond_string ?(flush=true) ?headers ~status ~body () =
+    let res = Response.make ~status ~flush
                 ~encoding:(Transfer.Fixed (Int64.of_int (String.length body)))
                 ?headers () in
     let body = Body.of_string body in
@@ -300,4 +300,3 @@ module Make_server(IO:IO) = struct
       ) res oc
     )
 end
-

--- a/lwt-core/cohttp_lwt_s.ml
+++ b/lwt-core/cohttp_lwt_s.ml
@@ -120,7 +120,7 @@ module type Server = sig
   (** [respond ?headers ?flush ~status ~body] will respond to an HTTP
     request with the given [status] code and response [body].  If
     [flush] is true, then every response chunk will be flushed to
-    the network rather than being buffered. [flush] is true by default. 
+    the network rather than being buffered. [flush] is true by default.
     The transfer encoding will be detected from the [body] value and
     set to chunked encoding if it cannot be determined immediately.
     You can override the encoding by supplying an appropriate [Content-length]
@@ -132,6 +132,7 @@ module type Server = sig
     body:Cohttp_lwt_body.t -> unit -> (Response.t * Cohttp_lwt_body.t) Lwt.t
 
   val respond_string :
+    ?flush:bool ->
     ?headers:Cohttp.Header.t ->
     status:Cohttp.Code.status_code ->
     body:string -> unit -> (Response.t * Cohttp_lwt_body.t) Lwt.t


### PR DESCRIPTION
We rename respond_with_string to respond_string and replace all occurences of
respond_with_string. We want to make the API for Server in Async and LWT as
similar as possible.

Refs: https://github.com/mirage/ocaml-cohttp/issues/524

The only diff now between `Cohttp_Async.Server.respond_string` and `Cohttp_Lwt.Server.respond_string` is that the LWT version requires an additional `unit` parameter. Why do a lot of the LWT Server functions require a unit parameter while the Async ones don't?