### PR TITLE
don't change the pipe when creating async body

### DIFF
--- a/cohttp-async/src/body_raw.ml
+++ b/cohttp-async/src/body_raw.ml
@@ -9,7 +9,7 @@ type t = [
 
 let empty = `Empty
 let of_string s = ((B.of_string s) :> t)
-let of_pipe p = `Pipe (Pipe.filter ~f:(fun s -> String.(s <> "")) p)
+let of_pipe p = `Pipe p
 
 let to_string = function
   | #B.t as body -> return (B.to_string body)


### PR DESCRIPTION
Leftover from #713. I missed this earlier, but now that we are
consuming empty strings when we call `is_empty`, we don't need
to change the pipe when constructing the async body.

The Lwt body's `of_stream` and cohttp's `of_string_list` were left untouched already so no change needed there.