### PR TITLE
media-params: get rid of string/token distinction

### DIFF
--- a/lib/accept.ml
+++ b/lib/accept.ml
@@ -44,8 +44,11 @@ let languages = function
 
 let rec string_of_pl = function
   | [] -> ""
-  | (k,T v)::r -> sprintf ";%s=%s%s" k v (string_of_pl r)
-  | (k,S v)::r -> sprintf ";%s=\"%s\"%s" k (Stringext.quote v) (string_of_pl r)
+  | (k, v)::r ->
+    let e = Stringext.quote v in
+    if v = e
+    then sprintf ";%s=%s%s"     k v (string_of_pl r)
+    else sprintf ";%s=\"%s\"%s" k e (string_of_pl r)
 
 let accept_el el pl q =
   sprintf "%s;q=%.3f%s" el ((float q)/.1000.) (string_of_pl pl)

--- a/lib/accept.mli
+++ b/lib/accept.mli
@@ -30,11 +30,7 @@ type 'a qlist = (q * 'a) list [@@deriving sexp]
 *)
 val qsort : 'a qlist -> 'a qlist
 
-type pv = Accept_types.pv =
-    T of string
-  | S of string [@@deriving sexp]
-
-type p = string * pv [@@deriving sexp]
+type p = string * string [@@deriving sexp]
 
 type media_range =
   Accept_types.media_range =
@@ -73,7 +69,7 @@ val encodings : string option -> encoding qlist
 
 val languages : string option -> language qlist
 
-val string_of_media_range : media_range * (string * pv) list -> q -> string
+val string_of_media_range : media_range * p list -> q -> string
 val string_of_charset : charset -> q -> string
 val string_of_encoding : encoding -> q -> string
 val string_of_language : language -> q -> string

--- a/lib/accept_parser.mly
+++ b/lib/accept_parser.mly
@@ -19,7 +19,7 @@
 %{
   open Accept_types
 
-  type param = Q of int | Kv of (string * pv)
+  type param = Q of int | Kv of p
 
   let rec get_q = function
     | (Q q)::_ -> q
@@ -40,11 +40,11 @@
 %%
 
 param :
-| SEMI TOK EQUAL QS { Kv ($2, S $4) }
+| SEMI TOK EQUAL QS { Kv ($2, $4) }
 | SEMI TOK EQUAL TOK {
   if $2="q" then try Q (truncate (1000.*.(float_of_string $4)))
     with Failure "float_of_string" -> raise Parsing.Parse_error
-  else Kv ($2, T $4)
+  else Kv ($2, $4)
 }
 
 params :

--- a/lib/accept_types.ml
+++ b/lib/accept_types.ml
@@ -19,8 +19,7 @@
 
 open Sexplib.Std
 
-type pv = T of string | S of string [@@deriving sexp]
-type p = string * pv [@@deriving sexp]
+type p = string * string [@@deriving sexp]
 type media_range =
   | MediaType of string * string
   | AnyMediaSubtype of string

--- a/lib_test/test_accept.ml
+++ b/lib_test/test_accept.ml
@@ -40,12 +40,12 @@ let valid_media_ranges = [
     1000,(A.AnyMediaSubtype "text",[]);
   ];
   "text/plain; q=0.8; charset=utf-8,text/HTML;charset=utf-8;q=0.9", [
-    800,(A.MediaType ("text","plain"),["charset",A.T"utf-8"]);
-    900,(A.MediaType ("text","html"),["charset",A.T"utf-8"]);
+    800,(A.MediaType ("text","plain"),["charset","utf-8"]);
+    900,(A.MediaType ("text","html"),["charset","utf-8"]);
   ];
-  "text/*;foo=\"bar\"", [1000,(A.AnyMediaSubtype "text",["foo",A.S"bar"])];
-  "*/*;qu=\"\\\"\"", [1000,(A.AnyMedia,["qu",A.S"\""])];
-  "*/*;f=\";q=0,text/plain\"", [1000,(A.AnyMedia,["f",A.S";q=0,text/plain"])];
+  "text/*;foo=\"bar\"", [1000,(A.AnyMediaSubtype "text",["foo","bar"])];
+  "*/*;qu=\"\\\"\"", [1000,(A.AnyMedia,["qu","\""])];
+  "*/*;f=\";q=0,text/plain\"", [1000,(A.AnyMedia,["f",";q=0,text/plain"])];
 ]
 
 let valid_media_ranges_suite =


### PR DESCRIPTION
From [RFC7231§3.1.1.1](https://tools.ietf.org/html/rfc7231#section-3.1.1.1):

>  A parameter value that matches the token production can be transmitted either as a token or within a quoted-string. The quoted and unquoted values are equivalent. For example, the following examples are all equivalent, but the first is preferred for consistency:
>
>     text/html;charset=utf-8
>     text/html;charset=UTF-8
>     Text/HTML;Charset="utf-8"
>     text/html; charset="utf-8"

The parser now simply returns a string and serializes to a token or a quoted string depending on whether the parameter includes characters that require escaping.