### PR TITLE
[POC] Support exception handler on Lwt response threads

### DIFF
--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -126,6 +126,7 @@ module type Server = sig
       or [Transfer-encoding] in the [headers] parameter. *)
   val respond :
     ?headers:Cohttp.Header.t ->
+    ?on_exn:(exn -> unit) ->
     ?flush:bool ->
     status:Cohttp.Code.status_code ->
     body:Body.t -> unit -> (Cohttp.Response.t * Body.t) Lwt.t

--- a/cohttp/src/s.ml
+++ b/cohttp/src/s.ml
@@ -111,6 +111,7 @@ module type Response = sig
     version: Code.version; (** (** HTTP version, usually 1.1 *) *)
     status: Code.status_code; (** HTTP status code of the response *)
     flush: bool;
+    on_exn: exn -> unit
   } [@@deriving fields, sexp]
 
   val make :
@@ -118,6 +119,7 @@ module type Response = sig
     ?status:Code.status_code ->
     ?flush:bool ->
     ?encoding:Transfer.encoding ->
+    ?on_exn:(exn -> unit) ->
     ?headers:Header.t ->
     unit -> t
 end


### PR DESCRIPTION
I'd like to be able to catch the errors while streaming a response as soon as possible, i.e. in the response thread.  Otherwise, I must handle them in the server exception handler or the toplevel `Lwt.async_exception_hook`.  I do not like either of these options because the client context is lost.  I wasn't able to find a way to do this, hence this patch.

 Here's a motivating example with a build command and example output: https://gist.github.com/timreinke/d059f346146ada6f51eee1255a42be4d . 

I added support for this by allowing the user to pass in an exception handler to `Cohttp_lwt_unix.Server.respond`.  To support plumbing the handler through to the response thread, I added an `on_exn` field to `S.Response.t`.  

I'm looking for some guidance:
1. Is there already a way to do this I simply missed?  If not, is this behavior something `cohttp` would like to support? Am I wrong for even wanting to do this?
2. It seems `S.Response.t` is supposed to be a pure data type based on the `deriving sexp` clause attached to it.  As such, this implementation does not seem the right way to plumb this handler through to the server response thread.  Any suggestions?
3. I haven't used `Async` so I don't know if the same problem exists there and my guess is a different approach would be needed. Is there opportunity for a unified API here?

If this discussion is better off on the devel mailing list, let me know and I'll move it there 😄.  Thanks for your time.

