### PR TITLE
pass ctx through in HEAD client requests

### DIFF
--- a/cohttp-lwt/src/client.ml
+++ b/cohttp-lwt/src/client.ml
@@ -74,8 +74,8 @@ module Make
     read_response ~closefn ic oc meth
 
   (* The HEAD should not have a response body *)
-  let head ?ctx:_ ?headers uri =
-    call ?headers `HEAD uri
+  let head ?ctx ?headers uri =
+    call ?ctx ?headers `HEAD uri
     >|= fst
 
   let get ?ctx ?headers uri = call ?ctx ?headers `GET uri


### PR DESCRIPTION
I'm still not sure what this `ctx` is about, but without the code below I'm unable to achieve HEAD requests on https://foo.com with any MirageOS unikernel. I suspect the "conduit" is lacking https support if not fiddled through. From git history, the `?ctx` was introduced in https://github.com/mirage/ocaml-cohttp/commit/097f38e95a9f2094023479cf59d4c387bcf3ea12 (PR https://github.com/mirage/ocaml-cohttp/pull/173) and the only change in `let head...` was in https://github.com/mirage/ocaml-cohttp/commit/d4b8144f099a9bd93cccb78312aa66eb7b7943ec (which got rid of unused variables, and changed `?ctx` to `?ctx:_`).

This PR fiddles `ctx` to `call` and let's me do HEAD https client requests. A merge and point-release would be great to have.