### PR TITLE
log invalid client input and do not catch out of memory

### DIFF
--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -109,16 +109,20 @@ module Make(IO:S.IO) = struct
       (fun () ->
          Lwt.catch
            (fun () -> callback conn req body)
-           (fun exn ->
-             Log.err (fun f -> f "Error handling %a: %s\n%!" Request.pp_hum req (Printexc.to_string exn));
-             respond_error ~body:"Internal Server Error" () >|= fun rsp ->
-             `Response rsp
+           (function
+             | Out_of_memory -> raise Out_of_memory
+             | exn ->
+               Log.err (fun f -> f "Error handling %a: %s\n%!" Request.pp_hum req (Printexc.to_string exn));
+               respond_error ~body:"Internal Server Error" () >|= fun rsp ->
+               `Response rsp
            ))
       (fun () -> Body.drain_body body)
 
   let rec handle_client ic oc conn callback =
     Request.read ic >>= function
-    | `Eof | `Invalid _ -> (* TODO: request logger for invalid req *)
+    | `Eof -> Lwt.return_unit
+    | `Invalid data ->
+      Log.err (fun m -> m "invalid input %s while handling client" data);
       Lwt.return_unit
     | `Ok req ->
       begin let body = read_body ic req in

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -110,7 +110,7 @@ module Make(IO:S.IO) = struct
          Lwt.catch
            (fun () -> callback conn req body)
            (function
-             | Out_of_memory -> raise Out_of_memory
+             | Out_of_memory -> Lwt.fail Out_of_memory
              | exn ->
                Log.err (fun f -> f "Error handling %a: %s\n%!" Request.pp_hum req (Printexc.to_string exn));
                respond_error ~body:"Internal Server Error" () >|= fun rsp ->


### PR DESCRIPTION
 - log invalid input from client in handle_client
 - in handle_request, do not catch Out_of_memory exception

the reasoning behind this change is that I'm eager to see when something goes wrong, and since `Request.read` already takes care of building a string with an error message, we should display this somewhere :)

for the second part, not catching out of memory, this is likely a matter of taste. there are situations where aborting/closing a single client connection may recover sufficient memory to get cohttp into a working state again.

but in reality, what I see with Canopy is that something in the stack (likely cohttp/conduit, don't see this in other unikernels) leaks memory, now a lot of connections are running into the above catch, and get an 500 back, cohttp reclaims some more memory... this goes on for _days_ until some other piece of code tries to allocate just enough memory to be over the limit, and crashes the unikernel.

for several days, the state is that HTTP(S) is up, but nearly always responds with 500 -- this PR changes the behaviour and have cohttp crash hard if there's an out of memory. now, certainly this opens an attack vector: an attacker that can provoke `callback` to allocate lots of memory will crash the server. please keep in mind that when callback is called, cohttp already parsed the client input (which may be of arbitrary size(?)) into a Cohttp.Request.t structure.

depending on your point of view, I'd as well be glad if the desired behaviour would be a configuration option (for Server.create).