### PR TITLE
Expose the IO module in cohttp-mirage

### DIFF
--- a/cohttp-mirage/src/cohttp_mirage.ml
+++ b/cohttp-mirage/src/cohttp_mirage.ml
@@ -3,3 +3,4 @@ module Static = Static
 module Client = Client
 module Server = Make.Server
 module Server_with_conduit = Server_with_conduit
+module IO = Io.Make


### PR DESCRIPTION
Not sure why this one hidden and I can't find the reason in the history either.