### PR TITLE
Add a note about the need for SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ There's a few things to notice:
 * We must trigger lwt's event loop for the request to run. `Lwt_main.run` will
   run the event loop and return with final value of `body` which we then print.
 
+Note that in order to request an HTTPS page like in the above example,
+you'll need Cohttp to have been compiled with SSL or TLS. For SSL, you'll
+need to install both [`ssl`](https://github.com/savonet/ocaml-ssl) and
+[`lwt_ssl`](https://github.com/ocsigen/lwt_ssl) before installing `cohttp`.
+The TLS route will require installing
+[`tls`](https://github.com/mirleft/ocaml-tls) before `cohttp`.
+
 Consult the following modules for reference:
 
 * [Cohttp_lwt.Client](https://github.com/mirage/ocaml-cohttp/blob/master/cohttp-lwt/src/s.ml)


### PR DESCRIPTION
This was quite a gotcha for me as I was trying to work through the _Client Tutorial_ example. After a lot of digging and question-asking I was able to arrive at a proper configuration of Cohttp and its dependencies such that I was able to request an HTTPS page. Here is [a relevant commit](https://github.com/jbranchaud/reasonml-cohttp-example/commit/a31c72ee412d7ec3e626d25e597af8ded7d8a34a#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) for reference.