### PR TITLE
partly inline read_response, fix body stream leak

### DIFF
--- a/cohttp-lwt/src/client.ml
+++ b/cohttp-lwt/src/client.ml
@@ -19,6 +19,8 @@ module Make
       let stream = Body.create_stream Response.read_body_chunk reader in
       let body = Body.of_stream stream in
       let closed = ref false in
+      (* Lwt.on_success registers a callback in the stream.
+       * The GC will still be able to collect stream. *)
       Lwt.on_success (Lwt_stream.closed stream)
         (fun () -> closed := true; closefn ());
       (* finalise could run in a thread different from the lwt main thread.

--- a/cohttp-lwt/src/client.ml
+++ b/cohttp-lwt/src/client.ml
@@ -64,12 +64,15 @@ module Make
     sent >>= fun () ->
     Response.read ic >>= function
     | `Invalid reason ->
+      closefn () ;
       Lwt.fail (Failure ("Failed to read response: " ^ reason))
     | `Eof ->
+      closefn () ;
       Lwt.fail (Failure "Server closed connection prematurely.")
     | `Ok res ->
       match meth with
       | `HEAD ->
+        closefn () ;
         Lwt.return (res, `Empty)
       | _ ->
         let body = read_body ~closefn ic res in
@@ -114,12 +117,15 @@ module Make
       Lwt_mutex.with_lock read_m begin fun () ->
         Response.read ic >>= function
         | `Invalid reason ->
+          closefn () ;
           Lwt.fail (Failure ("Failed to read response: " ^ reason))
         | `Eof ->
+          closefn () ;
           Lwt.fail (Failure "Server closed connection prematurely.")
         | `Ok res ->
           match meth with
           | `HEAD ->
+            closefn () ;
             Lwt.return (res, `Empty)
           | _ ->
             let body = read_body ~closefn ic res in


### PR DESCRIPTION
I'm currently working on an improved pipelining implementation that will gracefully handle timeouts and simplify the interface. (See #690)
The changes in this pull request are just preparations.
But I believe they would benefit the existing code, too.

* to handle for example remote timeouts it is necessary to always listen on the incoming stream to read the EOF. But when starting to listen one may not yet know the request method of the next response. That's why I inlined the `Response.read` handling, which does not need knowledge of the request method.
* to me it seemed the finalising in the body handling is wrong. closefn is called twice ~~and there is a stream leak if the body is not fully consumed by the user~~.