### PR TITLE
Remove deprecated Lwt_logs

### DIFF
--- a/cohttp-lwt-unix/bin/cohttp_server_lwt.ml
+++ b/cohttp-lwt-unix/bin/cohttp_server_lwt.ml
@@ -118,10 +118,7 @@ let start_server docroot port host index tls () =
   Server.create ~ctx ~mode config
 
 let lwt_start_server docroot port host index verbose tls =
-  (match List.length verbose with
-  | 0 -> ()
-  | 1 -> Logs.set_level (Some Logs.Info)
-  | _ -> Logs.set_level (Some Logs.Debug));
+  Logs.set_level verbose;
   Lwt_main.run (start_server docroot port host index tls ())
 
 open Cmdliner
@@ -138,9 +135,7 @@ let index =
   let doc = "Name of index file in directory." in
   Arg.(value & opt string "index.html" & info ["i"] ~docv:"INDEX" ~doc)
 
-let verb =
-  let doc = "Logging output to console." in
-  Arg.(value & flag_all & info ["v"; "verbose"] ~doc)
+let verb = Logs_cli.level ()
 
 let tls =
   let doc = "TLS certificate files." in

--- a/cohttp-lwt-unix/bin/cohttp_server_lwt.ml
+++ b/cohttp-lwt-unix/bin/cohttp_server_lwt.ml
@@ -117,9 +117,35 @@ let start_server docroot port host index tls () =
   let ctx = Cohttp_lwt_unix.Net.init ~ctx () in
   Server.create ~ctx ~mode config
 
+(* The example of Lwt-aware reporter in Logs' documentation *)
+let lwt_reporter () =
+  let buf_fmt ~like =
+    let b = Buffer.create 512 in
+    Fmt.with_buffer ~like b,
+    fun () -> let m = Buffer.contents b in Buffer.reset b; m
+  in
+  let app, app_flush = buf_fmt ~like:Fmt.stdout in
+  let dst, dst_flush = buf_fmt ~like:Fmt.stderr in
+  let reporter = Logs_fmt.reporter ~app ~dst () in
+  let report src level ~over k msgf =
+    let k () =
+      let write () = match level with
+      | Logs.App -> Lwt_io.write Lwt_io.stdout (app_flush ())
+      | _ -> Lwt_io.write Lwt_io.stderr (dst_flush ())
+      in
+      let unblock () = over (); Lwt.return_unit in
+      Lwt.finalize write unblock |> Lwt.ignore_result;
+      k ()
+    in
+    reporter.Logs.report src level ~over:(fun () -> ()) k msgf;
+  in
+  { Logs.report = report }
+
 let lwt_start_server docroot port host index verbose tls =
   Logs.set_level verbose;
+  Logs.set_reporter (lwt_reporter ());
   Lwt_main.run (start_server docroot port host index tls ())
+
 
 open Cmdliner
 

--- a/cohttp-lwt-unix/bin/jbuild
+++ b/cohttp-lwt-unix/bin/jbuild
@@ -2,6 +2,12 @@
 
 (executables
  ((names (cohttp_curl_lwt cohttp_proxy_lwt cohttp_server_lwt))
-  (libraries (cohttp-lwt-unix cohttp_server logs.cli cmdliner))
+  (libraries
+   (cohttp-lwt-unix
+    cohttp_server
+    logs
+    logs.lwt
+    logs.cli
+    cmdliner))
   (package cohttp-lwt-unix)
   (public_names (cohttp-curl-lwt cohttp-proxy-lwt cohttp-server-lwt))))

--- a/cohttp-lwt-unix/bin/jbuild
+++ b/cohttp-lwt-unix/bin/jbuild
@@ -7,6 +7,7 @@
     cohttp_server
     logs
     logs.lwt
+    logs.fmt
     logs.cli
     cmdliner))
   (package cohttp-lwt-unix)

--- a/cohttp-lwt-unix/bin/jbuild
+++ b/cohttp-lwt-unix/bin/jbuild
@@ -2,6 +2,6 @@
 
 (executables
  ((names (cohttp_curl_lwt cohttp_proxy_lwt cohttp_server_lwt))
-  (libraries (cohttp-lwt-unix cohttp_server cmdliner))
+  (libraries (cohttp-lwt-unix cohttp_server logs.cli cmdliner))
   (package cohttp-lwt-unix)
   (public_names (cohttp-curl-lwt cohttp-proxy-lwt cohttp-server-lwt))))

--- a/cohttp-lwt-unix/src/jbuild
+++ b/cohttp-lwt-unix/src/jbuild
@@ -7,6 +7,7 @@
   (preprocess (pps (ppx_sexp_conv)))
   (libraries
    (fmt
+    logs
     logs.lwt
     conduit-lwt-unix
     magic-mime

--- a/cohttp-lwt-unix/src/server.ml
+++ b/cohttp-lwt-unix/src/server.ml
@@ -4,6 +4,8 @@ module Server_core = Cohttp_lwt.Make_server (Io)
 include Server_core
 open Lwt
 
+let log_src = Logs.Src.create "cohttp-lwt-unix.server"
+
 let blank_uri = Uri.of_string ""
 
 let resolve_file ~docroot ~uri =
@@ -31,7 +33,10 @@ let respond_file ?headers ~fname () =
               | "" -> None
               | buf -> Some buf)
             (fun exn ->
-               Lwt_log.ign_debug ~exn ("Error resolving file " ^ fname);
+               Logs.debug ~src:log_src
+                 (fun m -> m "Error resolving file %s (%s)"
+                   fname
+                   (Printexc.to_string exn));
                return_none)
         ) in
       Lwt.on_success (Lwt_stream.closed stream) (fun () ->


### PR DESCRIPTION
With the release of Lwt 4.0.0, the module `Lwt_logs` is deprecated. This PR replaces uses of this deprecated module with uses of `Logs` and `Logs_lwt`.

This is similar to #608 except that it uses `Logs_lwt` where there used to be Lwt.