### PR TITLE
cohttp: revert change to Header.replace, add Header.update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 ## Unreleased
 
 - cohttp: a change in #694 modified the semantics of Header.replace.
-  The semantics change is reverted, and a new Header.update function
-  is introduced which changes a header value only when present. (@mseri)
+  The semantics change is reverted, and a new Header.update_existing function
+  is introduced which changes a header value only when present. (#702 @mseri)
 
 ## v2.5.3 (2020-06-27)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 ## Unreleased
 
 - cohttp: a change in #694 modified the semantics of Header.replace.
-  The semantics change is reverted, and a new Header.update_existing function
-  is introduced which changes a header value only when present. (#702 @mseri)
+  The semantics change is reverted, and a new Header.update function
+  is introduced, following the semantics of Map.update. (#702 @mseri)
 
 ## v2.5.3 (2020-06-27)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- cohttp: a change in #694 modified the semantics of Header.replace.
+  The semantics change is reverted, and a new Header.update function
+  is introduced which changes a header value only when present. (@mseri)
+
 ## v2.5.3 (2020-06-27)
 
 - cohttp-async: adapt to async >= v0.14 (#699 @copy)

--- a/cohttp/src/header.ml
+++ b/cohttp/src/header.ml
@@ -79,11 +79,11 @@ let replace h k v =
   let k = LString.of_string k in
   StringMap.add k [v] h
 
-let update h k v =
-  let k' = LString.of_string k in
-  if StringMap.mem k' h
-  then replace h k v
-  else h
+let update_existing h k v =
+    let k' = LString.of_string k in
+    if StringMap.mem k' h
+    then Some (replace h k v)
+    else None
 
 let get h k =
   let k = LString.of_string k in

--- a/cohttp/src/header.ml
+++ b/cohttp/src/header.ml
@@ -79,11 +79,20 @@ let replace h k v =
   let k = LString.of_string k in
   StringMap.add k [v] h
 
-let update_existing h k v =
-    let k' = LString.of_string k in
-    if StringMap.mem k' h
-    then Some (replace h k v)
-    else None
+let update h k f =
+  let k = LString.of_string k in
+  let f v =
+    let v' = match v with
+      | None -> f None
+      | Some l -> f (Some (String.concat "," l))
+    in match v' with
+    | None -> None
+    | Some s ->
+      if is_header_with_list_value k then
+        Some (String.split_on_char ',' s)
+      else Some [s]
+  in
+  StringMap.update k f h
 
 let get h k =
   let k = LString.of_string k in

--- a/cohttp/src/header.ml
+++ b/cohttp/src/header.ml
@@ -77,8 +77,12 @@ let remove h k =
 
 let replace h k v =
   let k = LString.of_string k in
-  if StringMap.mem k h
-  then StringMap.add k [v] h
+  StringMap.add k [v] h
+
+let update h k v =
+  let k' = LString.of_string k in
+  if StringMap.mem k' h
+  then replace h k v
   else h
 
 let get h k =

--- a/cohttp/src/header.ml
+++ b/cohttp/src/header.ml
@@ -84,7 +84,10 @@ let update h k f =
   let f v =
     let v' = match v with
       | None -> f None
-      | Some l -> f (Some (String.concat "," l))
+      | Some l -> 
+        if is_header_with_list_value k then
+          f (Some (String.concat "," l))
+        else f (Some (List.hd l))
     in match v' with
     | None -> None
     | Some s ->

--- a/cohttp/src/header.mli
+++ b/cohttp/src/header.mli
@@ -67,7 +67,13 @@ val replace : t -> string -> string -> t
     if [w] is [Some z] then [k] is associated to [z] in the resulting headers.
     If [k] was already associated in [h] to a value that is physically equal
     to [z], [h] is returned unchanged (the result of the function is then
-    physically equal to [h]). The original header parameters are not modified. *)
+    physically equal to [h]). Similarly as for [get], if the header is one
+    of the set of headers defined to have list values, then all of the values are
+    concatenated into a single string separated by commas and passed to [f],
+    while the return value of [f] is split on commas and associated to [k].
+    If it is a singleton header, then the first value is passed to [f] and
+    no concatenation is performed, similarly for the return value.
+    The original header parameters are not modified. *)
 val update: t -> string -> (string option -> string option) -> t
 
 (** Check if a key exists in the header. *)

--- a/cohttp/src/header.mli
+++ b/cohttp/src/header.mli
@@ -60,9 +60,12 @@ val remove : t -> string -> t
     adds it to the header map. The original header parameter is not modified. *)
 val replace : t -> string -> string -> t
 
-(** Replace the value of a key from the header map if it exists, otherwise
-    return the header map unmodified. The original header parameter is not modified. *)
-val update: t -> string -> string -> t
+(** [update_existing h k v] replaces the value [v] of a key [k] in the
+    header map [h] if [k] is already in [h], otherwise it leaves [h]
+    unchanged and returns [None].
+    The option value returned by the function contains the updated map.
+    The original header parameter is not modified. *)
+val update_existing: t -> string -> string -> t option
 
 (** Check if a key exists in the header. *)
 val mem : t -> string -> bool

--- a/cohttp/src/header.mli
+++ b/cohttp/src/header.mli
@@ -56,9 +56,13 @@ val add_opt_unless_exists : t option -> string -> string -> t
     original header parameter is not modified. *)
 val remove : t -> string -> t
 
-(** Replace the value of a key from the header map if it exists. The
-   original header parameter is not modified. *)
+(** Replace the value of a key from the header map if it exists, otherwise it
+    adds it to the header map. The original header parameter is not modified. *)
 val replace : t -> string -> string -> t
+
+(** Replace the value of a key from the header map if it exists, otherwise
+    return the header map unmodified. The original header parameter is not modified. *)
+val update: t -> string -> string -> t
 
 (** Check if a key exists in the header. *)
 val mem : t -> string -> bool

--- a/cohttp/src/header.mli
+++ b/cohttp/src/header.mli
@@ -60,12 +60,15 @@ val remove : t -> string -> t
     adds it to the header map. The original header parameter is not modified. *)
 val replace : t -> string -> string -> t
 
-(** [update_existing h k v] replaces the value [v] of a key [k] in the
-    header map [h] if [k] is already in [h], otherwise it leaves [h]
-    unchanged and returns [None].
-    The option value returned by the function contains the updated map.
-    The original header parameter is not modified. *)
-val update_existing: t -> string -> string -> t option
+(** [update h k f] returns a map containing the same headers as [h],
+    except for the header [k]. Depending on the value of [v] where [v] is
+    [f (get h k)], the header [k] is added, removed or updated.
+    If [w] is [None], the header is removed if it exists; otherwise,
+    if [w] is [Some z] then [k] is associated to [z] in the resulting headers.
+    If [k] was already associated in [h] to a value that is physically equal
+    to [z], [h] is returned unchanged (the result of the function is then
+    physically equal to [h]). The original header parameters are not modified. *)
+val update: t -> string -> (string option -> string option) -> t
 
 (** Check if a key exists in the header. *)
 val mem : t -> string -> bool

--- a/cohttp/test/test_header.ml
+++ b/cohttp/test/test_header.ml
@@ -147,13 +147,13 @@ module Updates = struct
     Alcotest.(check (option string)) "replace_new_header" (Some "3") (H.get h "third")
 
   let update_headers_if_exists () =
-    let h1 = H.update_existing h "second" "2a" in
+    let h1 = H.update h "second" (function | Some _ -> Some "2a" | None -> None) in
     let h2 = H.replace h "second" "2a" in
-    Alcotest.(check (option t_header)) "update_existing_header" h1 (Some h2)
+    Alcotest.(check t_header) "update_existing_header" h1 h2
 
   let update_headers_if_absent () =
-    let h1 = H.update_existing h "third" "3" in
-    Alcotest.(check (option t_header)) "update_new_header: none returned" None h1;
+    let h1 = H.update h "third" (function | Some _ -> Some "3" | None -> None) in
+    Alcotest.(check t_header) "update_new_header: unchanged" h h1;
     Alcotest.(check (option string)) "update_new_header: map unchanged" None (H.get h "third")
 end
 

--- a/cohttp/test/test_header.ml
+++ b/cohttp/test/test_header.ml
@@ -137,6 +137,8 @@ module Updates = struct
   let h = H.init ()
     |> fun h -> H.add h "first" "1"
     |> fun h -> H.add h "second" "2"
+    |> fun h -> H.add h "accept" "foo"
+    |> fun h -> H.add h "accept" "bar"
 
   let replace_headers_if_exists () =
     let h = H.replace h "second" "2a" in
@@ -150,6 +152,11 @@ module Updates = struct
     let h1 = H.update h "second" (function | Some _ -> Some "2a" | None -> None) in
     let h2 = H.replace h "second" "2a" in
     Alcotest.(check t_header) "update_existing_header" h1 h2
+
+  let update_headers_if_exists_multi () =
+    let h1 = H.update h "accept" (function | Some v -> Some ("baz,"^v) | None -> None) in
+    let h2 = H.add h "accept" "baz" in
+    Alcotest.(check (option string)) "update_existing_header_multivalued" (H.get h1 "accept") (H.get h2 "accept")
 
   let update_headers_if_absent () =
     let h1 = H.update h "third" (function | Some _ -> Some "3" | None -> None) in
@@ -511,6 +518,7 @@ Alcotest.run "test_header" [
     "replace existing", `Quick, Updates.replace_headers_if_exists;
     "replace absent", `Quick, Updates.replace_headers_if_absent;
     "update existing", `Quick, Updates.update_headers_if_exists;
+    "update existing list", `Quick, Updates.update_headers_if_exists_multi;
     "update absent", `Quick, Updates.update_headers_if_absent;
     "large header", `Slow, large_header;
     "many headers", `Slow, many_headers;

--- a/cohttp/test/test_header.ml
+++ b/cohttp/test/test_header.ml
@@ -156,6 +156,7 @@ module Updates = struct
     Alcotest.(check (option t_header)) "update_new_header: none returned" None h1;
     Alcotest.(check (option string)) "update_new_header: map unchanged" None (H.get h "third")
 end
+
 module Content_range = struct
   let h1 = H.of_list ["Content-Length", "123"]
   let h2 = H.of_list ["Content-Range", "bytes 200-300/1000"]


### PR DESCRIPTION
A change in #694 modified the semantics of Header.replace.
The semantics change is reverted, and a new Header.update function is introduced which changes a header value only when present.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>