### PR TITLE
compile with async_extra v0.9.115.15+07

### DIFF
--- a/cohttp-async/bin/cohttp_curl_async.ml
+++ b/cohttp-async/bin/cohttp_curl_async.ml
@@ -39,7 +39,7 @@ let _ =
   Logs.set_level @@ Some Logs.Debug;
   Logs.set_reporter (Logs_fmt.reporter ());
   let open Command.Spec in
-  Command.async ~summary:"Fetch URL and print it"
+  Command.async_spec ~summary:"Fetch URL and print it"
     (empty
      +> anon ("url" %: string)
      +> flag "-X" (optional_with_default "GET" string)

--- a/cohttp-async/bin/cohttp_server_async.ml
+++ b/cohttp-async/bin/cohttp_server_async.ml
@@ -120,14 +120,14 @@ let start_server docroot port index cert_file key_file verbose () =
         Logs.err (fun f -> f "Error from %s" (Socket.Address.to_string addr));
         Logs.err (fun f -> f "%s" @@ Exn.to_string exn)))
     ~mode
-    (Tcp.on_port port)
+    (Tcp.Where_to_listen.of_port port)
     (handler ~info ~docroot ~index) >>= fun _serv ->
   Deferred.never ()
 
 let () =
   let open Command in
   run @@
-  async ~summary:"Serve the local directory contents via HTTP or HTTPS"
+  async_spec ~summary:"Serve the local directory contents via HTTP or HTTPS"
     Spec.(
       empty
       +> anon (maybe_with_default "." ("docroot" %: string))


### PR DESCRIPTION
Incorporating fixes for:
* https://github.com/janestreet/async_extra/commit/b5a6baa6d78bba95920d861135c8f5f3c4dcee6a renaming `Command.async` to `Command.async_spec`
* https://github.com/janestreet/async_extra/commit/5a163ffd7029f62d3cf7c59d56f1e3a76f9299d5 renaming `Tcp.on_port` to `Tcp.Where_to_listen.of_port`

A version of `async_extra` that works with this is not on opam yet, but I'm using the [janestreet/opam-repository](/janestreet/opam-repository) thing already.