### PR TITLE
Fix chunked encoding of empty bodies.

### DIFF
--- a/cohttp/src/transfer_io.ml
+++ b/cohttp/src/transfer_io.ml
@@ -80,9 +80,14 @@ module Make(IO : S.IO) = struct
 
     let write oc buf =
       let len = String.length buf in
-      write oc (Printf.sprintf "%x\r\n" len) >>= fun () ->
-      write oc buf >>= fun () ->
-      write oc "\r\n"
+      (* do NOT send empty chunks, as it signals the end of the
+         chunked body *)
+      if len <> 0 then
+        write oc (Printf.sprintf "%x\r\n" len) >>= fun () ->
+        write oc buf >>= fun () ->
+        write oc "\r\n"
+      else
+        return ()
   end
 
   module Fixed = struct


### PR DESCRIPTION
An empty (zero length) chunk signals the end of an HTTP chunked body encoding. When uploading an empty body or a strings body with an empty string somewhere, that chunked would be sent as a zero length chunk, ending the body per the protocol, and the subsequent chunks (or the final 0 length chunk) would become trailing garbage.

While this is incorrect for one-shot requests but can be recovered from in the parser is permissive, it is absolutely breaking in keep-alive connections as the rest of the body is being parsed as the next HTTP header.