### PR TITLE
Add Cohttp_lwt_unix.Net alias

### DIFF
--- a/cohttp-lwt-unix/bin/cohttp_server_lwt.ml
+++ b/cohttp-lwt-unix/bin/cohttp_server_lwt.ml
@@ -112,7 +112,7 @@ let start_server docroot port host index tls () =
   in
   Conduit_lwt_unix.init ~src:host ()
   >>= fun ctx ->
-  let ctx = Cohttp_lwt_unix_net.init ~ctx () in
+  let ctx = Cohttp_lwt_unix.Net.init ~ctx () in
   Server.create ~ctx ~mode config
 
 let lwt_start_server docroot port host index verbose tls =

--- a/cohttp-lwt-unix/src/cohttp_lwt_unix.ml
+++ b/cohttp-lwt-unix/src/cohttp_lwt_unix.ml
@@ -26,6 +26,8 @@ module Response = struct
            : module type of Make(Cohttp_lwt_unix_io) with type t := t)
 end
 
+module Net = Cohttp_lwt_unix_net
+
 module Client = struct
   include
     Cohttp_lwt.Make_client

--- a/cohttp-lwt-unix/src/cohttp_lwt_unix.mli
+++ b/cohttp-lwt-unix/src/cohttp_lwt_unix.mli
@@ -24,6 +24,8 @@ module Request : Cohttp.S.Request with type t = Cohttp.Request.t
 (** The [Response] module holds the information about a HTTP response. *)
 module Response : Cohttp.S.Response with type t = Cohttp.Response.t
 
+module Net : module type of struct include Cohttp_lwt_unix_net end
+
 (** {2 Module types for Client and Server} *)
 
 (** The [Client] module type defines the additional UNIX-specific functions


### PR DESCRIPTION
In preparation for when Cohttp_lwt_unix switches to module aliases

@avsm this is also required for 0.99