### PR TITLE
Use Pipe.singleton in cohttp-async/body_raw

### DIFF
--- a/cohttp-async/src/body_raw.ml
+++ b/cohttp-async/src/body_raw.ml
@@ -37,7 +37,7 @@ let is_empty (body:t) =
 
 let to_pipe = function
   | `Empty -> Pipe.of_list []
-  | `String s -> Pipe.of_list [s]
+  | `String s -> Pipe.singleton s
   | `Strings sl -> Pipe.of_list sl
   | `Pipe p -> p
 


### PR DESCRIPTION
Use Pipe.singleton when the pipe only contains one value, as it is more efficient than Pipe.of_list