### PR TITLE
Remove all instance of Lwt_log

### DIFF
--- a/cohttp-lwt-unix/bin/cohttp_server_lwt.ml
+++ b/cohttp-lwt-unix/bin/cohttp_server_lwt.ml
@@ -81,10 +81,12 @@ let handler ~info ~docroot ~index (ch,_conn) req _body =
   let uri = Cohttp.Request.uri req in
   let path = Uri.path uri in
   (* Log the request to the console *)
-  Lwt_log.debug_f "%s %s %s"
-    (Cohttp.(Code.string_of_method (Request.meth req)))
-    path
-    (Sexplib.Sexp.to_string_hum (Conduit_lwt_unix.sexp_of_flow ch)) >>= fun () ->
+  Logs.debug (fun f ->
+      f "%s %s %s"
+        (Cohttp.(Code.string_of_method (Request.meth req)))
+        path
+        (Sexplib.Sexp.to_string_hum (Conduit_lwt_unix.sexp_of_flow ch))
+    );
   (* Get a canonical filename from the URL and docroot *)
   match Request.meth req with
   | (`GET | `HEAD) as meth ->
@@ -98,11 +100,14 @@ let handler ~info ~docroot ~index (ch,_conn) req _body =
       ~body:(html_of_method_not_allowed meth (String.concat "," allowed) path info) ()
 
 let start_server docroot port host index tls () =
-  Lwt_log.info_f "Listening for HTTP request on: %s %d" host port >>= fun () ->
-  let info = Printf.sprintf "Served by Cohttp/Lwt listening on %s:%d" host port in
+  Logs.info (fun f -> f "Listening for HTTP request on: %s %d" host port);
+  let info =
+    Printf.sprintf "Served by Cohttp/Lwt listening on %s:%d" host port in
   let conn_closed (ch,_conn) =
-    Lwt_log.ign_debug_f "connection %s closed"
-      (Sexplib.Sexp.to_string_hum (Conduit_lwt_unix.sexp_of_flow ch)) in
+    Logs.debug (fun f ->
+        f "connection %s closed"
+          (Sexplib.Sexp.to_string_hum (Conduit_lwt_unix.sexp_of_flow ch)))
+  in
   let callback = handler ~info ~docroot ~index in
   let config = Server.make ~callback ~conn_closed () in
   let mode = match tls with
@@ -117,8 +122,8 @@ let start_server docroot port host index tls () =
 let lwt_start_server docroot port host index verbose tls =
   (match List.length verbose with
   | 0 -> ()
-  | 1 -> Lwt_log_core.(add_rule "*" Info)
-  | _ -> Lwt_log_core.(add_rule "*" Debug));
+  | 1 -> Logs.set_level (Some Logs.Info)
+  | _ -> Logs.set_level (Some Logs.Debug));
   Lwt_main.run (start_server docroot port host index tls ())
 
 open Cmdliner

--- a/cohttp-lwt-unix/bin/jbuild
+++ b/cohttp-lwt-unix/bin/jbuild
@@ -2,6 +2,6 @@
 
 (executables
  ((names (cohttp_curl_lwt cohttp_proxy_lwt cohttp_server_lwt))
-  (libraries (cohttp-lwt-unix cohttp_server cmdliner))
+  (libraries (cohttp-lwt-unix cohttp_server cmdliner logs))
   (package cohttp-lwt-unix)
   (public_names (cohttp-curl-lwt cohttp-proxy-lwt cohttp-server-lwt))))

--- a/cohttp-lwt-unix/src/server.ml
+++ b/cohttp-lwt-unix/src/server.ml
@@ -31,7 +31,9 @@ let respond_file ?headers ~fname () =
               | "" -> None
               | buf -> Some buf)
             (fun exn ->
-               Lwt_log.ign_debug ~exn ("Error resolving file " ^ fname);
+               Logs.debug (fun f ->
+                   f "Error resolving file %s.@.Exn: %s"
+                     fname (Printexc.to_string exn));
                return_none)
         ) in
       Lwt.on_success (Lwt_stream.closed stream) (fun () ->

--- a/cohttp-lwt-unix/test/jbuild
+++ b/cohttp-lwt-unix/test/jbuild
@@ -6,7 +6,7 @@
   (names (test_parser))))
 
 (executables
- ((libraries (cohttp_lwt_unix_test cohttp-lwt-unix))
+ ((libraries (cohttp_lwt_unix_test cohttp-lwt-unix logs))
   (modules (test_sanity))
   (names (test_sanity))))
 

--- a/cohttp-lwt-unix/test/test_sanity.ml
+++ b/cohttp-lwt-unix/test/test_sanity.ml
@@ -97,12 +97,12 @@ let ts =
       Client.callv uri reqs >>= fun resps ->
       let resps = Lwt_stream.map_s (fun (_, b) -> Body.to_string b) resps in
       Lwt_stream.fold (fun b i ->
-          Lwt_log.ign_info_f "Request %i\n" i;
+          Logs.info (fun f -> f "Request %i\n" i);
           begin match i with
             | 0 -> assert_equal b "one"
             | 1 ->
               assert_equal b "two";
-              Lwt_log.ign_info "Sending extra request";
+              Logs.info (fun f -> f "Sending extra request");
               push (Some (r 3))
             | 2 ->
               assert_equal b "three";

--- a/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.ml
+++ b/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.ml
@@ -32,12 +32,12 @@ let temp_server ?port spec callback =
 
 let test_server_s ?port ?(name="Cohttp Server Test") spec f =
   temp_server ?port spec begin fun uri ->
-    Lwt_log.ign_info_f "Test %s running on %s" name (Uri.to_string uri);
+    Logs.info (fun f -> f "Test %s running on %s" name (Uri.to_string uri));
     let tests = f uri in
     let results =
       tests
       |> Lwt_list.map_s (fun (name, test) ->
-        Lwt_log.ign_debug_f "Running %s" name;
+        Logs.debug (fun f -> f "Running %s" name);
         let res = Lwt.try_bind test
                     (fun () -> return `Ok)
                     (fun exn -> return (`Exn exn)) in

--- a/cohttp_lwt_unix_test/src/jbuild
+++ b/cohttp_lwt_unix_test/src/jbuild
@@ -3,4 +3,4 @@
 (library
  ((name cohttp_lwt_unix_test)
   (wrapped false)
-  (libraries (cohttp-lwt-unix cohttp_test oUnit))))
+  (libraries (cohttp-lwt-unix cohttp_test logs oUnit))))


### PR DESCRIPTION
Use Logs exclusively. This makes us compatible with lwt 4.0 as well