### PR TITLE
Set default user-agent

### DIFF
--- a/cohttp-lwt-unix/test/test_parser.ml
+++ b/cohttp-lwt-unix/test/test_parser.ml
@@ -246,14 +246,14 @@ let write_req expected req =
 let make_simple_req () =
   let open Cohttp in
   let open Cohttp_lwt_unix in
-  let expected = "POST /foo/bar HTTP/1.1\r\nfoo: bar\r\nhost: localhost\r\ntransfer-encoding: chunked\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n" in
+  let expected = "POST /foo/bar HTTP/1.1\r\nfoo: bar\r\nhost: localhost\r\ntransfer-encoding: chunked\r\nuser-agent: ocaml-cohttp/\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n" in
   let req = Request.make ~encoding:Transfer.Chunked ~meth:`POST ~headers:(Header.init_with "Foo" "bar") (Uri.of_string "/foo/bar") in
   write_req expected req
 
 let mutate_simple_req () =
   let open Cohttp in
   let open Cohttp_lwt_unix in
-  let expected = "POST /foo/bar HTTP/1.1\r\nfoo: bar\r\nhost: localhost\r\ntransfer-encoding: chunked\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n" in
+  let expected = "POST /foo/bar HTTP/1.1\r\nfoo: bar\r\nhost: localhost\r\ntransfer-encoding: chunked\r\nuser-agent: ocaml-cohttp/\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n" in
   let req = Request.make ~encoding:Transfer.Chunked ~headers:(Header.init_with "foo" "bar") (Uri.of_string "/foo/bar") in
   let req = Fieldslib.Field.fset Request.Fields.meth req `POST in
   write_req expected req

--- a/cohttp/src/request.ml
+++ b/cohttp/src/request.ml
@@ -43,6 +43,8 @@ let make ?(meth=`GET) ?(version=`HTTP_1_1) ?encoding ?headers uri =
        | Some p -> ":" ^ string_of_int p
        | None -> "") in
   let headers =
+    Header.add_unless_exists headers "user-agent" Header.user_agent in
+  let headers =
     (* Add user:password auth to headers from uri
      * if headers don't already have auth *)
     match Header.get_authorization headers, Uri.user uri, Uri.password uri with


### PR DESCRIPTION
This will make cohttp-based clients always set the user-agent request field.
See https://tools.ietf.org/html/rfc2616#section-14.43