### PR TITLE
Update code base to be compatible with new async/core

### DIFF
--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -21,6 +21,10 @@ build: [
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
+  "async_kernel" {>= "v0.11.0"}
+  "async_unix" {>= "v0.11.0"}
+  "async_extra" {>= "v0.11.0"}
+  "base" {>= "v0.11.0"}
   "cohttp"
   "conduit-async"
   "magic-mime"

--- a/cohttp-async/bin/cohttp_curl_async.ml
+++ b/cohttp-async/bin/cohttp_curl_async.ml
@@ -14,8 +14,8 @@
  *
   }}}*)
 
-open Core
-open Async
+open Base
+open Async_kernel
 open Cohttp_async
 
 let show_headers h =
@@ -31,21 +31,22 @@ let make_net_req uri meth' body () =
   show_headers (Cohttp.Response.headers res);
   body
   |> Body.to_pipe
-  |> Pipe.iter ~f:(fun b -> print_string b; return ())
+  |> Pipe.iter ~f:(fun b -> Caml.Pervasives.print_string b; return ())
 
 let _ =
   (* enable logging to stdout *)
   Fmt_tty.setup_std_outputs ();
   Logs.set_level @@ Some Logs.Debug;
   Logs.set_reporter (Logs_fmt.reporter ());
-  let open Command.Spec in
-  Command.async_spec ~summary:"Fetch URL and print it"
-    (empty
-     +> anon ("url" %: string)
-     +> flag "-X" (optional_with_default "GET" string)
-       ~doc:" Set HTTP method"
-     +> flag "data-binary" (optional_with_default "" string)
-       ~doc:" Data to send when using POST"
+  let open Async_extra.Command in
+  async_spec ~summary:"Fetch URL and print it"
+    Spec.(
+      empty
+      +> anon ("url" %: string)
+      +> flag "-X" (optional_with_default "GET" string)
+        ~doc:" Set HTTP method"
+      +> flag "data-binary" (optional_with_default "" string)
+        ~doc:" Data to send when using POST"
     )
     make_net_req
-  |> Command.run
+  |> run

--- a/cohttp-async/bin/cohttp_server_async.ml
+++ b/cohttp-async/bin/cohttp_server_async.ml
@@ -15,8 +15,9 @@
  *
   }}}*)
 
-open Core
-open Async
+open Base
+open Async_kernel
+open Async_unix
 
 open Cohttp_async
 open Cohttp_server
@@ -40,7 +41,7 @@ let serve ~info ~docroot ~index uri path =
     (* Get a list of current files and map to HTML *)
     | `Directory -> begin
       let path_len = String.length path in
-      if path_len <> 0 && path.[path_len - 1] <> '/'
+      if Int.(path_len <> 0) && Char.(path.[path_len - 1] <> '/')
       then Server.respond_with_redirect (Uri.with_path uri (path^"/"))
       (* Check if the index file exists *)
       else Sys.file_exists (file_name / index)
@@ -72,7 +73,7 @@ let serve ~info ~docroot ~index uri path =
   | Error exn ->
     begin match Monitor.extract_exn exn with
     | Unix.Unix_error (Unix.ENOENT, "stat", p) ->
-      if p = ("((filename "^file_name^"))") (* Really? *)
+      if String.equal p ("((filename "^file_name^"))") (* Really? *)
       then Server.respond_string ~status:`Not_found
         (html_of_not_found path info)
       else raise exn
@@ -114,18 +115,18 @@ let start_server docroot port index cert_file key_file verbose () =
   let mode = determine_mode cert_file key_file in
   let mode_str = (match mode with `OpenSSL _ -> "HTTPS" | `TCP -> "HTTP") in
   Logs.info (fun f -> f "Listening for %s requests on %d" mode_str port);
-  let info = sprintf "Served by Cohttp/Async listening on %d" port in
+  let info = Printf.sprintf "Served by Cohttp/Async listening on %d" port in
   Server.create
     ~on_handler_error:(`Call (fun addr exn ->
         Logs.err (fun f -> f "Error from %s" (Socket.Address.to_string addr));
         Logs.err (fun f -> f "%s" @@ Exn.to_string exn)))
     ~mode
-    (Tcp.Where_to_listen.of_port port)
+    (Async_extra.Tcp.Where_to_listen.of_port port)
     (handler ~info ~docroot ~index) >>= fun _serv ->
   Deferred.never ()
 
 let () =
-  let open Command in
+  let open Async_extra.Command in
   run @@
   async_spec ~summary:"Serve the local directory contents via HTTP or HTTPS"
     Spec.(

--- a/cohttp-async/bin/jbuild
+++ b/cohttp-async/bin/jbuild
@@ -3,5 +3,13 @@
 (executables
  ((names (cohttp_curl_async cohttp_server_async))
   (package cohttp-async)
-  (libraries (cohttp-async cohttp_server fmt.tty))
+  (libraries
+   (cohttp-async
+    async_kernel
+    async_extra
+    async_unix
+    base
+    cohttp
+    cohttp_server
+    fmt.tty))
   (public_names (cohttp-curl-async cohttp-server-async))))

--- a/cohttp-async/src/body.mli
+++ b/cohttp-async/src/body.mli
@@ -1,5 +1,5 @@
-open! Core
-open! Async
+open! Base
+open! Async_kernel
 open! Cohttp
 
 type t = [

--- a/cohttp-async/src/body_raw.ml
+++ b/cohttp-async/src/body_raw.ml
@@ -1,5 +1,5 @@
-open Core
-open Async
+open Base
+open Async_kernel
 module B = Cohttp.Body
 
 type t = [

--- a/cohttp-async/src/client.ml
+++ b/cohttp-async/src/client.ml
@@ -1,5 +1,6 @@
-open Core
-open Async
+open Base
+open Async_kernel
+open Async_unix
 
 module Request = struct
   include Cohttp.Request
@@ -66,7 +67,7 @@ let request ?interrupt ?ssl_config ?uri ?(body=`Empty) req =
       read_request ic >>| fun (resp, body) ->
       don't_wait_for (
         Pipe.closed body >>= fun () ->
-        Deferred.all_ignore [Reader.close ic; Writer.close oc]);
+        Deferred.all_unit [Reader.close ic; Writer.close oc]);
       (resp, `Pipe body)) >>= begin function
     | Ok res -> return res
     | Error e ->
@@ -82,7 +83,7 @@ let callv ?interrupt ?ssl_config uri reqs =
   try_with (fun () ->
       reqs
       |> Pipe.iter ~f:(fun (req, body) ->
-          incr reqs_c;
+          Int.incr reqs_c;
           Request.write (fun w -> Body_raw.write_body Request.write_body body w)
             req oc)
       |> don't_wait_for;
@@ -93,7 +94,7 @@ let callv ?interrupt ?ssl_config uri reqs =
             return `Eof
           else
             ic |> read_request >>| fun (resp, body) ->
-            incr resp_c;
+            Int.incr resp_c;
             last_body_drained := Pipe.closed body;
             `Ok (resp, `Pipe body)
         ) in

--- a/cohttp-async/src/client.mli
+++ b/cohttp-async/src/client.mli
@@ -1,102 +1,99 @@
-open! Core
-open! Async
-
 (** Send an HTTP request with an arbitrary body
     The request is sent as-is. *)
 val request :
-  ?interrupt:unit Deferred.t ->
+  ?interrupt:unit Async_kernel.Deferred.t ->
   ?ssl_config:Conduit_async.Ssl.config ->
   ?uri:Uri.t ->
   ?body:Body.t ->
   Cohttp.Request.t ->
-  (Cohttp.Response.t * Body.t) Deferred.t
+  (Cohttp.Response.t * Body.t) Async_kernel.Deferred.t
 
 (** Send an HTTP request with arbitrary method and a body
     Infers the transfer encoding *)
 val call :
-  ?interrupt:unit Deferred.t ->
+  ?interrupt:unit Async_kernel.Deferred.t ->
   ?ssl_config:Conduit_async.Ssl.config ->
   ?headers:Cohttp.Header.t ->
   ?chunked:bool ->
   ?body:Body.t ->
   Cohttp.Code.meth ->
   Uri.t ->
-  (Cohttp.Response.t * Body.t) Deferred.t
+  (Cohttp.Response.t * Body.t) Async_kernel.Deferred.t
 
 val callv :
-  ?interrupt:unit Deferred.t ->
+  ?interrupt:unit Async_kernel.Deferred.t ->
   ?ssl_config:Conduit_async.Ssl.config ->
   Uri.t ->
-  (Cohttp.Request.t * Body.t) Pipe.Reader.t ->
-  (Cohttp.Response.t * Body.t) Pipe.Reader.t Deferred.t
+  (Cohttp.Request.t * Body.t) Async_kernel.Pipe.Reader.t ->
+  (Cohttp.Response.t * Body.t) Async_kernel.Pipe.Reader.t Async_kernel.Deferred.t
 
 (** Send an HTTP GET request *)
 val get :
-  ?interrupt:unit Deferred.t ->
+  ?interrupt:unit Async_kernel.Deferred.t ->
   ?ssl_config:Conduit_async.Ssl.config ->
   ?headers:Cohttp.Header.t ->
   Uri.t ->
-  (Cohttp.Response.t * Body.t) Deferred.t
+  (Cohttp.Response.t * Body.t) Async_kernel.Deferred.t
 
 (** Send an HTTP HEAD request *)
 val head :
-  ?interrupt:unit Deferred.t ->
+  ?interrupt:unit Async_kernel.Deferred.t ->
   ?ssl_config:Conduit_async.Ssl.config ->
   ?headers:Cohttp.Header.t ->
   Uri.t ->
-  Cohttp.Response.t Deferred.t
+  Cohttp.Response.t Async_kernel.Deferred.t
 
 (** Send an HTTP DELETE request *)
 val delete :
-  ?interrupt:unit Deferred.t ->
+  ?interrupt:unit Async_kernel.Deferred.t ->
   ?ssl_config:Conduit_async.Ssl.config ->
   ?headers:Cohttp.Header.t ->
   ?chunked:bool ->
   ?body:Body.t ->
   Uri.t ->
-  (Cohttp.Response.t * Body.t) Deferred.t
+  (Cohttp.Response.t * Body.t) Async_kernel.Deferred.t
 
 (** Send an HTTP POST request.
     [chunked] encoding is off by default as not many servers support it
 *)
 val post :
-  ?interrupt:unit Deferred.t ->
+  ?interrupt:unit Async_kernel.Deferred.t ->
   ?ssl_config:Conduit_async.Ssl.config ->
   ?headers:Cohttp.Header.t ->
   ?chunked:bool ->
   ?body:Body.t ->
   Uri.t ->
-  (Cohttp.Response.t * Body.t) Deferred.t
+  (Cohttp.Response.t * Body.t) Async_kernel.Deferred.t
 
 (** Send an HTTP PUT request.
     [chunked] encoding is off by default as not many servers support it
 *)
 val put :
-  ?interrupt:unit Deferred.t ->
+  ?interrupt:unit Async_kernel.Deferred.t ->
   ?ssl_config:Conduit_async.Ssl.config ->
   ?headers:Cohttp.Header.t ->
   ?chunked:bool ->
   ?body:Body.t ->
   Uri.t ->
-  (Response.t * Body.t) Deferred.t
+  (Response.t * Body.t) Async_kernel.Deferred.t
 
 (** Send an HTTP PATCH request.
     [chunked] encoding is off by default as not many servers support it
 *)
 val patch :
-  ?interrupt:unit Deferred.t ->
+  ?interrupt:unit Async_kernel.Deferred.t ->
   ?ssl_config:Conduit_async.Ssl.config ->
   ?headers:Cohttp.Header.t ->
   ?chunked:bool ->
   ?body:Body.t ->
   Uri.t ->
-  (Response.t * Body.t) Deferred.t
+  (Response.t * Body.t) Async_kernel.Deferred.t
 
 (** Send an HTTP POST request in form format *)
 val post_form:
-  ?interrupt:unit Deferred.t ->
+  ?interrupt:unit Async_kernel.Deferred.t ->
   ?ssl_config:Conduit_async.Ssl.config ->
   ?headers:Cohttp.Header.t ->
   params:(string * string list) list ->
   Uri.t ->
-  (Response.t * Body.t) Deferred.t
+  (Response.t * Body.t) Async_kernel.Deferred.t

--- a/cohttp-async/src/io.ml
+++ b/cohttp-async/src/io.ml
@@ -14,8 +14,12 @@
  *
   }}}*)
 
-open Core
-open Async
+open Base
+open Async_kernel
+
+module Writer = Async_unix.Writer
+module Reader = Async_unix.Reader
+module Format = Caml.Format
 
 let log_src_name = "cohttp.async.io"
 let src = Logs.Src.create log_src_name ~doc:"Cohttp Async IO module"
@@ -31,13 +35,13 @@ let default_reporter () =
       m ) in
   let report src _level ~over k msgf =
     let k _ =
-      if Logs.Src.name src = log_src_name then (
+      if String.equal (Logs.Src.name src) log_src_name then (
         Writer.write (Lazy.force Writer.stderr) (fmtr_flush ())
       );
       over ();
       k () in
     msgf @@ fun ?header:_ ?tags:_ fmt ->
-    Format.kfprintf k fmtr ("@[" ^^ fmt ^^ "@]@.")
+    Format.kfprintf k fmtr Caml.("@[" ^^ fmt ^^ "@]@.")
   in
   { Logs.report }
 
@@ -52,10 +56,10 @@ let set_log = lazy (
 )
 
 let check_debug norm_fn debug_fn =
-  match Sys.getenv "COHTTP_DEBUG" with
-  | Some _ ->
+  match Caml.Sys.getenv "COHTTP_DEBUG" with
+  | _ ->
     Lazy.force set_log; debug_fn
-  | None -> norm_fn
+  | exception Caml.Not_found -> norm_fn
 
 type 'a t = 'a Deferred.t
 let (>>=) = Deferred.(>>=)
@@ -93,7 +97,7 @@ let write =
        return ())
     (fun oc buf ->
        Log.debug
-         (fun fmt -> fmt "%4d >>> %s" (Pid.to_int (Unix.getpid ())) buf);
+         (fun fmt -> fmt "%4d >>> %s" (Unix.getpid ()) buf);
        Writer.write oc buf;
        return ())
 

--- a/cohttp-async/src/io.mli
+++ b/cohttp-async/src/io.mli
@@ -13,9 +13,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
   }}}*)
 
-open Async
-
 include Cohttp.S.IO
-  with type 'a t = 'a Deferred.t
-   and type ic = Reader.t
-   and type oc = Writer.t
+  with type 'a t = 'a Async_kernel.Deferred.t
+   and type ic = Async_unix.Reader.t
+   and type oc = Async_unix.Writer.t

--- a/cohttp-async/src/jbuild
+++ b/cohttp-async/src/jbuild
@@ -6,8 +6,11 @@
   (public_name cohttp-async)
   (libraries
    (logs.fmt
+    base
     fmt
-    async
+    async_unix
+    async_kernel
+    async_extra
     uri
     uri.services
     ipaddr.unix

--- a/cohttp-async/src/server.ml
+++ b/cohttp-async/src/server.ml
@@ -1,5 +1,7 @@
-open Core
-open Async
+open Base
+open Async_kernel
+open Async_unix
+open Async_extra
 
 module Request = struct
   include Cohttp.Request

--- a/cohttp-async/src/server.mli
+++ b/cohttp-async/src/server.mli
@@ -1,11 +1,9 @@
-open! Core
-open! Async
-
-type ('address, 'listening_on) t constraint 'address = [< Socket.Address.t ]
+type ('address, 'listening_on) t constraint 'address
+  = [< Async_unix.Socket.Address.t ]
   [@@deriving sexp_of]
 
-val close          : (_, _) t -> unit Deferred.t
-val close_finished : (_, _) t -> unit Deferred.t
+val close          : (_, _) t -> unit Async_kernel.Deferred.t
+val close_finished : (_, _) t -> unit Async_kernel.Deferred.t
 val is_closed      : (_, _) t -> bool
 
 val listening_on   : (_, 'listening_on) t -> 'listening_on
@@ -16,12 +14,15 @@ type 'r respond_t =
   ?flush:bool ->
   ?headers:Cohttp.Header.t ->
   ?body:Body.t ->
-  Cohttp.Code.status_code -> 'r Deferred.t
+  Cohttp.Code.status_code -> 'r Async_kernel.Deferred.t
 
 type response_action =
   (* The connection is not closed in the [`Expert] case until the [unit
-     Deferred.t] becomes determined. *)
-  [ `Expert of Cohttp.Response.t * (Reader.t -> Writer.t -> unit Deferred.t)
+     Async_kernel.Deferred.t] becomes determined. *)
+  [ `Expert of Cohttp.Response.t
+               * (Async_unix.Reader.t
+                  -> Async_unix.Writer.t
+                  -> unit Async_kernel.Deferred.t)
   | `Response of response ]
 
 val respond : response respond_t
@@ -29,30 +30,30 @@ val respond : response respond_t
 (** Resolve a URI and a docroot into a concrete local filename. *)
 val resolve_local_file : docroot:string -> uri:Uri.t -> string
 
-(** Respond with a [string] Pipe that provides the response string Pipe.Reader.t.
-    @param code Default is HTTP 200 `OK *)
+(** Respond with a [string] Pipe that provides the response string
+    Pipe.Reader.t. @param code Default is HTTP 200 `OK *)
 val respond_with_pipe :
   ?flush:bool ->
   ?headers:Cohttp.Header.t -> ?code:Cohttp.Code.status_code ->
-  string Pipe.Reader.t -> response Deferred.t
+  string Async_kernel.Pipe.Reader.t -> response Async_kernel.Deferred.t
 
 val respond_string :
   ?flush:bool ->
   ?headers:Cohttp.Header.t ->
   ?status:Cohttp.Code.status_code ->
-  string -> response Deferred.t
+  string -> response Async_kernel.Deferred.t
 
 (** Respond with a redirect to an absolute [uri]
     @param uri Absolute URI to redirect the client to *)
 val respond_with_redirect :
-  ?headers:Cohttp.Header.t -> Uri.t -> response Deferred.t
+  ?headers:Cohttp.Header.t -> Uri.t -> response Async_kernel.Deferred.t
 
 
-(** Respond with file contents, and [error_string Pipe.Reader.t] if the file isn't found *)
+(** Respond with file contents, and [error_string Pipe.Async_unix.Reader.t] if the file isn't found *)
 val respond_with_file :
   ?flush:bool ->
   ?headers:Cohttp.Header.t -> ?error_body:string ->
-  string -> response Deferred.t
+  string -> response Async_kernel.Deferred.t
 
 type mode = Conduit_async.server
 
@@ -61,25 +62,26 @@ type mode = Conduit_async.server
 val create_expert :
   ?max_connections:int ->
   ?backlog:int ->
-  ?buffer_age_limit:Writer.buffer_age_limit ->
+  ?buffer_age_limit:Async_unix.Writer.buffer_age_limit ->
   ?mode:mode ->
   on_handler_error:[ `Call of 'address -> exn  -> unit
                    | `Ignore
                    | `Raise ] ->
-  ('address, 'listening_on) Tcp.Where_to_listen.t
-  -> (body:Body.t -> 'address -> Request.t -> response_action Deferred.t)
-  -> ('address, 'listening_on) t Deferred.t
+  ('address, 'listening_on) Async_extra.Tcp.Where_to_listen.t
+  -> (body:Body.t -> 'address -> Request.t
+      -> response_action Async_kernel.Deferred.t)
+  -> ('address, 'listening_on) t Async_kernel.Deferred.t
 
 
 (** Build a HTTP server, based on the [Tcp.Server] interface *)
 val create :
   ?max_connections:int ->
   ?backlog:int ->
-  ?buffer_age_limit: Writer.buffer_age_limit ->
+  ?buffer_age_limit:Async_unix.Writer.buffer_age_limit ->
   ?mode:Conduit_async.server ->
   on_handler_error:[ `Call of 'address -> exn  -> unit
                    | `Ignore
                    | `Raise ] ->
-  ('address, 'listening_on) Tcp.Where_to_listen.t
-  -> (body:Body.t -> 'address -> Request.t -> response Deferred.t)
-  -> ('address, 'listening_on) t Deferred.t
+  ('address, 'listening_on) Async_extra.Tcp.Where_to_listen.t
+  -> (body:Body.t -> 'address -> Request.t -> response Async_kernel.Deferred.t)
+  -> ('address, 'listening_on) t Async_kernel.Deferred.t

--- a/cohttp-async/test/jbuild
+++ b/cohttp-async/test/jbuild
@@ -1,7 +1,14 @@
 (jbuild_version 1)
 
 (executables
- ((libraries (cohttp_async_test cohttp-async))
+ ((libraries
+   (cohttp_async_test
+    async_unix
+    base
+    core
+    async_kernel
+    ounit
+    cohttp-async))
   (modules (test_async_integration))
   (names (test_async_integration))))
 

--- a/cohttp-async/test/test_async_integration.ml
+++ b/cohttp-async/test/test_async_integration.ml
@@ -1,5 +1,5 @@
-open Core
-open Async
+open Base
+open Async_kernel
 open OUnit
 open Cohttp
 open Cohttp_async
@@ -93,5 +93,8 @@ let ts =
   end
 
 let () =
-  ts |> run_async_tests >>= (fun _ -> Shutdown.exit 0) |> don't_wait_for;
-  never_returns (Scheduler.go ())
+  ts
+  |> run_async_tests
+  >>= (fun _ -> Async_unix.Shutdown.exit 0)
+  |> don't_wait_for;
+  Core.never_returns (Async_unix.Scheduler.go ())

--- a/cohttp_async_test/src/cohttp_async_test.ml
+++ b/cohttp_async_test/src/cohttp_async_test.ml
@@ -1,5 +1,5 @@
-open Core
-open Async
+open Base
+open Async_kernel
 open OUnit
 open Cohttp_async
 
@@ -16,9 +16,10 @@ let temp_server ?port spec callback =
   let port = match port with
     | None -> Cohttp_test.next_port ()
     | Some p -> p in
-  let uri = Uri.of_string ("http://0.0.0.0:" ^ (string_of_int port)) in
+  let uri = Uri.of_string ("http://0.0.0.0:" ^ (Int.to_string port)) in
   let server = Server.create ~on_handler_error:`Raise
-    (Tcp.Where_to_listen.of_port port) (fun ~body _sock req -> spec req body) in
+    (Async_extra.Tcp.Where_to_listen.of_port port)
+    (fun ~body _sock req -> spec req body) in
   server >>= fun server ->
   callback uri >>= fun res ->
   Server.close server >>| fun () ->

--- a/cohttp_async_test/src/cohttp_async_test.mli
+++ b/cohttp_async_test/src/cohttp_async_test.mli
@@ -1,4 +1,4 @@
-open Async
+open Async_kernel
 
 include Cohttp_test.S with type 'a io = 'a Deferred.t and type body = Cohttp_async.Body.t
 val run_async_tests : OUnit.test io -> OUnit.test_result list Deferred.t

--- a/cohttp_async_test/src/jbuild
+++ b/cohttp_async_test/src/jbuild
@@ -3,4 +3,5 @@
 (library
  ((name cohttp_async_test)
   (wrapped false)
-  (libraries (fmt.tty uri.services cohttp_test cohttp-async))))
+  (libraries
+   (fmt.tty uri.services async_kernel async_extra cohttp_test cohttp-async))))

--- a/examples/async/hello_world.ml
+++ b/examples/async/hello_world.ml
@@ -1,7 +1,7 @@
 (* This file is in the public domain *)
 
-open Core
-open Async
+open Base
+open Async_kernel
 open Cohttp_async
 
 (* given filename: hello_world.ml compile with:
@@ -20,8 +20,8 @@ let handler ~body:_ _sock req =
     Server.respond_string ~status:`Not_found "Route not found"
 
 let start_server port () =
-  eprintf "Listening for HTTP on port %d\n" port;
-  eprintf "Try 'curl http://localhost:%d/test?hello=xyz'\n%!" port;
+  Caml.Printf.eprintf "Listening for HTTP on port %d\n" port;
+  Caml.Printf.eprintf "Try 'curl http://localhost:%d/test?hello=xyz'\n%!" port;
   Cohttp_async.Server.create ~on_handler_error:`Raise
     (Tcp.Where_to_listen.of_port port) handler
   >>= fun _ -> Deferred.never ()

--- a/examples/async/jbuild
+++ b/examples/async/jbuild
@@ -2,7 +2,7 @@
 
 (executables
  ((names (hello_world receive_post))
-  (libraries (cohttp-async))
+  (libraries (cohttp-async async_extra base async_kernel))
 ))
 
 (alias

--- a/examples/async/receive_post.ml
+++ b/examples/async/receive_post.ml
@@ -1,25 +1,26 @@
 (* This file is in the public domain *)
-open Core
-open Async
+open Base
+open Async_kernel
 open Cohttp_async
 
 (* compile with: $ corebuild receive_post.native -pkg cohttp.async *)
 
 let start_server port () =
-  eprintf "Listening for HTTP on port %d\n" port;
-  eprintf "Try 'curl -X POST -d 'foo bar' http://localhost:%d\n" port;
+  Caml.Printf.eprintf "Listening for HTTP on port %d\n" port;
+  Caml.Printf.eprintf "Try 'curl -X POST -d 'foo bar' http://localhost:%d\n" port;
   Cohttp_async.Server.create ~on_handler_error:`Raise
-    (Tcp.Where_to_listen.of_port port) (fun ~body _ req ->
+    (Async_extra.Tcp.Where_to_listen.of_port port) (fun ~body _ req ->
       match req |> Cohttp.Request.meth with
       | `POST ->
         (Body.to_string body) >>= (fun body ->
-          Log.Global.info "Body: %s" body;
+          Caml.Printf.eprintf "Body: %s" body;
           Server.respond `OK)
       | _ -> Server.respond `Method_not_allowed
     )
   >>= fun _ -> Deferred.never ()
 
 let () =
+  let module Command = Async_extra.Command in
   Command.async_spec
     ~summary:"Simple http server that outputs body of POST's"
     Command.Spec.(empty +>

--- a/examples/async/s3_cp.ml
+++ b/examples/async/s3_cp.ml
@@ -43,8 +43,8 @@
    example of abstraction, interface design or error handling.
 *)
 
-open Core
-open Async
+open Base
+open Async_kernel
 open Cohttp
 open Cohttp_async
 


### PR DESCRIPTION
@avsm after this I will get rid of Core's command module. It adds an extra dependency (Async_extra) and it just makes us maintain 2 command line interfaces. Cmdliner is superior in every, we should just use it.