### PR TITLE
Async: Use Pipe.empty over of_list for empty pipes

### DIFF
--- a/cohttp-async/src/body_raw.ml
+++ b/cohttp-async/src/body_raw.ml
@@ -36,7 +36,7 @@ let is_empty (body:t) =
       | Some _ | None -> false
 
 let to_pipe = function
-  | `Empty -> Pipe.of_list []
+  | `Empty -> Pipe.empty ()
   | `String s -> Pipe.singleton s
   | `Strings sl -> Pipe.of_list sl
   | `Pipe p -> p


### PR DESCRIPTION
The current implementation of [Pipe.empty] is to call [of_list] on an
empty list, however this may change in the future.