### PR TITLE
Better handling of IO errors

### DIFF
--- a/cohttp-lwt-unix/src/io.mli
+++ b/cohttp-lwt-unix/src/io.mli
@@ -14,9 +14,8 @@
  *
   }}}*)
 
-include Cohttp.S.IO
- with type 'a t = 'a Lwt.t
- and type ic = Lwt_io.input_channel
+include Cohttp_lwt.S.IO
+ with type ic = Lwt_io.input_channel
  and type oc = Lwt_io.output_channel
  and type conn = Conduit_lwt_unix.flow
-
+ and type error = exn

--- a/cohttp-lwt-unix/src/net.mli
+++ b/cohttp-lwt-unix/src/net.mli
@@ -16,11 +16,7 @@
 
 (** Basic satisfaction of {! Cohttp_lwt.Net } *)
 
-module IO : Cohttp.S.IO
- with type 'a t = 'a Lwt.t
- and type ic = Lwt_io.input_channel
- and type oc = Lwt_io.output_channel
- and type conn = Conduit_lwt_unix.flow
+module IO = Io
 
 type ctx = {
   ctx : Conduit_lwt_unix.ctx;

--- a/cohttp-lwt-unix/test/test_sanity.ml
+++ b/cohttp-lwt-unix/test/test_sanity.ml
@@ -6,6 +6,12 @@ open Cohttp_lwt_unix_test
 
 module Body = Cohttp_lwt.Body
 
+module IO = Cohttp_lwt_unix.IO
+module Request = struct
+  include Cohttp.Request
+  include (Make(IO) : module type of Make(IO) with type t := t)
+end
+
 let message = "Hello sanity!"
 
 let chunk_body = ["one"; ""; " "; "bar"; ""]
@@ -14,6 +20,8 @@ let leak_repeat = 1024
 
 let () = Debug.activate_debug ()
 let () = Logs.set_level (Some Info)
+
+let cond = Lwt_condition.create ()
 
 let server =
   List.map const [ (* t *)
@@ -73,6 +81,20 @@ let server =
           Lwt_io.close ic
       )
     ))
+  ]
+  @ (* client_close *)
+  [
+    fun _ _ ->
+    let ready = Lwt_condition.wait cond in
+    let i = ref 0 in
+    let stream = Lwt_stream.from (fun () ->
+        ready >|= fun () ->
+        incr i;
+        if !i > 1000 then failwith "Connection should have failed by now!";
+        Some (String.make 4096 'X')
+      )
+    in
+    Lwt.return (`Response (Cohttp.Response.make ~status:`OK (), `Stream stream))
   ]
   |> response_sequence
 
@@ -186,6 +208,19 @@ let ts =
       Body.to_string body >|= fun body ->
       assert_equal ~printer "expert 2" body
     in
+    let client_close () =
+      Cohttp_lwt_unix.Net.(connect_uri ~ctx:default_ctx) uri >>= fun (_conn, ic, oc) ->
+      let req = Cohttp.Request.make_for_client ~chunked:false `GET (Uri.with_path uri "/test.html") in
+      Request.write (fun _writer -> Lwt.return_unit) req oc
+      >>= fun () ->
+      Response.read ic >>= function
+      | `Eof | `Invalid _ -> assert false
+      | `Ok rsp ->
+        assert_equal ~printer:Cohttp.Code.string_of_status `OK (Cohttp.Response.status rsp);
+        Cohttp_lwt_unix.Net.close ic oc;
+        Lwt_condition.broadcast cond ();
+        Lwt.pause ()
+    in
     [ "sanity test",                            check_logs t
     ; "empty chunk test",                       check_logs empty_chunk
     ; "pipelined chunk test",                   check_logs pipelined_chunk
@@ -195,6 +230,7 @@ let ts =
     ; "unreadable file returns 500",            unreadable_file_500
     ; "no leaks on requests",                   check_logs test_no_leak
     ; "expert response",                        check_logs expert_pipelined
+    ; "client_close",                           check_logs client_close
     ]
   end
 

--- a/cohttp-lwt/src/cohttp_lwt.ml
+++ b/cohttp-lwt/src/cohttp_lwt.ml
@@ -14,7 +14,7 @@
  *
   }}}*)
 
-module type IO = S.IO with type 'a t = 'a Lwt.t
+module type IO = S.IO
 
 module Request = Cohttp.Request
 module Response = Cohttp.Response

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -4,7 +4,17 @@
     functors must be instantiated by an implementation that provides
     a concrete IO monad. *)
 
-module type IO = Cohttp.S.IO with type 'a t = 'a Lwt.t
+module type IO = sig
+  include Cohttp.S.IO with type 'a t = 'a Lwt.t
+
+  type error
+
+  val catch : (unit -> 'a t) -> ('a, error) result t
+  (** [catch f] is [f () >|= Result.ok], unless [f] fails with an IO error,
+      in which case it returns the error. *)
+
+  val pp_error : Format.formatter -> error -> unit
+end
 (** The IO module is specialized for the [Lwt] monad. *)
 
 (** The [Net] module type defines how to connect to a remote node

--- a/cohttp-mirage/src/io.ml
+++ b/cohttp-mirage/src/io.ml
@@ -21,38 +21,61 @@ open Lwt.Infix
 
 module Make (Channel: Mirage_channel_lwt.S) = struct
 
+  type error =
+    | Read_error of Channel.error
+    | Write_error of Channel.write_error
+
+  let pp_error f = function
+    | Read_error e -> Channel.pp_error f e
+    | Write_error e -> Channel.pp_write_error f e
+
   type 'a t = 'a Lwt.t
   type ic = Channel.t
   type oc = Channel.t
   type conn = Channel.flow
 
-  let failf fmt = Fmt.kstrf Lwt.fail_with fmt
+  exception Read_exn of Channel.error
+  exception Write_exn of Channel.write_error
+
+  let () =
+    Printexc.register_printer (function
+        | Read_exn e -> Some (Format.asprintf "IO read error: %a" Channel.pp_error e)
+        | Write_exn e -> Some (Format.asprintf "IO write error: %a" Channel.pp_write_error e)
+        | _ -> None
+      )
 
   let read_line ic =
     Channel.read_line ic >>= function
     | Ok (`Data [])   -> Lwt.return_none
     | Ok `Eof         -> Lwt.return_none
-    | Ok (`Data bufs) -> Lwt.return (Some (Cstruct.copyv bufs))
-    | Error e         -> failf "Flow error: %a" Channel.pp_error e
+    | Ok (`Data bufs) -> Lwt.return_some (Cstruct.copyv bufs)
+    | Error e         -> Lwt.fail (Read_exn e)
 
   let read ic len =
     Channel.read_some ~len ic >>= function
     | Ok (`Data buf) -> Lwt.return (Cstruct.to_string buf)
     | Ok `Eof        -> Lwt.return ""
-    | Error e        -> failf "Flow error: %a" Channel.pp_error e
+    | Error e        -> Lwt.fail (Read_exn e)
 
   let write oc buf =
     Channel.write_string oc buf 0 (String.length buf);
     Channel.flush oc >>= function
     | Ok ()         -> Lwt.return_unit
     | Error `Closed -> Lwt.fail_with "Trying to write on closed channel"
-    | Error e       -> failf "Flow error: %a" Channel.pp_write_error e
+    | Error e       -> Lwt.fail (Write_exn e)
 
   let flush _ =
     (* NOOP since we flush in the normal writer functions above *)
     Lwt.return_unit
 
-  let  (>>= ) = Lwt.( >>= )
+  let (>>= ) = Lwt.( >>= )
   let return = Lwt.return
 
+  let catch f =
+    Lwt.try_bind f Lwt.return_ok
+      (function
+        | Read_exn e -> Lwt.return_error (Read_error e)
+        | Write_exn e -> Lwt.return_error (Write_error e)
+        | ex -> Lwt.fail ex
+      )
 end

--- a/cohttp-mirage/src/io.mli
+++ b/cohttp-mirage/src/io.mli
@@ -19,8 +19,7 @@
 
 (** Cohttp IO implementation using Mirage channels. *)
 
-module Make (Channel: Mirage_channel_lwt.S) : Cohttp.S.IO
-  with type 'a t = 'a Lwt.t
-   and type ic = Channel.t
+module Make (Channel: Mirage_channel_lwt.S) : Cohttp_lwt.S.IO
+  with type ic = Channel.t
    and type oc = Channel.t
    and type conn = Channel.flow


### PR DESCRIPTION
Before, if the client closed the connection while we were handling a request, the server would crash (by default, unless the user overrode that using `on_exn` or changing `Lwt`'s async exception handler). Now, we just log this at `info` level and continue. Exceptions produced by user code are logged as errors, while other exceptions generated by cohttp call back to the conduit exception handler, as before.

Fixes #511.

I first tried getting the IO operations to return a `result` and plumbing that through everywhere, but it was very painful and caused lots of API changes. So instead, each IO monad is now expected to include handling of IO errors, and provides a `catch` operation to expose it. This avoids changes to the core of cohttp. The lwt-unix and mirage implementations both make use of `Lwt.fail` to carry IO errors.

This PR adds a unit-test to check that the server doesn't crash if the client closes the connection. It also adds checks to some other tests to ensure that no errors or warnings were logged during the test.