### PR TITLE
cohttp.opam: enforce a modern fieldslib

### DIFF
--- a/cohttp.opam
+++ b/cohttp.opam
@@ -26,8 +26,8 @@ depends: [
   "uri" {>= "1.9.0"}
   "fieldslib"
   "sexplib"
-  "ppx_fields_conv"
-  "ppx_sexp_conv"
+  "ppx_fields_conv" {build & >="v0.9.0"}
+  "ppx_sexp_conv" {build & >="v0.9.0"}
   "stringext"
   "base64" {>= "2.0.0"}
   "magic-mime"


### PR DESCRIPTION
otherwise downgrades result in the deriving fields annotations
not being picked up (e.g. rubytt) and build failures