### PR TITLE
fix the binary names to be the same as previous releases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## v0.99.0 
+## v0.99.0 (2017-07-12)
 
 Port build to jbuilder, and break up OPAM packages into multiple
 independent packages instead of being optional dependencies against

--- a/cohttp-async/bin/jbuild
+++ b/cohttp-async/bin/jbuild
@@ -4,4 +4,4 @@
  ((names (cohttp_curl_async cohttp_server_async))
   (package cohttp-async)
   (libraries (cohttp-async cohttp_server fmt.tty))
-  (public_names (cohttp_curl_async cohttp_server_async))))
+  (public_names (cohttp-curl-async cohttp-server-async))))

--- a/cohttp-lwt-unix/bin/jbuild
+++ b/cohttp-lwt-unix/bin/jbuild
@@ -4,4 +4,4 @@
  ((names (cohttp_curl_lwt cohttp_proxy_lwt cohttp_server_lwt))
   (libraries (cohttp-lwt-unix cohttp_server cmdliner))
   (package cohttp-lwt-unix)
-  (public_names (cohttp_curl_lwt cohttp_proxy_lwt cohttp_server_lwt))))
+  (public_names (cohttp-curl-lwt cohttp-proxy-lwt cohttp-server-lwt))))


### PR DESCRIPTION
e.g. cohttp_server_lwt should be cohttp-server-lwt