### PR TITLE
Specify dependencies more precisely

### DIFF
--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -24,6 +24,7 @@ depends: [
   "cohttp"
   "conduit-async"
   "magic-mime"
+  "logs"
   "fmt"
   "ounit" {test}
 ]

--- a/cohttp-lwt-unix.opam
+++ b/cohttp-lwt-unix.opam
@@ -23,6 +23,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "conduit-lwt-unix"
   "cmdliner"
+  "magic-mime"
   "logs"
   "fmt"
   "cohttp-lwt"

--- a/cohttp.opam
+++ b/cohttp.opam
@@ -30,9 +30,7 @@ depends: [
   "ppx_sexp_conv" {build & >="v0.9.0"}
   "stringext"
   "base64" {>= "2.0.0"}
-  "magic-mime"
-  "fmt"
-  "logs"
+  "fmt" {test}
   "jsonm" {build}
   "alcotest" {test}
 ]

--- a/cohttp/test/jbuild
+++ b/cohttp/test/jbuild
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (executables
- ((libraries (cohttp alcotest))
+ ((libraries (cohttp alcotest fmt))
   (modules (test_accept))
   (names (test_accept))))
 


### PR DESCRIPTION
fmt/logs/magic-mime are in fact not dependencies of cohttp and should be
moved to their appropriate subpackages or set as test deps.