### PR TITLE
cohttp-async: require new uri (was used in client.ml)

### DIFF
--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -35,5 +35,6 @@ depends: [
   "sexplib0"
   "ppx_sexp_conv" {>= "v0.9.0"}
   "ounit" {test}
+  "uri" {>= "2.0.0"}
 ]
 available: [ocaml-version >= "4.04.1"]

--- a/cohttp-async/src/dune
+++ b/cohttp-async/src/dune
@@ -3,5 +3,5 @@
   (synopsis    "Async backend")
   (public_name cohttp-async)
   (libraries   logs.fmt base fmt async_unix async_kernel async_extra uri
-               uri.services ipaddr.unix conduit-async magic-mime cohttp)
+               uri.services uri.sexp ipaddr.unix conduit-async magic-mime cohttp)
   (preprocess (pps ppx_sexp_conv)))


### PR DESCRIPTION
This should prevent breaks when some specific versions of cohttp,
cohttp-async and uri pinned are installed.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>