### PR TITLE
remove warnings with new Async

### DIFF
--- a/async/body.mli
+++ b/async/body.mli
@@ -1,5 +1,5 @@
-open Core.Std
-open Async.Std
+open Core
+open Async
 open Cohttp
 
 type t = [

--- a/async/body_raw.ml
+++ b/async/body_raw.ml
@@ -1,5 +1,5 @@
-open Core.Std
-open Async.Std
+open Core
+open Async
 module B = Cohttp.Body
 
 type t = [
@@ -71,7 +71,7 @@ let write_body write_body (body : t) writer =
 
 let pipe_of_body read_chunk ic =
   let open Cohttp.Transfer in
-  Pipe.init (fun writer ->
+  Pipe.create_reader ~close_on_exception:false (fun writer ->
       Deferred.repeat_until_finished () (fun () ->
           read_chunk ic >>= function
           | Chunk buf ->

--- a/async/client.ml
+++ b/async/client.ml
@@ -1,5 +1,5 @@
-open Core.Std
-open Async.Std
+open Core
+open Async
 
 module Request = struct
   include Cohttp.Request

--- a/async/client.mli
+++ b/async/client.mli
@@ -1,5 +1,5 @@
-open Core.Std
-open Async.Std
+open Core
+open Async
 
 (** Send an HTTP request with an arbitrary body
     The request is sent as-is. *)

--- a/async/io.ml
+++ b/async/io.ml
@@ -14,8 +14,8 @@
  *
   }}}*)
 
-open Core.Std
-open Async.Std
+open Core
+open Async
 
 let log_src_name = "cohttp.async.io"
 let src = Logs.Src.create log_src_name ~doc:"Cohttp Async IO module"

--- a/async/io.mli
+++ b/async/io.mli
@@ -13,7 +13,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
   }}}*)
 
-open Async.Std
+open Async
 
 include Cohttp.S.IO
   with type 'a t = 'a Deferred.t

--- a/async/server.ml
+++ b/async/server.ml
@@ -1,5 +1,5 @@
-open Core.Std
-open Async.Std
+open Core
+open Async
 
 module Request = struct
   include Cohttp.Request

--- a/async/server.mli
+++ b/async/server.mli
@@ -1,5 +1,5 @@
-open Core.Std
-open Async.Std
+open Core
+open Async
 
 type ('address, 'listening_on) t constraint 'address = [< Socket.Address.t ]
   [@@deriving sexp_of]

--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -23,11 +23,8 @@ depends: [
   "jbuilder" {build}
   "cohttp"
   "conduit" {>= "0.14.0"}
-  "async"
+  "async" {>= "v0.9"}
   "magic-mime"
   "fmt"
-]
-conflicts: [
-  "async" {< "113.24.00"}
 ]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
As you said, nobody uses Async with cohttp. And seriously, there is no reason to use older Janestreet libraries now that new and better ones are released. And also, such user can use older release of cohttp is he/she really wants to.