### PR TITLE
Use implicit executable dependency for generate.exe

### DIFF
--- a/cohttp/src/dune
+++ b/cohttp/src/dune
@@ -6,7 +6,6 @@
 (rule
  (targets code.ml code.mli)
  (deps
-  ../scripts/generate.exe
   (source_tree "../scripts/codes"))
  (action
   (chdir


### PR DESCRIPTION
Explicit executable dependencies make dune fail in cross-compilation settings.
More info in https://github.com/ocaml/dune/issues/3917.
