### PR TITLE
Add missing test dependency

### DIFF
--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -34,6 +34,7 @@ depends: [
   "conduit-async" {>="3.0.0"}
   "conduit-async-ssl"
   "magic-mime"
+  "mirage-crypto" {with-test}
   "logs"
   "fmt" {>= "0.8.2"}
   "sexplib0"


### PR DESCRIPTION
With this all Travis builds (except MacOS for the usual issues of brew) are passing on opam-repository, see https://travis-ci.org/github/mseri/opam-repository/builds/741329994

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>