### PR TITLE
Correction of [Header.replace] function and better encoding management in [Request.make] and [Response.make] functions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- cohttp: better body encoding management when creating request and
+  response, and correction of Header.replace fonction (#694 @lyrm)
+
 ## v2.5.1 (2020-02-18)
 
 - cohttp-lwt: pass ctx through HEAD client requests (#689 @hannesm)

--- a/cohttp/src/header.ml
+++ b/cohttp/src/header.ml
@@ -77,7 +77,9 @@ let remove h k =
 
 let replace h k v =
   let k = LString.of_string k in
-  StringMap.add k [v] h
+  if StringMap.mem k h
+  then StringMap.add k [v] h
+  else h
 
 let get h k =
   let k = LString.of_string k in

--- a/cohttp/src/header.mli
+++ b/cohttp/src/header.mli
@@ -19,45 +19,45 @@
     of values associated with a single key. *)
 type t [@@deriving sexp]
 
-(** Construct a fresh, empty map of HTTP headers *)
+(** Construct a fresh, empty map of HTTP headers. *)
 val init : unit -> t
 
-(** Test whether a HTTP headers are empty or not. *)
+(** Test whether HTTP headers are empty or not. *)
 val is_empty : t -> bool
 
-(** Construct a fresh map of HTTP headers with a single key and value entry *)
+(** Construct a fresh map of HTTP headers with a single key and value entry. *)
 val init_with  : string -> string -> t
 
-(** Add a key and value to an existing header map *)
+(** Add a key and value to an existing header map. *)
 val add : t -> string -> string -> t
 
-(** Add multiple key and value pairs to an existing header map *)
+(** Add multiple key and value pairs to an existing header map. *)
 val add_list : t -> (string * string) list -> t
 
-(** Add multiple values to a key in an existing header map *)
+(** Add multiple values to a key in an existing header map. *)
 val add_multi : t -> string -> string list -> t
 
 (** Given an optional header, either update the existing one with
     a key and value, or construct a fresh header with those values if
-    the header is [None] *)
+    the header is [None]. *)
 val add_opt : t option -> string -> string -> t
 
 (** Given a header, update it with the key and value unless the key is
-    already present in the header *)
+    already present in the header. *)
 val add_unless_exists : t -> string -> string -> t
 
-(** [add_unless_exists h k v] updates [h] with the key [k] and value [v]
+(** [add_opt_unless_exists h k v] updates [h] with the key [k] and value [v]
     unless the key is already present in the header.  If [h] is [None]
     then a fresh header is allocated containing the key [k] and the
     value [v]. *)
 val add_opt_unless_exists : t option -> string -> string -> t
 
-(** Remove a key from the header map and return a fresh header set.  The
+(** Remove a key from the header map and return a fresh header set. The
     original header parameter is not modified. *)
 val remove : t -> string -> t
 
-(** Replace a key from the header map if it exists.  The original
-    header parameter is not modified. *)
+(** Replace the value of a key from the header map if it exists. The
+   original header parameter is not modified. *)
 val replace : t -> string -> string -> t
 
 (** Check if a key exists in the header. *)

--- a/cohttp/src/request.ml
+++ b/cohttp/src/request.ml
@@ -27,9 +27,9 @@ type t = {
 let fixed_zero = Transfer.Fixed Int64.zero
 
 let guess_encoding ?(encoding=fixed_zero) headers =
-  match Header.get_content_range headers with
-  | Some clen -> Transfer.Fixed clen
-  | None -> encoding
+  match Header.get_transfer_encoding headers with
+  | Transfer.(Chunked | Fixed _) as enc -> enc
+  | Unknown -> encoding
 
 let make ?(meth=`GET) ?(version=`HTTP_1_1) ?encoding ?headers uri =
   let headers =

--- a/cohttp/src/response.ml
+++ b/cohttp/src/response.ml
@@ -24,8 +24,12 @@ type t = {
   flush: bool;
 } [@@deriving fields, sexp]
 
-let make ?(version=`HTTP_1_1) ?(status=`OK) ?(flush=false) ?(encoding=Transfer.Chunked) ?headers () =
-  let headers = match headers with None -> Header.init () |Some h -> h in
+let make ?(version=`HTTP_1_1) ?(status=`OK) ?(flush=false) ?(encoding=Transfer.Fixed Int64.zero) ?(headers=Header.init ()) () =
+  let encoding =
+    match Header.get_transfer_encoding headers with
+    | Transfer.(Chunked | Fixed _)  as enc -> enc
+    | Unknown -> encoding
+  in
   { encoding; headers; version; flush; status }
 
 let pp_hum ppf r =

--- a/cohttp/src/response.ml
+++ b/cohttp/src/response.ml
@@ -24,7 +24,7 @@ type t = {
   flush: bool;
 } [@@deriving fields, sexp]
 
-let make ?(version=`HTTP_1_1) ?(status=`OK) ?(flush=false) ?(encoding=Transfer.Fixed Int64.zero) ?(headers=Header.init ()) () =
+let make ?(version=`HTTP_1_1) ?(status=`OK) ?(flush=false) ?(encoding=Transfer.Chunked) ?(headers=Header.init ()) () =
   let encoding =
     match Header.get_transfer_encoding headers with
     | Transfer.(Chunked | Fixed _)  as enc -> enc

--- a/cohttp/src/s.ml
+++ b/cohttp/src/s.ml
@@ -113,6 +113,12 @@ module type Response = sig
     flush: bool;
   } [@@deriving fields, sexp]
 
+  (* The response creates by [make ~encoding ~headers ()] has an
+     encoding value determined from the content of [headers] or if no
+     proper header is present, using the value of [encoding]. Checked
+     headers are "content-lenght", "content-range" and
+     "transfer-encoding". The default value of [encoding] is
+     chunked. *)
   val make :
     ?version:Code.version ->
     ?status:Code.status_code ->


### PR DESCRIPTION
1.  `Header` module: 
The `replace` function was not working properly (it should do nothing if the key is not already in the headers). I have also corrected some minor typos in documentation.

2. `Response.make` function:
This function create a `Response.t` record from the inputs. In particular, it fills its `encoding` field with the optional argument `~encoding`. However it does not take into account the headers and that can cause a bug when these values are different. Read the detailed example below for more explanation. In brief, you can have a chunked body that is read as not chunked by the client. 

3. `Request.make` function:
As requested by this [RFC](https://tools.ietf.org/html/rfc7230#section-3.3.2), the `guess_encoding` function should first check for the presence of the header *transfer-encoding* before checking for *content-length* or *content-range* headers to determine the body encoding.

**Example**: 
Let's take a response defined by: 
```ocaml 
let resp = Response.make ~headers:(Header.of_list ["content-length", "100L"]) ()
````
The value of the field `resp.encoding` is therefore `Chunked` (default value).  When the response is written (see `Cohttp-lwt.Server.handle_client` which calls `Cohttp.Response.write`): 
-  as the headers contain a `content-length` value, they are written unchanged by `Response.write_header` whatever the value of `response.encoding`.  
-  the value of the field `encoding` is used to determine how to write the response (see `Response.make_body_writer`) without considering the headers. 

As a result, the body is written as a chunked body whereas the client will read it as not chunked.
