### PR TITLE
Implement Unix domain socket support for Cohttp-async

### DIFF
--- a/cohttp/src/request.ml
+++ b/cohttp/src/request.ml
@@ -38,10 +38,13 @@ let make ?(meth=`GET) ?(version=`HTTP_1_1) ?encoding ?headers uri =
     | Some h -> h in
   let headers =
     Header.add_unless_exists headers "host"
-      (Uri.host_with_default ~default:"localhost" uri ^
-       match Uri.port uri with
-       | Some p -> ":" ^ string_of_int p
-       | None -> "") in
+      (match Uri.scheme uri with
+      | Some "httpunix" -> ""
+      | _ ->
+        Uri.host_with_default ~default:"localhost" uri ^
+         match Uri.port uri with
+         | Some p -> ":" ^ string_of_int p
+         | None -> "") in
   let headers =
     Header.add_unless_exists headers "user-agent" Header.user_agent in
   let headers =


### PR DESCRIPTION
Conduit already supported it and Cohttp-async nearly did as well, defining a `httpunix` schema, but there were some snags in supporting it fully:

1. It tried to get the port of a Unix domain socket. They usually don't have ports. In theory creating such can be done with Uri, but it would be rather unexpected
2. When using Unix sockets on HTTP 1.1 it is required to send the `Host` header but [RFC2616, Section 14.26](https://tools.ietf.org/html/rfc2616#section-14.23) states that for Unix domain socket said header should be empty

The latter change was required to talk to the Docker daemon which otherwise returns HTTP 400, but now responds fine.