### PR TITLE
Async: use Conduit V2 API

### DIFF
--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -28,7 +28,7 @@ depends: [
   "base" {>= "v0.11.0"}
   "core" {test}
   "cohttp"
-  "conduit-async" {>="1.0.3"}
+  "conduit-async" {>="1.2.0"}
   "magic-mime"
   "logs"
   "fmt" {>="0.8.2"}

--- a/cohttp-async/src/client.ml
+++ b/cohttp-async/src/client.ml
@@ -34,12 +34,15 @@ module Net = struct
     >>= fun (host, addr, port) ->
     let mode =
       match (Uri.scheme uri, ssl_config) with
-      | Some "https", Some config -> `OpenSSL_with_config (host, addr, port, config)
-      | Some "https", None -> `OpenSSL (host, addr, port)
+      | Some "https", Some config ->
+        `OpenSSL (addr, port, config)
+      | Some "https", None ->
+        let config = Conduit_async.V2.Ssl.Config.create ~hostname:host () in
+        `OpenSSL (addr, port, config)
       | Some "httpunix", _ -> `Unix_domain_socket host
       | _ -> `TCP (addr, port)
     in
-    Conduit_async.connect ?interrupt mode
+    Conduit_async.V2.connect ?interrupt mode
 end
 
 let read_request ic =

--- a/cohttp-async/src/client.mli
+++ b/cohttp-async/src/client.mli
@@ -2,7 +2,7 @@
     The request is sent as-is. *)
 val request :
   ?interrupt:unit Async_kernel.Deferred.t ->
-  ?ssl_config:Conduit_async.Ssl.config ->
+  ?ssl_config:Conduit_async.V2.Ssl.Config.t ->
   ?uri:Uri.t ->
   ?body:Body.t ->
   Cohttp.Request.t ->
@@ -12,7 +12,7 @@ val request :
     Infers the transfer encoding *)
 val call :
   ?interrupt:unit Async_kernel.Deferred.t ->
-  ?ssl_config:Conduit_async.Ssl.config ->
+  ?ssl_config:Conduit_async.V2.Ssl.Config.t ->
   ?headers:Cohttp.Header.t ->
   ?chunked:bool ->
   ?body:Body.t ->
@@ -22,7 +22,7 @@ val call :
 
 val callv :
   ?interrupt:unit Async_kernel.Deferred.t ->
-  ?ssl_config:Conduit_async.Ssl.config ->
+  ?ssl_config:Conduit_async.V2.Ssl.Config.t ->
   Uri.t ->
   (Cohttp.Request.t * Body.t) Async_kernel.Pipe.Reader.t ->
   (Cohttp.Response.t * Body.t) Async_kernel.Pipe.Reader.t Async_kernel.Deferred.t
@@ -30,7 +30,7 @@ val callv :
 (** Send an HTTP GET request *)
 val get :
   ?interrupt:unit Async_kernel.Deferred.t ->
-  ?ssl_config:Conduit_async.Ssl.config ->
+  ?ssl_config:Conduit_async.V2.Ssl.Config.t ->
   ?headers:Cohttp.Header.t ->
   Uri.t ->
   (Cohttp.Response.t * Body.t) Async_kernel.Deferred.t
@@ -38,7 +38,7 @@ val get :
 (** Send an HTTP HEAD request *)
 val head :
   ?interrupt:unit Async_kernel.Deferred.t ->
-  ?ssl_config:Conduit_async.Ssl.config ->
+  ?ssl_config:Conduit_async.V2.Ssl.Config.t ->
   ?headers:Cohttp.Header.t ->
   Uri.t ->
   Cohttp.Response.t Async_kernel.Deferred.t
@@ -46,7 +46,7 @@ val head :
 (** Send an HTTP DELETE request *)
 val delete :
   ?interrupt:unit Async_kernel.Deferred.t ->
-  ?ssl_config:Conduit_async.Ssl.config ->
+  ?ssl_config:Conduit_async.V2.Ssl.Config.t ->
   ?headers:Cohttp.Header.t ->
   ?chunked:bool ->
   ?body:Body.t ->
@@ -58,7 +58,7 @@ val delete :
 *)
 val post :
   ?interrupt:unit Async_kernel.Deferred.t ->
-  ?ssl_config:Conduit_async.Ssl.config ->
+  ?ssl_config:Conduit_async.V2.Ssl.Config.t ->
   ?headers:Cohttp.Header.t ->
   ?chunked:bool ->
   ?body:Body.t ->
@@ -70,7 +70,7 @@ val post :
 *)
 val put :
   ?interrupt:unit Async_kernel.Deferred.t ->
-  ?ssl_config:Conduit_async.Ssl.config ->
+  ?ssl_config:Conduit_async.V2.Ssl.Config.t ->
   ?headers:Cohttp.Header.t ->
   ?chunked:bool ->
   ?body:Body.t ->
@@ -82,7 +82,7 @@ val put :
 *)
 val patch :
   ?interrupt:unit Async_kernel.Deferred.t ->
-  ?ssl_config:Conduit_async.Ssl.config ->
+  ?ssl_config:Conduit_async.V2.Ssl.Config.t ->
   ?headers:Cohttp.Header.t ->
   ?chunked:bool ->
   ?body:Body.t ->
@@ -92,7 +92,7 @@ val patch :
 (** Send an HTTP POST request in form format *)
 val post_form:
   ?interrupt:unit Async_kernel.Deferred.t ->
-  ?ssl_config:Conduit_async.Ssl.config ->
+  ?ssl_config:Conduit_async.V2.Ssl.Config.t ->
   ?headers:Cohttp.Header.t ->
   params:(string * string list) list ->
   Uri.t ->


### PR DESCRIPTION
This switches the Conduit API used by the Async backend. It would previously use the default V1 one.

In particular, the TLS configuration in V2 has access to the hostname, and when it is passed in, it will add a Server Name Indication (SNI) extension.

This has the following effects on a sample Client Hello:

```diff
- Extensions Length: 164
+ Extensions Length: 191
+ Extension: server_name (len=23)
  Extension: ec_point_formats (len=4)
  Extension: supported_groups (len=4)
  Extension: SessionTicket TLS (len=0)
```

This should take care of #624 (@dwwoelfel can you check that this works for you?).

That's technically a breaking change since `ssl_config` is using a V2 type, but that seems reasonable.

Thoughts?

Thanks!