### PR TITLE
Add expert mode for cohttp-lwt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 ## dev
 
 * Port opam files to opam2 and add local synopsis and descriptions.
+* Lwt: Add Expert response action for servers (#647 by @andreas)
+
+Compatibility breaking interface changes:
+
+* Async: Expert response action no longer writes empty HTTP body (#647 by @andreas)
 
 ## v1.2.0 (2018-10-19)
 

--- a/cohttp-async/src/server.ml
+++ b/cohttp-async/src/server.ml
@@ -86,7 +86,7 @@ let handle_client handle_request sock rd wr =
     in
     Pipe.iter ~continue_on_error:false requests_pipe ~f:(function
       | `Expert (response, io_handler, body, finished) ->
-        Response.write ~flush:true (Body_raw.write_body Response.write_body Body.empty) response wr
+        Response.write_header response wr
         >>= fun () ->
         io_handler rd wr
         >>= fun () ->

--- a/cohttp-async/src/server.mli
+++ b/cohttp-async/src/server.mli
@@ -16,9 +16,16 @@ type 'r respond_t =
   ?body:Body.t ->
   Cohttp.Code.status_code -> 'r Async_kernel.Deferred.t
 
+(** A request handler can respond in two ways:
+    - Using [`Response], with a {!Response.t} and a {!Body.t}.
+    - Using [`Expert], with a {!Response.t} and an IO function that is expected
+      to write the response body. The IO function has access to the underlying
+      {!Async_unix.Reader.t} and {!Async_unix.Writer.t}, which allows writing a
+      response body more efficiently, stream a response or to switch protocols
+      entirely (e.g. websockets). Processing of pipelined requests continue
+      after the {!unit Async_kernel.Deferred.t} is resolved. The connection can
+      be closed by closing the {!Async_unix.Reader.t}. *)
 type response_action =
-  (* The connection is not closed in the [`Expert] case until the [unit
-     Async_kernel.Deferred.t] becomes determined. *)
   [ `Expert of Cohttp.Response.t
                * (Async_unix.Reader.t
                   -> Async_unix.Writer.t

--- a/cohttp-async/test/test_async_integration.ml
+++ b/cohttp-async/test/test_async_integration.ml
@@ -26,21 +26,33 @@ let server =
     (* large request *)
     (fun _ body ->
        body |> Body.to_string >>| String.length >>= fun len ->
-       Server.respond_string (Int.to_string len));
+       Server.respond_string (Int.to_string len) >>| response
+    )
   ] @ (* pipelined_chunk *)
   (response_bodies |> List.map ~f:(Fn.compose const ok))
-  @ [ (* large response chunked *)
-    (fun _ _ ->
-       let body =
-         let (r, w) = Pipe.create () in
-         let chunk = chunk chunk_size in
-         for _ = 0 to chunks - 1 do
-           Pipe.write_without_pushback w chunk
-         done;
-         Pipe.close w;
-         r
-       in
-       Server.respond_with_pipe ~code:`OK body
+  @
+  (* large response chunked *)
+  (fun _ _ ->
+     let body =
+       let (r, w) = Pipe.create () in
+       let chunk = chunk chunk_size in
+       for _ = 0 to chunks - 1 do
+         Pipe.write_without_pushback w chunk
+       done;
+       Pipe.close w;
+       r
+     in
+     Server.respond_with_pipe ~code:`OK body >>| response
+  )
+  :: [ (* pipelined_expert *)
+    expert (fun _ic oc ->
+      Async_unix.Writer.write oc "8\r\nexpert 1\r\n0\r\n\r\n";
+      Async_unix.Writer.flushed oc
+    );
+    expert (fun ic oc ->
+      Async_unix.Writer.write oc "8\r\nexpert 2\r\n0\r\n\r\n";
+      Async_unix.Writer.flushed oc >>= fun () ->
+      Async_unix.Reader.close ic
     )
   ]
   |> response_sequence
@@ -84,11 +96,21 @@ let ts =
       assert_equal Cohttp.Transfer.Chunked (Response.encoding resp);
       body |> Body.to_string >>| String.length >>| fun len ->
       assert_equal ~printer:(Int.to_string) (chunk_size * chunks) len in
+    let expert_pipelined () =
+      let printer x = x in
+      Client.get uri >>= fun (_rsp, body) ->
+      Body.to_string body >>= fun body ->
+      assert_equal ~printer "expert 1" body;
+      Client.get ~headers uri >>= fun (_rsp, body) ->
+      Body.to_string body >>| fun body ->
+      assert_equal ~printer "expert 2" body
+    in
     [ "empty chunk test", empty_chunk
     ; "large response", large_response
     ; "large request", large_request
     ; "pipelined chunk test", pipelined_chunk
     ; "large chunked response", large_chunked_response
+    ; "expert response", expert_pipelined
     ]
   end
 

--- a/cohttp-lwt-unix/src/io.ml
+++ b/cohttp-lwt-unix/src/io.ml
@@ -29,20 +29,35 @@ type conn = Conduit_lwt_unix.flow
 let src = Logs.Src.create "cohttp.lwt.io" ~doc:"Cohttp Lwt IO module"
 module Log = (val Logs.src_log src : Logs.LOG)
 
+let with_closed_handler f ~if_closed =
+  (* TODO Use [Lwt_io.is_closed] when available:
+     https://github.com/ocsigen/lwt/pull/635 *)
+  Lwt.catch f
+    (function
+    | Lwt_io.Channel_closed _ -> Lwt.return if_closed
+    | exn -> raise exn
+    )
+
 let read_line ic =
-  Lwt_io.read_line_opt ic >>= function
-  | None ->
-    Log.debug (fun f -> f  "<<< EOF");
-    Lwt.return_none
-  | Some l as x ->
-    Log.debug (fun f -> f  "<<< %s" l);
-    Lwt.return x
+  with_closed_handler ~if_closed:None
+    (fun () ->
+      Lwt_io.read_line_opt ic >>= function
+      | None ->
+        Log.debug (fun f -> f  "<<< EOF");
+        Lwt.return_none
+      | Some l as x ->
+        Log.debug (fun f -> f  "<<< %s" l);
+        Lwt.return x
+    )
 
 let read ic count =
   let count = min count Sys.max_string_length in
-  Lwt_io.read ~count ic >>= fun buf ->
-  Log.debug (fun f -> f  "<<<[%d] %s" count buf);
-  Lwt.return buf
+  with_closed_handler ~if_closed:""
+    (fun () ->
+      Lwt_io.read ~count ic >>= fun buf ->
+      Log.debug (fun f -> f  "<<<[%d] %s" count buf);
+      Lwt.return buf
+    )
 
 let write oc buf =
   Log.debug (fun f -> f  ">>> %s" (String.trim buf));

--- a/cohttp-lwt.opam
+++ b/cohttp-lwt.opam
@@ -31,6 +31,7 @@ depends: [
   "lwt"
   "sexplib0"
   "ppx_sexp_conv" {>= "v0.9.0"}
+  "logs"
 ]
 conflicts: [
   "lwt" {< "2.5.0"}

--- a/cohttp-lwt/src/dune
+++ b/cohttp-lwt/src/dune
@@ -3,4 +3,4 @@
   (public_name cohttp-lwt)
   (synopsis    "Lwt backend")
   (preprocess  (pps ppx_sexp_conv))
-  (libraries   lwt uri cohttp))
+  (libraries   lwt uri cohttp logs logs.lwt))

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -106,9 +106,16 @@ module type Server = sig
 
   type conn = IO.conn * Cohttp.Connection.t
 
+  (** A request handler can respond in two ways:
+      - Using [`Response], with a {!Response.t} and a {!Body.t}.
+      - Using [`Expert], with a {!Response.t} and an IO function that is
+        expected to write the response body. The IO function has access to the
+        underlying {!IO.ic} and {!IO.oc}, which allows writing a response body
+        more efficiently, stream a response or to switch protocols entirely
+        (e.g. websockets). Processing of pipelined requests continue after the
+        {!unit Lwt.t} is resolved. The connection can be closed by closing the
+        {!IO.ic}. *)
   type response_action =
-    (* The connection is not closed in the [`Expert] case until the [unit
-       Lwt.t] becomes determined. *)
     [ `Expert of Cohttp.Response.t
                  * (IO.ic
                     -> IO.oc

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -7,6 +7,9 @@ module Make(IO:S.IO) = struct
   module Request = Make.Request(IO)
   module Response = Make.Response(IO)
 
+  let src = Logs.Src.create "cohttp.lwt.server" ~doc:"Cohttp Lwt server module"
+  module Log = (val Logs.src_log src : Logs.LOG)
+
   type conn = IO.conn * Cohttp.Connection.t
 
   type response_action =
@@ -107,7 +110,7 @@ module Make(IO:S.IO) = struct
          Lwt.catch
            (fun () -> callback conn req body)
            (fun exn ->
-             Format.eprintf "Error handling %a: %s\n%!" Request.pp_hum req (Printexc.to_string exn);
+             Log.err (fun f -> f "Error handling %a: %s\n%!" Request.pp_hum req (Printexc.to_string exn));
              respond_error ~body:"Internal Server Error" () >|= fun rsp ->
              `Response rsp
            ))

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -9,17 +9,38 @@ module Make(IO:S.IO) = struct
 
   type conn = IO.conn * Cohttp.Connection.t
 
+  type response_action =
+    [ `Expert of Cohttp.Response.t
+                 * (IO.ic
+                    -> IO.oc
+                    -> unit Lwt.t)
+    | `Response of Cohttp.Response.t * Body.t ]
+
   type t = {
     callback :
       conn ->
       Cohttp.Request.t ->
       Body.t ->
-      (Cohttp.Response.t * Body.t) Lwt.t;
+      response_action Lwt.t;
     conn_closed: conn -> unit;
   }
 
-  let make ?(conn_closed=ignore) ~callback () =
+  let make_response_action ?(conn_closed=ignore) ~callback () =
     { conn_closed ; callback }
+
+  let make ?conn_closed ~callback () =
+    let callback conn req body =
+      callback conn req body >|= fun rsp ->
+      `Response rsp
+    in
+    make_response_action ?conn_closed ~callback ()
+
+  let make_expert ?conn_closed ~callback () =
+    let callback conn req body =
+      callback conn req body >|= fun rsp ->
+      `Expert rsp
+    in
+    make_response_action ?conn_closed ~callback ()
 
   module Transfer_IO = Cohttp__Transfer_io.Make(IO)
 
@@ -70,74 +91,56 @@ module Make(IO:S.IO) = struct
       |Some uri -> "Not found: " ^ (Uri.to_string uri) in
     respond_string ~status:`Not_found ~body ()
 
-  let request_stream ic =
-    (* don't try to read more from ic until the previous request has
-       been fully read an released this mutex *)
-    let read_m = Lwt_mutex.create () in
-    (* If the request is HTTP version 1.0 then the request stream should be
-       considered closed after the first request/response. *)
-    let early_close = ref false in
-    Lwt_stream.from begin fun () ->
-      if !early_close
-      then Lwt.return_none
-      else
-        Lwt_mutex.lock read_m >>= fun () ->
-        Request.read ic >>= function
-        | `Eof | `Invalid _ -> (* TODO: request logger for invalid req *)
-          Lwt_mutex.unlock read_m;
-          Lwt.return_none
-        | `Ok req -> begin
-            early_close := not (Request.is_keep_alive req);
-            (* Ensure the input body has been fully read before reading
-               again *)
-            match Request.has_body req with
-            | `Yes ->
-              let reader = Request.make_body_reader req ic in
-              let body_stream = Body.create_stream
-                                  Request.read_body_chunk reader in
-              Lwt.on_success (Lwt_stream.closed body_stream)
-                (fun () -> Lwt_mutex.unlock read_m);
-              let body = Body.of_stream body_stream in
-              (* The read_m remains locked until the caller reads the body *)
-              Lwt.return (Some (req, body))
-            (* TODO for now we are just repeating the old behaviour
-             * of ignoring the body in the request. Perhaps it should be
-             * changed it did for responses *)
-            | `No | `Unknown ->
-              Lwt_mutex.unlock read_m;
-              Lwt.return (Some (req, `Empty))
-          end
-    end
+  let read_body ic req =
+    match Request.has_body req with
+    | `Yes ->
+      let reader = Request.make_body_reader req ic in
+      let body_stream = Body.create_stream
+                          Request.read_body_chunk reader in
+      Body.of_stream body_stream
+    | `No | `Unknown ->
+      `Empty
 
-  let response_stream callback io_id conn_id req_stream =
-    Lwt_stream.map_s (fun (req, body) ->
-      Lwt.finalize
-        (fun () ->
-           Lwt.catch
-             (fun () -> callback (io_id, conn_id) req body)
-             (fun exn ->
-               Format.eprintf "Error handling %a: %s\n%!" Request.pp_hum req (Printexc.to_string exn);
-               respond_error ~body:"Internal Server Error" ()))
-        (fun () -> Body.drain_body body)
-    ) req_stream
+  let handle_request callback conn req body =
+    Lwt.finalize
+      (fun () ->
+         Lwt.catch
+           (fun () -> callback conn req body)
+           (fun exn ->
+             Format.eprintf "Error handling %a: %s\n%!" Request.pp_hum req (Printexc.to_string exn);
+             respond_error ~body:"Internal Server Error" () >|= fun rsp ->
+             `Response rsp
+           ))
+      (fun () -> Body.drain_body body)
+
+  let rec handle_client ic oc conn callback =
+    Request.read ic >>= function
+    | `Eof | `Invalid _ -> (* TODO: request logger for invalid req *)
+      Lwt.return_unit
+    | `Ok req ->
+      begin let body = read_body ic req in
+      handle_request callback conn req body >>= function
+      | `Response (res,body) ->
+         let flush = Response.flush res in
+         Response.write ~flush (fun writer ->
+             Body.write_body (Response.write_body writer) body
+           ) res oc >>= fun () ->
+         if Request.is_keep_alive req then
+           handle_client ic oc conn callback
+         else
+           Lwt.return_unit
+      | `Expert (res,io_handler) ->
+         Response.write_header res oc >>= fun () ->
+         io_handler ic oc >>= fun () ->
+         handle_client ic oc conn callback
+    end
 
   let callback spec io_id ic oc =
     let conn_id = Cohttp.Connection.create () in
     let conn_closed () = spec.conn_closed (io_id,conn_id) in
-    (* The server operates by reading requests into a Lwt_stream of requests
-       and mapping them into a stream of responses serially using [spec]. The
-       responses are then sent over the wire *)
-    let req_stream = request_stream ic in
-    let res_stream = response_stream spec.callback io_id conn_id req_stream in
     Lwt.finalize
       (fun () ->
-         (* Transmit the responses *)
-         res_stream |> Lwt_stream.iter_s (fun (res,body) ->
-             let flush = Response.flush res in
-             Response.write ~flush (fun writer ->
-                 Body.write_body (Response.write_body writer) body
-               ) res oc
-           )
+         handle_client ic oc (io_id,conn_id) spec.callback
       )
       (fun () ->
          (* Clean up resources when the response stream terminates and call

--- a/cohttp_async_test/src/cohttp_async_test.mli
+++ b/cohttp_async_test/src/cohttp_async_test.mli
@@ -1,4 +1,4 @@
 open Async_kernel
 
-include Cohttp_test.S with type 'a io = 'a Deferred.t and type body = Cohttp_async.Body.t
+include Cohttp_test.S with type 'a io = 'a Deferred.t and type body = Cohttp_async.Body.t and type ic = Async_unix.Reader.t and type oc = Async_unix.Writer.t
 val run_async_tests : OUnit.test io -> OUnit.test_result list Deferred.t

--- a/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.ml
+++ b/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.ml
@@ -3,13 +3,25 @@ open OUnit
 open Cohttp_lwt_unix
 
 type 'a io = 'a Lwt.t
+type ic = Lwt_io.input_channel
+type oc = Lwt_io.output_channel
 type body = Cohttp_lwt.Body.t
 
-type spec = Request.t -> body -> (Response.t * body) io
+type response_action =
+  [ `Expert of Cohttp.Response.t
+               * (ic
+                  -> oc
+                  -> unit io)
+  | `Response of Cohttp.Response.t * body ]
+
+type spec = Request.t -> body -> response_action io
 
 type async_test = unit -> unit Lwt.t
 
-let const = Cohttp_test.const
+let response rsp = `Response rsp
+let expert ?(rsp=Cohttp.Response.make ()) f _req _body =
+  return (`Expert (rsp, f))
+let const rsp _req _body = rsp >|= response
 
 let response_sequence = Cohttp_test.response_sequence Lwt.fail_with
 
@@ -20,7 +32,7 @@ let temp_server ?port spec callback =
   let port = match port with
     | None -> Cohttp_test.next_port ()
     | Some p -> p in
-  let server = Server.make ~callback:(fun _ req body -> spec req body) () in
+  let server = Server.make_response_action ~callback:(fun _ req body -> spec req body) () in
   let uri = Uri.of_string ("http://0.0.0.0:" ^ (string_of_int port)) in
   let server_failed, server_failed_wake = Lwt.task () in
   let server = Lwt.catch

--- a/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.mli
+++ b/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.mli
@@ -1,1 +1,1 @@
-include Cohttp_test.S with type 'a io = 'a Lwt.t and type body = Cohttp_lwt.Body.t
+include Cohttp_test.S with type 'a io = 'a Lwt.t and type body = Cohttp_lwt.Body.t and type ic = Lwt_io.input_channel and type oc = Lwt_io.output_channel

--- a/cohttp_test/src/cohttp_test.ml
+++ b/cohttp_test/src/cohttp_test.ml
@@ -2,11 +2,22 @@ open Cohttp
 
 module type S = sig
   type 'a io
+  type ic
+  type oc
   type body
 
-  type spec = Request.t -> body -> (Response.t * body) io
+  type response_action =
+    [ `Expert of Cohttp.Response.t
+                 * (ic
+                    -> oc
+                    -> unit io)
+    | `Response of Cohttp.Response.t * body ]
+
+  type spec = Request.t -> body -> response_action io
   type async_test = unit -> unit io
 
+  val response : (Response.t * body) -> response_action
+  val expert : ?rsp:Cohttp.Response.t -> (ic -> oc -> unit io) -> spec
   val const : (Response.t * body) io -> spec
   val response_sequence : spec list -> spec
   val temp_server : ?port:int -> spec -> (Uri.t -> 'a io) -> 'a io
@@ -30,5 +41,3 @@ let response_sequence fail responses =
       xs := xs';
       x req body
     | [] -> fail "response_sequence: Server exhausted responses"
-
-let const resp _ _ = resp

--- a/cohttp_test/src/cohttp_test.mli
+++ b/cohttp_test/src/cohttp_test.mli
@@ -2,12 +2,24 @@ open Cohttp
 
 module type S = sig
   type 'a io
+  type ic
+  type oc
   type body
 
+  type response_action =
+    [ `Expert of Cohttp.Response.t
+                 * (ic
+                    -> oc
+                    -> unit io)
+    | `Response of Cohttp.Response.t * body ]
+
   (** A server that is being tested must be defined by providing a spec *)
-  type spec = Request.t -> body -> (Response.t * body) io
+  type spec = Request.t -> body -> response_action io
 
   type async_test = unit -> unit io
+
+  val response : Response.t * body -> response_action
+  val expert : ?rsp:Response.t -> (ic -> oc -> unit io) -> spec
 
   (** A constant handler that always returns its argument *)
   val const : (Response.t * body) io -> spec
@@ -34,4 +46,3 @@ end
 val next_port : unit -> int
 val response_sequence : (string -> 'a) -> ('b -> 'c -> 'a) list
   -> 'b -> 'c -> 'a
-val const : 'a -> 'c -> 'd -> 'a


### PR DESCRIPTION
This PR adds "expert mode" to `cohttp-lwt` similar to what exists for `cohttp-async` (#488).

My primary use case is for websocket support like #488. The changes also relate to other issues regarding streaming though (#534, #529), and this approach could be used to solve those use cases.  An `Expert`-response does currently not allow omitting a body (a decision inherited from #488), but if that was permitted, then it could be used to for writing/streaming bigarrays efficiently ([mentioned here](https://github.com/mirage/ocaml-cohttp/pull/534#issuecomment-284478847)).

I've rewritten the response/response handling, such that it no longer uses `Lwt_stream`. Though the abstraction of mapping a stream of requests to a stream of responses sounds elegant, I think it's actually simpler without it. In particular the use of refs (`early_close`) and  mutexes (`read_m`) is no longer required. I'm happy to receive feedback on the choice though.

I've not added any tests, but I'd be happy to if the overall approach is approved.

/cc @mattjbray 