### PR TITLE
Add ppx_type_conv lower bound

### DIFF
--- a/cohttp.opam
+++ b/cohttp.opam
@@ -26,6 +26,7 @@ depends: [
   "uri" {>= "1.9.0"}
   "fieldslib"
   "sexplib"
+  "ppx_type_conv" {build & >="v0.9.1"}
   "ppx_fields_conv" {build & >="v0.9.0"}
   "ppx_sexp_conv" {build & >="v0.9.0"}
   "stringext"


### PR DESCRIPTION
Previous versions don't interact with ppx_deriving that well.

Best would be to somehow black list this version in opam-repository. But it doesn't hurt adding this here.

@hannesm