### PR TITLE
Fix exception observed on 32-bit architectures

### DIFF
--- a/lib/transfer_io.ml
+++ b/lib/transfer_io.ml
@@ -88,8 +88,8 @@ module Make(IO : S.IO) = struct
       match !remaining with
       | 0L -> return Done
       | len ->
-        let len' = Int64.to_int len in
-        let read_len = min len' 0x8000 in
+        let max_read_len = Int64.of_int 0x8000 in
+        let read_len = Int64.to_int (min len max_read_len) in
         read ic read_len >>= function
         | "" -> return Done
         | buf ->


### PR DESCRIPTION
When determining how much to read in one go in a fixed length
transfer, we used to first convert an Int64 length to an int
and then bound that by 0x8000. However, the conversion can
result in a negative value and this later on results in an
exception. The 0x8000 bound should be applied in Int64 space.