### PR TITLE
Fix logs

### DIFF
--- a/cohttp-lwt-unix-nossl/src/debug.ml
+++ b/cohttp-lwt-unix-nossl/src/debug.ml
@@ -38,7 +38,7 @@ let default_reporter (file_descr, ppf) =
       Lwt.async (fun () -> Lwt.catch
         (fun () -> Lwt.finalize write clean)
         (fun exn ->
-           Logs.warn (fun m -> m "Flushing error: %s.\n%!" (Printexc.to_string exn)) ;
+           Logs.warn (fun m -> m "Flushing error: %s." (Printexc.to_string exn)) ;
            Lwt.return_unit)) ;
       k () in
     let with_metadata header _tags k ppf fmt =
@@ -61,8 +61,9 @@ let set_log = lazy (
 
 let activate_debug () =
   Lazy.force set_log;
-  _debug_active := true;
-  Logs.debug (fun f -> f "Cohttp debugging output is active")
+  if not !_debug_active
+  then ( _debug_active := true
+       ; Logs.debug (fun f -> f "Cohttp debugging output is active") )
 
 let () =
   try (

--- a/cohttp-lwt-unix-nossl/src/dune
+++ b/cohttp-lwt-unix-nossl/src/dune
@@ -4,5 +4,5 @@
  (synopsis "Lwt/Unix backend for Cohttp")
  (preprocess
   (pps ppx_sexp_conv))
- (libraries fmt logs logs.lwt conduit-lwt magic-mime lwt.unix cohttp
+ (libraries fmt logs logs.fmt conduit-lwt magic-mime lwt.unix cohttp
    cohttp-lwt))

--- a/cohttp-lwt-unix-nossl/src/server.ml
+++ b/cohttp-lwt-unix-nossl/src/server.ml
@@ -34,7 +34,7 @@ let respond_file ?headers ~fname () =
               | "" -> None
               | buf -> Some buf)
             (fun exn ->
-               Log.debug
+               Log.warn
                  (fun m -> m "Error resolving file %s (%s)"
                    fname
                    (Printexc.to_string exn));
@@ -63,11 +63,20 @@ let respond_file ?headers ~fname () =
 let log_on_exn =
   function
   | Unix.Unix_error (error, func, arg) ->
-     Logs.warn (fun m -> m "Client connection error %s: %s(%S)"
+     Log.warn (fun m -> m "Client connection error %s: %s(%S)"
        (Unix.error_message error) func arg)
-  | exn -> Logs.err (fun m -> m "Unhandled exception: %a" Fmt.exn exn)
+  | exn -> Log.err (fun m -> m "Unhandled exception: %a" Fmt.exn exn)
+
+let pp_sockaddr ppf = function
+  | Unix.ADDR_UNIX v -> Fmt.pf ppf "<unix:%s>" v
+  | Unix.ADDR_INET (inet_addr, port) -> Fmt.pf ppf "<inet:%s:%d>" (Unix.string_of_inet_addr inet_addr) port
 
 let safe error_handler callback spec flow () =
+  let () = match flow with
+    | Conduit_lwt.TCP.T (Value file_descr) ->
+      let sockaddr = Conduit_lwt.TCP.Protocol.peer file_descr in
+      Log.debug (fun m -> m "Receive a connection from: %a.%!" pp_sockaddr sockaddr) ;
+    | _ -> () in
   Lwt.catch
     (fun () -> let ic, oc = Conduit_lwt.io_of_flow flow in callback spec flow ic oc)
     (fun exn -> error_handler exn)

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -105,6 +105,7 @@ module Make(IO:S.IO) = struct
       `Empty
 
   let handle_request callback conn req body =
+    Log.debug (fun m -> m "Handle request: %a." Request.pp_hum req) ;
     Lwt.finalize
       (fun () ->
          Lwt.catch


### PR DESCRIPTION
This patch wants to fix logs, however, if we look on `conduit-lwt-server`, if we execute it with `COHTTP_DEBUG`, it seems that the verbose option takes the lead on which level should be printed. In other words, if you want logs on `cohttp_lwt_server` you must (even if you prepend with `COHTTP_DEBUG`) use `-vvv`.

This is a fix for #719 