### PR TITLE
Require at least conduit 0.14.0 for lwt-unix

### DIFF
--- a/cohttp.opam
+++ b/cohttp.opam
@@ -32,7 +32,7 @@ depends: [
   "uri" {>= "1.9.0"}
   "fieldslib"
   "sexplib"
-  "conduit" {>= "0.11.0"}
+  "conduit" {>= "0.14.0"}
   "ppx_fields_conv"
   "ppx_sexp_conv"
   "stringext"


### PR DESCRIPTION
`~on_exn` argument for Conduit_lwt_unix.serve was added in 0.14.0. Closes #536. Does this fix it?