### PR TITLE
Add Cohttp_lwt.Body alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ let body =
   let code = resp |> Response.status |> Code.code_of_status in
   Printf.printf "Response code: %d\n" code;
   Printf.printf "Headers: %s\n" (resp |> Response.headers |> Header.to_string);
-  body |> Cohttp_lwt_body.to_string >|= fun body ->
+  body |> Cohttp_lwt.Body.to_string >|= fun body ->
   Printf.printf "Body of length: %d\n" (String.length body);
   body
 
@@ -100,7 +100,7 @@ There's a few things to notice:
   contains the response's status code, headers, http version, etc. The second
   element contains the body.
 * The body is then converted to a string and is returned (after the length is
-  printed). Note that `Cohttp_lwt_body.to_string` hence it's up to us to keep
+  printed). Note that `Cohttp_lwt.Body.to_string` hence it's up to us to keep
   a reference to the result.
 * We must trigger lwt's event loop for the request to run. `Lwt_main.run` will
   run the event loop and return with final value of `body` which we then print.
@@ -116,14 +116,14 @@ Implementing a server in cohttp is mostly equivalent to implementing a function
 of type:
 
 ```ocaml
-conn -> Cohttp.Request.t -> Cohttp_lwt_body.t -> (Cohttp.Response.t * Cohttp_lwt_body.t) Lwt.t
+conn -> Cohttp.Request.t -> Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 ```
 
 The parameters are self explanatory but we'll summarize them quickly here:
 
 * `conn` - contains connection information
 * `Cohttp.Request.t` - Request information such as method, uri, headers, etc.
-* `Cohttp_lwt_body.t` - Contains the request body. You must manually decode the
+* `Cohttp_lwt.Body.t` - Contains the request body. You must manually decode the
   request body into json, form encoded pairs, etc. For cohttp, the body is
   simply binary data.
 
@@ -141,7 +141,7 @@ let server =
     let uri = req |> Request.uri |> Uri.to_string in
     let meth = req |> Request.meth |> Code.string_of_method in
     let headers = req |> Request.headers |> Header.to_string in
-    body |> Cohttp_lwt_body.to_string >|= (fun body ->
+    body |> Cohttp_lwt.Body.to_string >|= (fun body ->
       (Printf.sprintf "Uri: %s\nMethod: %s\nHeaders\nHeaders: %s\nBody: %s"
          uri meth headers body))
     >>= (fun body -> Server.respond_string ~status:`OK ~body ())

--- a/cohttp-lwt-jsoo/src/cohttp_lwt_xhr.ml
+++ b/cohttp-lwt-jsoo/src/cohttp_lwt_xhr.ml
@@ -16,7 +16,7 @@
   }}}*)
 
 module C = Cohttp
-module CLB = Cohttp_lwt_body
+module CLB = Cohttp_lwt.Body
 
 let (>>=) = Lwt.(>>=)
 let (>|=) = Lwt.(>|=)
@@ -112,9 +112,9 @@ module Make_api(X : sig
 
     val call :
       ?headers:Cohttp.Header.t ->
-      ?body:Cohttp_lwt_body.t ->
+      ?body:Cohttp_lwt.Body.t ->
       Cohttp.Code.meth ->
-      Uri.t -> (Response.t * Cohttp_lwt_body.t) Lwt.t
+      Uri.t -> (Response.t * Cohttp_lwt.Body.t) Lwt.t
 
   end) = struct
 
@@ -141,7 +141,7 @@ module Make_api(X : sig
 
   let post_form ?ctx ?headers ~params uri =
     let headers = C.Header.add_opt headers "content-type" "application/x-www-form-urlencoded" in
-    let body = Cohttp_lwt_body.of_string (Uri.encoded_of_query params) in
+    let body = Cohttp_lwt.Body.of_string (Uri.encoded_of_query params) in
     post ?ctx ~chunked:false ~headers ~body uri
 
   (* No implementation (can it be done?).  What should the failure exception be? *)

--- a/cohttp-lwt-unix/bin/cohttp_curl_lwt.ml
+++ b/cohttp-lwt-unix/bin/cohttp_curl_lwt.ml
@@ -37,11 +37,11 @@ let client uri ofile meth' =
     prerr_endline (Code.string_of_status status);
     exit 1
   | true ->
-    Cohttp_lwt_body.length body >>= fun (len, body) ->
+    Cohttp_lwt.Body.length body >>= fun (len, body) ->
     debug (fun d -> d "Client body length: %Ld" len) >>= fun () ->
-    Cohttp_lwt_body.to_string body >>= fun s ->
+    Cohttp_lwt.Body.to_string body >>= fun s ->
     let output_body c =
-      Lwt_stream.iter_s (Lwt_io.fprint c) (Cohttp_lwt_body.to_stream body) in
+      Lwt_stream.iter_s (Lwt_io.fprint c) (Cohttp_lwt.Body.to_stream body) in
     match ofile with
     | None -> output_body Lwt_io.stdout
     | Some fname -> Lwt_io.with_file ~mode:Lwt_io.output fname output_body

--- a/cohttp-lwt-unix/src/cohttp_lwt_unix.ml
+++ b/cohttp-lwt-unix/src/cohttp_lwt_unix.ml
@@ -72,7 +72,7 @@ module Server = struct
       ) in
       Lwt_stream.on_terminate stream (fun () ->
         ignore_result (Lwt_io.close ic));
-      let body = Cohttp_lwt_body.of_stream stream in
+      let body = Cohttp_lwt.Body.of_stream stream in
       let mime_type = Magic_mime.lookup fname in
       let headers = Cohttp.Header.add_opt_unless_exists
                       headers "content-type" mime_type in

--- a/cohttp-lwt-unix/src/cohttp_lwt_unix.mli
+++ b/cohttp-lwt-unix/src/cohttp_lwt_unix.mli
@@ -63,7 +63,7 @@ module Server : sig
 
   val respond_file :
     ?headers:Cohttp.Header.t ->
-    fname:string -> unit -> (Cohttp.Response.t * Cohttp_lwt_body.t) Lwt.t
+    fname:string -> unit -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 
   val create :
     ?timeout:int ->

--- a/cohttp-lwt-unix/test/test_parser.ml
+++ b/cohttp-lwt-unix/test/test_parser.ml
@@ -230,9 +230,9 @@ let write_req expected req =
   (* Use the low-level write_header/footer API *)
   let buf = Lwt_bytes.create 4096 in
   let oc = oc_of_buffer buf in
-  let body = Cohttp_lwt_body.of_string "foobar" in
+  let body = Cohttp_lwt.Body.of_string "foobar" in
   Req_io.write (fun writer ->
-    Cohttp_lwt_body.write_body (Req_io.write_body writer) body
+    Cohttp_lwt.Body.write_body (Req_io.write_body writer) body
   ) req oc >>= fun () ->
   assert_equal ~pp_diff expected (get_substring oc buf);
   (* Use the high-level write API. This also tests that req is immutable
@@ -266,9 +266,9 @@ let make_simple_res () =
   let buf = Lwt_bytes.create 4096 in
   let oc = oc_of_buffer buf in
   let res = Response.make ~headers:(Header.of_list [("foo","bar")]) () in
-  let body = Cohttp_lwt_body.of_string "foobar" in
+  let body = Cohttp_lwt.Body.of_string "foobar" in
   Rep_io.write (fun writer ->
-    Cohttp_lwt_body.write_body (Rep_io.write_body writer) body
+    Cohttp_lwt.Body.write_body (Rep_io.write_body writer) body
   ) res oc >>= fun () ->
   assert_equal expected (get_substring oc buf);
   (* Use the high-level write API. This also tests that req is immutable

--- a/cohttp-lwt-unix/test/test_sanity.ml
+++ b/cohttp-lwt-unix/test/test_sanity.ml
@@ -4,7 +4,7 @@ open Cohttp
 open Cohttp_lwt_unix
 open Cohttp_lwt_unix_test
 
-module Body = Cohttp_lwt_body
+module Body = Cohttp_lwt.Body
 
 let message = "Hello sanity!"
 
@@ -42,7 +42,7 @@ let server =
   |> (fun tests ->
     tests @ [
       (fun _ body -> (* Returns 500 on bad file *)
-         Cohttp_lwt_body.to_string body >>= fun fname ->
+         Body.to_string body >>= fun fname ->
          Server.respond_file ~fname ())] @
     (Array.init (leak_repeat * 2) (fun _ _ _ ->
          (* no leaks *)
@@ -141,7 +141,7 @@ let ts =
           assert_equal (Response.status resp_head) `OK;
           Client.get uri >>= fun (resp_get, body) ->
           assert_equal (Response.status resp_get) `OK;
-          Cohttp_lwt_body.drain_body body) stream ()
+          Body.drain_body body) stream ()
     in
     [ "sanity test", t
     ; "empty chunk test", empty_chunk

--- a/cohttp-lwt/src/cohttp_lwt.mli
+++ b/cohttp-lwt/src/cohttp_lwt.mli
@@ -25,6 +25,7 @@ module type IO = S.IO with type 'a t = 'a Lwt.t
 (** The IO module is specialized for the [Lwt] monad. *)
 
 module S : (module type of Cohttp_lwt_s)
+module Body : (module type of Cohttp_lwt_body)
 
 (** Aliases for module types inside S. These are deprecated and are only
     here for backwards comaptibility *)

--- a/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.mli
+++ b/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.mli
@@ -1,1 +1,1 @@
-include Cohttp_test.S with type 'a io = 'a Lwt.t and type body = Cohttp_lwt_body.t
+include Cohttp_test.S with type 'a io = 'a Lwt.t and type body = Cohttp_lwt.Body.t

--- a/examples/doc/client_lwt.ml
+++ b/examples/doc/client_lwt.ml
@@ -7,7 +7,7 @@ let body =
   let code = resp |> Response.status |> Code.code_of_status in
   Printf.printf "Response code: %d\n" code;
   Printf.printf "Headers: %s\n" (resp |> Response.headers |> Header.to_string);
-  body |> Cohttp_lwt_body.to_string >|= fun body ->
+  body |> Cohttp_lwt.Body.to_string >|= fun body ->
   Printf.printf "Body of length: %d\n" (String.length body);
   body
 

--- a/examples/doc/server_lwt.ml
+++ b/examples/doc/server_lwt.ml
@@ -7,7 +7,7 @@ let server =
     let uri = req |> Request.uri |> Uri.to_string in
     let meth = req |> Request.meth |> Code.string_of_method in
     let headers = req |> Request.headers |> Header.to_string in
-    body |> Cohttp_lwt_body.to_string >|= (fun body ->
+    body |> Cohttp_lwt.Body.to_string >|= (fun body ->
       (Printf.sprintf "Uri: %s\nMethod: %s\nHeaders\nHeaders: %s\nBody: %s"
          uri meth headers body))
     >>= (fun body -> Server.respond_string ~status:`OK ~body ())


### PR DESCRIPTION
In preparation for preserving compatibility when the library switches over to
use module aliases.