### PR TITLE
Catch exceptions when closing channels in mirage client

### DIFF
--- a/cohttp-mirage/src/client.ml
+++ b/cohttp-mirage/src/client.ml
@@ -45,7 +45,9 @@ module Net_IO = struct
 
   let close_in _ = ()
   let close_out _ = ()
-  let close ic _oc = Lwt.ignore_result (Channel.close ic)
+  let close ic _oc = Lwt.ignore_result @@ Lwt.catch
+    (fun () -> Channel.close ic)
+    (fun e  -> Lwt.return @@ Ok ())
 
 end
 let ctx resolver conduit = { Net_IO.resolver; conduit }


### PR DESCRIPTION
Lwt.ignore_result doesn't catch exceptions, which can result in
uncatchable exceptions, because these exceptions will be handled by
Lwt.async_exception_hook.  In race conditions and when using the
socket network, the closing of channels can result in a 'Unix.Unix_error
(Unix.EBADF, "check_descriptor", "")' exception. This change catches
these exceptions.