### PR TITLE
Associative list implementation for headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,35 @@
+## ? (2021-03-30)
+(@lyrm #747)
+
++ New implementation of Header modules using an associative list instead of a map, with one major semantic change (function ```get```, see below), and some new functions (```clean_dup```, ```get_multi_concat```)
++ More Alcootest tests as well as fuzzing tests for this particular module.
+
+### Purpose
+
+The new header implementation uses an associative list instead of a map to represent headers and is focused on predictibility and intuitivity: except for some specific and documented functions, the headers are always kept in transmission order, which makes debugging easier and is also important for [RFC7230§3.2.2](https://tools.ietf.org/html/rfc7230#section-3.2.2) that states that multiple values of a header must be kept in order.
+
+Also, to get an intuitive function behaviour, no extra work to enforce RFCs is done by the basic functions. For example, RFC7230§3.2.2 requires that a sender does not send multiple values for a non list-value header. This particular rule could require the ```Header.add``` function to remove previous values of non-list-value headers, which means some changes of the headers would be out of control of the user. With the current implementation, an user has to actively call dedicated functions to enforce such RFCs (here ```Header.clean_dup```).
+
+### Semantic changes
+Two functions have a semantic change : ```get``` and ```update```.
+
+#### get
+```get``` was previously doing more than just returns the value associated to a key; it was also checking if the searched header could have multiple values: if not, the last value associated to the header was returned; otherwise, all the associated values were concatenated and returned. This semantics does not match the global idea behind the new header implementation, and would also be very unefficient.
+
++ The new ```get``` function only returns the last value associated to the searched header.
++ ```get_multi_concat``` function has been added to get a result similar to the previous ```get``` function.
+
+#### update
+```update``` is a pretty new function (#703) and changes are minor and related to ```get``` semantic changes.
+
++ ```update h k f``` is now modifying only the last occurences of the header ```k``` instead of all its occurrences.
++ a new function ```update_all``` function has been added and work on all the occurrences of the updated header.
+
+### New functions :
+
++ ```clean_dup```  enables the user to clean headers that follows the {{:https://tools.ietf.org/html/rfc7230#section-3.2.2} RFC7230§3.2.2} (no duplicate, except ```set-cookie```)
++ ```get_multi_concat``` has been added to get a result similar to the previous ```get``` function.
+
 ## v4.0.0 (2021-03-24)
 
 - cohttp.response: fix malformed status header for custom status codes (@mseri @aalekseyev #752)

--- a/cohttp-async/bin/cohttp_curl_async.ml
+++ b/cohttp-async/bin/cohttp_curl_async.ml
@@ -19,10 +19,7 @@ open Async_kernel
 open Cohttp_async
 
 let show_headers h =
-  Cohttp.Header.iter
-    (fun k v ->
-      List.iter v ~f:(fun v_i -> Logs.info (fun m -> m "%s: %s%!" k v_i)))
-    h
+  Cohttp.Header.iter (fun k v -> Logs.info (fun m -> m "%s: %s%!" k v)) h
 
 let make_net_req uri meth' body () =
   let meth = Cohttp.Code.method_of_string meth' in

--- a/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.ml
+++ b/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.ml
@@ -182,9 +182,7 @@ module Make_client_async (P : Params) = Make_api (struct
             (fun k v ->
               (* some headers lead to errors in the javascript console, should
                  we filter then out here? *)
-              List.iter
-                (fun v -> xml ## (setRequestHeader (Js.string k) (Js.string v)))
-                v)
+              xml ## (setRequestHeader (Js.string k) (Js.string v)))
             headers
     in
 
@@ -278,12 +276,9 @@ module Make_client_sync (P : Params) = Make_api (struct
       | Some headers ->
           C.Header.iter
             (fun k v ->
-              List.iter
-                (* some headers lead to errors in the javascript console, should
-                   we filter then out here? *)
-                  (fun v ->
-                  xml ## (setRequestHeader (Js.string k) (Js.string v)))
-                v)
+              (* some headers lead to errors in the javascript console, should
+                 we filter then out here? *)
+              xml ## (setRequestHeader (Js.string k) (Js.string v)))
             headers
     in
     (* perform call *)

--- a/cohttp-lwt-unix/test/test_parser.ml
+++ b/cohttp-lwt-unix/test/test_parser.ml
@@ -247,10 +247,10 @@ let make_simple_req () =
     "POST /foo/bar HTTP/1.1\r\n\
      foo: bar\r\n\
      host: localhost\r\n\
-     transfer-encoding: chunked\r\n\
      user-agent: "
     ^ user_agent
-    ^ "\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n"
+    ^ "\r\ntransfer-encoding: chunked\
+       \r\n\r\n6\r\nfoobar\r\n0\r\n\r\n"
   in
   let req =
     Request.make ~encoding:Transfer.Chunked ~meth:`POST
@@ -266,10 +266,10 @@ let mutate_simple_req () =
     "POST /foo/bar HTTP/1.1\r\n\
      foo: bar\r\n\
      host: localhost\r\n\
-     transfer-encoding: chunked\r\n\
      user-agent: "
     ^ user_agent
-    ^ "\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n"
+    ^ "\r\ntransfer-encoding: chunked\
+       \r\n\r\n6\r\nfoobar\r\n0\r\n\r\n"
   in
   let req =
     Request.make ~encoding:Transfer.Chunked

--- a/cohttp-lwt-unix/test/test_parser.ml
+++ b/cohttp-lwt-unix/test/test_parser.ml
@@ -24,6 +24,8 @@ let basic_res =
    Server: Apache/1.3.3.7 (Unix) (Red-Hat/Linux)\r\n\
    Last-Modified: Wed, 08 Jan 2003 23:11:55 GMT\r\n\
    Etag: \"3f80f-1b6-3e1cb03b\"\r\n\
+   Accept: text/*\r\n\
+   Accept: application/xml\r\n\
    Accept-Ranges:  none\r\n\
    Content-Length: 0\r\n\
    Connection: close\r\n\
@@ -244,13 +246,9 @@ let make_simple_req () =
   let open Cohttp in
   let open Cohttp_lwt_unix in
   let expected =
-    "POST /foo/bar HTTP/1.1\r\n\
-     foo: bar\r\n\
-     host: localhost\r\n\
-     user-agent: "
+    "POST /foo/bar HTTP/1.1\r\nfoo: bar\r\nhost: localhost\r\nuser-agent: "
     ^ user_agent
-    ^ "\r\ntransfer-encoding: chunked\
-       \r\n\r\n6\r\nfoobar\r\n0\r\n\r\n"
+    ^ "\r\ntransfer-encoding: chunked\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n"
   in
   let req =
     Request.make ~encoding:Transfer.Chunked ~meth:`POST
@@ -263,13 +261,9 @@ let mutate_simple_req () =
   let open Cohttp in
   let open Cohttp_lwt_unix in
   let expected =
-    "POST /foo/bar HTTP/1.1\r\n\
-     foo: bar\r\n\
-     host: localhost\r\n\
-     user-agent: "
+    "POST /foo/bar HTTP/1.1\r\nfoo: bar\r\nhost: localhost\r\nuser-agent: "
     ^ user_agent
-    ^ "\r\ntransfer-encoding: chunked\
-       \r\n\r\n6\r\nfoobar\r\n0\r\n\r\n"
+    ^ "\r\ntransfer-encoding: chunked\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n"
   in
   let req =
     Request.make ~encoding:Transfer.Chunked

--- a/cohttp.opam
+++ b/cohttp.opam
@@ -44,6 +44,7 @@ depends: [
   "fmt" {with-test}
   "jsonm" {build}
   "alcotest" {with-test}
+  "crowbar" {with-test}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/cohttp/fuzz/dune
+++ b/cohttp/fuzz/dune
@@ -1,0 +1,26 @@
+(executable
+  (name fuzz_header)
+  (libraries crowbar cohttp))
+
+(rule
+ (alias runtest)
+  (package cohttp)
+  (action
+    (run ./fuzz_header.exe)))
+
+(rule
+ (alias fuzz)
+ (deps
+  (:exe fuzz_header.exe)
+  (source_tree inputs))
+ (action
+  (run afl-fuzz -i inputs -o findings -- ./%{exe} @@)))
+
+(rule
+ (alias bun-fuzz)
+ (locks %{project_root}/bun)
+ (deps
+  (:exe fuzz_me.exe)
+  (source_tree input))
+ (action
+  (run bun --input inputs --output findings -- ./%{exe})))

--- a/cohttp/fuzz/dune
+++ b/cohttp/fuzz/dune
@@ -1,12 +1,12 @@
 (executable
-  (name fuzz_header)
-  (libraries crowbar cohttp))
+ (name fuzz_header)
+ (libraries crowbar cohttp))
 
 (rule
  (alias runtest)
-  (package cohttp)
-  (action
-    (run ./fuzz_header.exe)))
+ (package cohttp)
+ (action
+  (run ./fuzz_header.exe)))
 
 (rule
  (alias fuzz)

--- a/cohttp/fuzz/fuzz_header.ml
+++ b/cohttp/fuzz/fuzz_header.ml
@@ -73,7 +73,8 @@ let list_value_header_gen =
   let printer fmt str = pp fmt "%s" str in
   with_printer printer gen
 
-(** Generate a tchar following {{https://tools.ietf.org/html/rfc7230#appendix-B}RFC 7230}.
+(** Generate a tchar following
+    {{:https://tools.ietf.org/html/rfc7230#appendix-B} RFC 7230}.
 
     tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" /
     "_" / "`" / "|" / "~" / DIGIT / ALPHA *)

--- a/cohttp/fuzz/fuzz_header.ml
+++ b/cohttp/fuzz/fuzz_header.ml
@@ -1,0 +1,562 @@
+(*{{{ Copyright (c) 2021 Carine Morel <carine@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *}}}*)
+
+module H = Cohttp.Header
+
+(** Here, we test the Header module with fuzzing. Some of these tests may be
+    redundant with Alcotest tests.
+
+    The tests are launched with [dune runtest] but can also be run with [afl]
+    with the command line : [dune build @cohttp/fuzz/fuzz --no-buffer].
+
+    The tests below reflects the semantics we want for each function, however in
+    some cases, it may actually be specific to the current implementation and
+    does not necessary need to be enforced in future implementations. To make it
+    clear, tests are annoted by their categories:
+
+    - FS (Functions semantics): tests the semantics described in the
+      documentation.
+
+    - SI (Specific to current Implementation): these tests are here to check the
+      implementation is doing what we thing it is doing but may change
+      accordingly to implementation changes. *)
+
+(* Generators *)
+let list_value_headers =
+  [|
+    "accept";
+    "accept-charset";
+    "accept-encoding";
+    "accept-language";
+    "accept-ranges";
+    "allow";
+    "cache-control";
+    "connection";
+    "content-encoding";
+    "content-language";
+    "expect";
+    "if-match";
+    "if-none-match";
+    "link";
+    "pragma";
+    "proxy-authenticate";
+    "te";
+    "trailer";
+    "transfer-encoding";
+    "upgrade";
+    "vary";
+    "via";
+    "warning";
+    "www-authenticate";
+  |]
+
+(** Pick a random list-value header name from a predefined array of values. *)
+let list_value_header_gen =
+  let open Crowbar in
+  let gen =
+    map
+      [ range (Array.length list_value_headers) ]
+      (fun i -> list_value_headers.(i))
+  in
+  let printer fmt str = pp fmt "%s" str in
+  with_printer printer gen
+
+(** Generate a tchar following {{https://tools.ietf.org/html/rfc7230#appendix-B}RFC 7230}.
+
+    tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" /
+    "_" / "`" / "|" / "~" / DIGIT / ALPHA *)
+let tchar_gen =
+  let tchar_code_gen =
+    let uppercased_letter = Crowbar.range ~min:65 26 in
+    let lowercased_letter = Crowbar.range ~min:97 26 in
+    let others =
+      List.map
+        (fun i -> Crowbar.const i)
+        [
+          33 (* ! *);
+          35 (* # *);
+          36 (* $ *);
+          37 (* % *);
+          38 (* & *);
+          42 (* * *);
+          43 (* + *);
+          45 (* - *);
+          46 (* . *);
+          94 (* ^ *);
+          95 (* _ *);
+          96 (* ` *);
+          124 (* | *);
+          126 (* ~ *);
+        ]
+      |> Crowbar.choose
+    in
+    let digit_and_others = Crowbar.(choose [ others; range ~min:48 10 ]) in
+    Crowbar.(choose [ lowercased_letter; uppercased_letter; digit_and_others ])
+  in
+  Crowbar.(map [ tchar_code_gen ] (fun i -> Char.escaped (Char.chr i)))
+
+(** Generate a non-emoty word of arbitrary length (composed of letters only). *)
+let word_gen =
+  let open Crowbar in
+  let gen =
+    fix (fun word_gen ->
+        choose
+          [
+            (* one letter word *)
+            tchar_gen;
+            (* two letters word *)
+            map [ tchar_gen; tchar_gen ] (fun l1 l2 -> l1 ^ l2);
+            (* add one letter *)
+            map [ tchar_gen; word_gen ] (fun l w -> l ^ w);
+          ])
+  in
+  let printer = pp_string in
+  with_printer printer gen
+
+(** Generate an header name: either a predefined list-value header or a random
+    word *)
+let header_name_gen =
+  let open Crowbar in
+  let gen = choose [ list_value_header_gen; word_gen ] in
+  let printer = pp_string in
+  with_printer printer gen
+
+let header_printer fmt (k, v) = Crowbar.pp fmt "%s, %s" k v
+
+(** Generate a header key/value pair *)
+let header_gen : (string * string) Crowbar.gen =
+  let open Crowbar in
+  let gen_setcookie = pair (const "Set-cookie") word_gen in
+  let gen_otherheader = pair header_name_gen word_gen in
+  let gen =
+    (* one in ten generate header is a "set-cookie" header *)
+    choose (gen_setcookie :: List.init 9 (fun _ -> gen_otherheader))
+  in
+  with_printer header_printer gen
+
+(** Generate a list of headers *)
+let header_list_gen : (string * string) list Crowbar.gen =
+  let open Crowbar in
+  let gen = list header_gen in
+  let printer = pp_list header_printer in
+  with_printer printer gen
+
+(** Generate a [Cohttp.Header.t] headers. *)
+let headers_gen : H.t Crowbar.gen =
+  let open Crowbar in
+  let gen =
+    fix (fun headers_gen ->
+        choose
+          [
+            (* empty header *)
+            const (H.init ());
+            (* add one pair (k, v) *)
+            map [ header_gen; headers_gen ] (fun (k, v) h -> H.add h k v);
+            (* add a list of headers *)
+            map [ headers_gen; header_list_gen ] (fun h l -> H.add_list h l);
+          ])
+  in
+  let printer fmt h = Crowbar.pp fmt "\n%s@." (H.to_string h) in
+  with_printer printer gen
+
+(* Tests *)
+(* Important note : keys must be lowercased before comparison *)
+let eqssl l1 l2 =
+  List.map (fun (k, v) -> (String.lowercase_ascii k, v)) l1
+  = List.map (fun (k, v) -> (String.lowercase_ascii k, v)) l2
+
+let is_empty_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall h, k, v. is_empty (add h k v) = false) *)
+    add_test ~name:"[is_empty] returns false on a non empty header"
+      [ headers_gen; header_name_gen; word_gen ] (fun h k v ->
+        check_eq false H.(is_empty (add h k v))))
+
+let init_with_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall k v. to_list (init_with k v) = [String.lowercase k, v] *)
+    add_test ~name:"[init_list k v] is [k, v]" [ header_name_gen; word_gen ]
+      (fun k v ->
+        check_eq H.(to_list (init_with k v)) [ (String.lowercase_ascii k, v) ]))
+
+let mem_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall k. mem (init ()) k = false *)
+    add_test ~name:"[mem h k] on an empty header is always false"
+      [ header_name_gen ] (fun k -> check_eq false H.(mem (init ()) k));
+    (* SI *)
+    (* forall h, k. H.mem h k = List.(mem_assoc k (H.to_list h)) *)
+    add_test ~name:"Header.mem has the same behavior than List.mem_assoc"
+      [ headers_gen; header_name_gen ] (fun h k ->
+        check_eq
+          H.(mem h k)
+          List.(mem_assoc (String.lowercase_ascii k) (H.to_list h))))
+
+let add_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall k, v, h. mem (add h k v) k = true *)
+    add_test ~name:"mem (add h k v) k  = true"
+      [ headers_gen; header_name_gen; word_gen ] (fun h k v ->
+        check_eq true H.(mem (add h k v) k));
+    add_test
+    (* FS *)
+    (* forall h, k, v. to_list (add h k v) = to_list h @ [lowercase k, v] *)
+      ~name:"[add] adds a value at the header end"
+      [ headers_gen; header_name_gen; word_gen ] (fun h k v ->
+        check_eq
+          (H.to_list h @ [ (String.lowercase_ascii k, v) ])
+          H.(to_list (add h k v))))
+
+let to_list_of_list_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall h. to_list (of_list h) = h (with lowercase key comparison) *)
+    add_test ~name:"to_list (of_list h) = h" [ header_list_gen ] (fun h ->
+        check_eq ~eq:eqssl H.(to_list (of_list h)) h);
+
+    (* FS and RFC *)
+    (* forall h, k1, v1, k2, v2. to_list (add (add h k1 v1) k2 v2) = to_list \
+       h @ [k1, v1; k2, v2] *)
+    add_test ~name:"checking [to_list] order after multiple [add] calls"
+      [ headers_gen; header_name_gen; word_gen; header_name_gen; word_gen ]
+      (fun h k1 v1 k2 v2 ->
+        check_eq ~eq:eqssl
+          H.(to_list (add (add h k1 v1) k2 v2))
+          H.(to_list h @ [ (k1, v1); (k2, v2) ])))
+
+let add_opt_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall hopt, k, v.
+              add_opt hopt k v = | add h k v     if hopt = Some h
+                                 | init_with k v if hopt = None *)
+    add_test ~name:"add_opt (Some h) = add and add_opt None = init_with"
+      [ option headers_gen; header_name_gen; word_gen ] (fun hopt k v ->
+        check_eq
+          H.(match hopt with None -> init_with k v | Some h -> add h k v)
+          H.(add_opt hopt k v)))
+
+let add_unless_exists_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall h, k, v. if mem h k = true then add_unless_exists h k v = h *)
+    add_test ~name:"[add_unless_exists h k v] does nothing if k exists"
+      [ headers_gen; header_list_gen; header_name_gen; word_gen; word_gen ]
+      (fun h l k v1 v2 ->
+        (* A random header such as mem h k = true *)
+        let h = H.(add_list (add h k v1) l) in
+        check_eq H.(add_unless_exists h k v2) h);
+    (* FS *)
+    (* forall h, k, v. if mem h k = false then add_unless_exists h k v = add \
+         h k v *)
+    add_test ~name:"add_unless_exists = add if key does not exist"
+      [ headers_gen; header_name_gen; word_gen ] (fun h k v ->
+        (* Making sure as mem h k = false *)
+        guard (not (H.mem h k));
+        check_eq H.(add_unless_exists h k v) H.(add h k v)))
+
+let add_list () =
+  Crowbar.(
+    (* FS *)
+    (* forall h, l. to_list (add_list h l) = to_list h @ l *)
+    add_test
+      ~name:"[add_list h l] adds all headers in [l] in order at the end of [h]"
+      [ headers_gen; header_list_gen ] (fun h l ->
+        check_eq ~eq:eqssl H.(to_list (add_list h l)) H.(to_list h @ l)))
+
+let add_multi () =
+  Crowbar.(
+    (* FS *)
+    (* forall h, k, vs. add_multi h k vs = add_list h (List.map (fun v -> k, v) vs) *)
+    add_test ~name:"[add_list] and [add_multi] have compatible semantics"
+      [ headers_gen; header_name_gen; list word_gen ] (fun h k vs ->
+        check_eq
+          H.(add_multi h k vs)
+          H.(add_list h (List.map (fun v -> (k, v)) vs)));
+    (* FS *)
+    (* forall h, k, l. get_multi (add_multi h k l) k = get_multi h k @ l *)
+    add_test ~name:"get_multi (add_multi h k l) k = get_multi h k @ l"
+      [ headers_gen; header_name_gen; Crowbar.list word_gen ] (fun h k l ->
+        check_eq H.(get_multi (add_multi h k l) k) H.(get_multi h k @ l)))
+
+let get_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall h k, if mem h k = false then get h k = None *)
+    add_test ~name:"[get h k] returns None if k does not exists in h"
+      [ headers_gen; header_name_gen ] (fun h k ->
+        guard H.(not (mem h k));
+        check_eq H.(get h k) None);
+    (* FS *)
+    (* forall h k, get (add h k v) = Some v *)
+    add_test ~name:"get (add h k v) = Some v"
+      [ headers_gen; header_name_gen; word_gen ] (fun h k v ->
+        check_eq H.(get (add h k v) k) (Some v)))
+
+let get_multi_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall h k, if mem h k = false then get_multi h k = [] *)
+    add_test ~name:"[get_multi h k] returns [] if k does not exists in h"
+      [ headers_gen; header_name_gen ] (fun h k ->
+        guard H.(not (mem h k));
+        check_eq H.(get_multi h k) []);
+    (* FS *)
+    (* forall l1, l2, k, v.
+          get_multi (of_list (l1 @ [ (k, v) ] @ l2)) k =
+          get_multi (of_list l1) k @ [ v ] @ get_multi (of_list l2) k *)
+    add_test ~name:"[get_multi] returns values in transmission order"
+      [ header_list_gen; header_list_gen; header_name_gen; word_gen ]
+      (fun l1 l2 k v ->
+        check_eq
+          H.(get_multi (of_list (l1 @ [ (k, v) ] @ l2)) k)
+          H.(get_multi (of_list l1) k @ [ v ] @ get_multi (of_list l2) k));
+    (* FS and RFC7230§3.2.2 *)
+    (* forall h, v1, v2, forall k in list values headers.
+            get_multi (add (add h k v1) k v2)) k = get_multi h k @ [v1; v2] *)
+    add_test ~name:"headers order is preserved"
+      [ headers_gen; list_value_header_gen; word_gen; word_gen ]
+      (fun h k v1 v2 ->
+        check_eq
+          H.(get_multi (add (add h k v1) k v2) k)
+          (H.(get_multi h k) @ [ v1; v2 ])))
+
+let remove_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall h, k. mem (remove h k) k = false *)
+    add_test ~name:"[remove] removes all values associated to a key"
+      [ headers_gen; header_name_gen ] (fun h k ->
+        check_eq false H.(mem (remove h k) k));
+    (* FS *)
+    (* forall h, k. remove (remove h k) k = remove h k*)
+    add_test ~name:"(fun x -> remove x k) is idempotent"
+      [ headers_gen; header_name_gen ] (fun h k ->
+        check_eq H.(remove (remove h k) k) H.(remove h k)))
+
+let replace_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall h, k, v. get_multi (replace h k v) = [ v ] *)
+    add_test ~name:"[replace] replaces the last value and remove the others"
+      [ headers_gen; header_list_gen; header_name_gen; word_gen; word_gen ]
+      (fun h l k v1 v2 ->
+        check_eq H.(get_multi (replace h k v1) k) [ v1 ];
+        (* This second check is to make sure the case where mem h k = true is tested *)
+        let h =
+          H.(add_list (add h k v1) l)
+          (* h is built such as mem h k = true *)
+        in
+        check_eq H.(get_multi (replace h k v2) k) [ v2 ]);
+    (* FS *)
+    (* forall h, k, v. if mem h k = false then replace h k v = add h k v) *)
+    add_test ~name:"replace h k v = add h k v if k does not exists in h"
+      [ headers_gen; header_name_gen; word_gen ] (fun h k v ->
+        guard H.(mem h k = false);
+        check_eq H.(replace h k v) H.(add h k v));
+    (* SI *)
+    (* forall h, l, k, v1, v2.
+           if mem (of_list l) k = false then
+              replace (add_list h ([ k, v1 ] @ l)) k v2 =
+             add_list (add (remove h k) k v2) l k) *)
+    add_test ~name:"[replace] does not change headers order"
+      [ headers_gen; header_list_gen; header_name_gen; word_gen; word_gen ]
+      (fun h l k v1 v2 ->
+        guard H.(not (mem (of_list l) k));
+        (* A random headers such as mem h k = true *)
+        let h1 = H.(add_list h ([ (k, v1) ] @ l)) in
+        let h2 = H.(add_list (remove h k) ([ (k, v2) ] @ l)) in
+        check_eq ~eq:eqssl H.(to_list (replace h1 k v2)) H.(to_list h2)))
+
+let update_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall h k, update h k id = h  *)
+    add_test ~name:"[update h k id] does nothing"
+      [ headers_gen; header_name_gen ] (fun h k ->
+        check_eq H.(update h k (fun x -> x)) h);
+    (*FS*)
+    (* forall h k f, remove (update h k f) k = remove h k *)
+    add_test ~name:"[update h k _] only changes k "
+      [ headers_gen; header_name_gen; word_gen ] (fun h k w ->
+        check_eq H.(remove (update h k (fun _ -> None)) k) H.(remove h k);
+        check_eq H.(remove (update h k (fun _ -> Some w)) k) H.(remove h k));
+    (*FS*)
+    add_test ~name:"[update h k (fun _ -> None)] removes last occurence of k."
+      [ headers_gen; header_name_gen ] (fun h k ->
+        let h1 = H.update h k (fun _ -> None) in
+        let r1 = H.get_multi h1 k in
+        let r2 =
+          match List.rev (H.get_multi h k) with
+          | [] -> []
+          | _ :: xs -> List.rev xs
+        in
+        check_eq r1 r2);
+    (*FS*)
+    add_test
+      ~name:
+        "[update h k (function Some _ -> Some w)] replaces last occurence of k."
+      [ headers_gen; header_name_gen; word_gen ] (fun h k w ->
+        let h1 = H.update h k (fun _ -> Some w) in
+        let r1 = H.get_multi h1 k in
+        let r2 =
+          match List.rev (H.get_multi h k) with
+          | [] -> [ w ]
+          | _ :: xs -> List.rev (w :: xs)
+        in
+        check_eq r1 r2))
+
+let update_all_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall h k, update_all h k id = h  *)
+    add_test ~name:"[update_all h k id] does nothing"
+      [ headers_gen; header_name_gen ] (fun h k ->
+        check_eq H.(update_all h k (fun x -> x)) h);
+    (*FS*)
+    (* forall h k f, remove (update_all h k f) k = remove h k *)
+    add_test ~name:"[update_all h k _] only changes k "
+      [ headers_gen; header_name_gen; word_gen ] (fun h k w ->
+        check_eq H.(remove (update_all h k (fun _ -> [])) k) H.(remove h k);
+        check_eq H.(remove (update_all h k (fun _ -> [ w ])) k) H.(remove h k));
+    (*FS*)
+    add_test ~name:"[update_all h k (fun _ -> [])] removes all occurences of k."
+      [ headers_gen; header_name_gen ] (fun h k ->
+        let h1 = H.update_all h k (fun _ -> []) in
+        check_eq H.(get_multi h1 k) []);
+    (*FS*)
+    add_test
+      ~name:
+        "[update_all h k (function _ -> [w])] removes all occurences of k and \
+         add one." [ headers_gen; header_name_gen; word_gen ] (fun h k w ->
+        let h1 = H.update_all h k (fun _ -> [ w ]) in
+        let r1 = H.get_multi h1 k in
+        let r2 = [ w ] in
+        check_eq r1 r2))
+
+let get_multi_concat_test () =
+  Crowbar.(
+    (* FS *)
+    (* forall h, k. if mem h k = false then get_multi_concat h k = None *)
+    add_test
+      ~name:"[get_multi_concat h k] returns \"\" if k does not exists in h"
+      [ headers_gen; header_name_gen ] (fun h k ->
+        guard H.(not (mem h k));
+        check_eq H.(get_multi_concat h k) None);
+    (* FS *)
+    (* forall h, k. get_multi_concat ~list_value_only:true h k = get h k
+       if k is not a list value header *)
+    add_test ~name:"[get_multi_concat] optional argument works properly"
+      [ headers_gen; word_gen ] (fun h k ->
+        guard (not (Array.mem (String.lowercase_ascii k) list_value_headers));
+        check_eq H.(get_multi_concat ~list_value_only:true h k) H.(get h k));
+    (* FS - Very important for RFC 7230.3.2.2 *)
+    add_test ~name:"[get_multi_concat] returns values in transmission order"
+      [ header_list_gen; header_list_gen; header_name_gen; word_gen ]
+      (fun l1 l2 k v ->
+        let str_opt ?(bfr = false) ?(aft = false) s =
+          match s with
+          | None -> ""
+          | Some v -> if bfr then "," ^ v else if aft then v ^ "," else v
+        in
+        check_eq
+          H.(str_opt (get_multi_concat (of_list (l1 @ [ (k, v) ] @ l2)) k))
+          H.(
+            str_opt ~aft:true (get_multi_concat (of_list l1) k)
+            ^ v
+            ^ str_opt ~bfr:true (get_multi_concat (of_list l2) k))))
+
+(* Note : clean_dup does nothing to already concatenated headers. For
+   example, ["a", "v1,v2"] will be not be cleaned. *)
+let clean_dup_test () =
+  Crowbar.(
+    (* FS *)
+    (* Check that there is no more duplicates (except set-cookie). *)
+    add_test
+      ~name:
+        "All headers name in [h] appears strictly once in [clean_dup h] except \
+         for [set-cookie]" [ headers_gen ] (fun h ->
+        let h = H.remove h "set-cookie" in
+        let h = H.(to_list (clean_dup h)) in
+        let compare_key (k, _) (k', _) = compare k k' in
+        check_eq (List.sort_uniq compare_key h) (List.sort compare_key h));
+    (* FS *)
+    (* forall h, k in list_value_headers.
+       String.concat "," (get_multi_concat h k) = get (clean_dup h) k *)
+    add_test ~name:"[clean_dup] concatenates properly list-value headers"
+      [ headers_gen; list_value_header_gen ] (fun h k ->
+        check_eq H.(get_multi_concat h k) H.(get (clean_dup h) k));
+    (* FS *)
+    (* forall h. clean_dup (clean_dup h) = clean_dup h *)
+    add_test ~name:"[clean_dup] is idempotent" [ headers_gen ] (fun h ->
+        check_eq H.(clean_dup (clean_dup h)) H.(clean_dup h));
+    (* FS *)
+    (* forall h. get_multi (clean_dup h) "set-cookie" = get_multi h "set-cookie"*)
+    add_test ~name:"[clean_dup] does nothing to [set-cookie] headers"
+      [ headers_gen ] (fun h ->
+        check_eq
+          H.(get_multi h "set-cookie")
+          H.(get_multi (clean_dup h) "set-cookie"));
+    (* FS *)
+    (* As the generated header values are only composed of letters (it
+       does not generate concatenated values like "gzip,chunked"), the
+       only cases where there are commas in a value is if [clean_dup]
+       concatenated multiple values.
+
+       This test checks that only one value is kept for non-list-value
+       headers and that this value is the last one. *)
+    add_test
+      ~name:"Only list-value headers can have multiple concatenated values "
+      [ headers_gen ] (fun h ->
+        (* As it is an exception, [set-cookie] is removed. *)
+        let h = H.remove h "set-cookie" in
+        let h' = H.(clean_dup h) in
+        let has_multiple_values v =
+          match String.split_on_char ',' v with
+          | [] | [ _ ] -> false
+          | _ -> true
+        in
+        check_eq true
+          H.(
+            fold
+              (fun k v b ->
+                if Array.mem k list_value_headers then b
+                else if has_multiple_values v then false
+                else b && get h k = Some v)
+              h' true)))
+
+let () =
+  init_with_test ();
+  is_empty_test ();
+  mem_test ();
+  add_test ();
+  to_list_of_list_test ();
+  add_opt_test ();
+  add_unless_exists_test ();
+  add_list ();
+  add_multi ();
+  get_test ();
+  get_multi_test ();
+  get_multi_concat_test ();
+  remove_test ();
+  replace_test ();
+  update_test ();
+  update_all_test ();
+  clean_dup_test ();
+  ()

--- a/cohttp/fuzz/fuzz_header.ml
+++ b/cohttp/fuzz/fuzz_header.ml
@@ -445,7 +445,7 @@ let update_all_test () =
     add_test
       ~name:
         "[update_all h k (function _ -> [w])] removes all occurences of k and \
-         add one." [ headers_gen; header_name_gen; word_gen ] (fun h k w ->
+         adds w." [ headers_gen; header_name_gen; word_gen ] (fun h k w ->
         let h1 = H.update_all h k (fun _ -> [ w ]) in
         let r1 = H.get_multi h1 k in
         let r2 = [ w ] in

--- a/cohttp/fuzz/fuzz_header.ml
+++ b/cohttp/fuzz/fuzz_header.ml
@@ -30,7 +30,7 @@ module H = Cohttp.Header
       documentation.
 
     - SI (Specific to current Implementation): these tests are here to check the
-      implementation is doing what we thing it is doing but may change
+      implementation is doing what we think it is doing but may change
       accordingly to implementation changes. *)
 
 (* Generators *)
@@ -108,7 +108,7 @@ let tchar_gen =
   in
   Crowbar.(map [ tchar_code_gen ] (fun i -> Char.escaped (Char.chr i)))
 
-(** Generate a non-emoty word of arbitrary length (composed of letters only). *)
+(** Generate a non-empty word of arbitrary length (composed of tchar only). *)
 let word_gen =
   let open Crowbar in
   let gen =
@@ -142,7 +142,7 @@ let header_gen : (string * string) Crowbar.gen =
   let gen_setcookie = pair (const "Set-cookie") word_gen in
   let gen_otherheader = pair header_name_gen word_gen in
   let gen =
-    (* one in ten generate header is a "set-cookie" header *)
+    (* one in ten generated header is a "set-cookie" header *)
     choose (gen_setcookie :: List.init 9 (fun _ -> gen_otherheader))
   in
   with_printer header_printer gen
@@ -515,7 +515,7 @@ let clean_dup_test () =
           H.(get_multi h "set-cookie")
           H.(get_multi (clean_dup h) "set-cookie"));
     (* FS *)
-    (* As the generated header values are only composed of letters (it
+    (* As the generated header values are only composed of tchar (it
        does not generate concatenated values like "gzip,chunked"), the
        only cases where there are commas in a value is if [clean_dup]
        concatenated multiple values.

--- a/cohttp/fuzz/inputs/input
+++ b/cohttp/fuzz/inputs/input
@@ -1,0 +1,1 @@
+something

--- a/cohttp/src/header.ml
+++ b/cohttp/src/header.ml
@@ -30,12 +30,126 @@ end = struct
   let compare a b = String.compare a b
 end
 
-module StringMap = Map.Make (LString)
+type t = (LString.t * string) list
 
-type t = string list StringMap.t
+let compare = Stdlib.compare
+let init () = []
+let is_empty = function [] -> true | _ -> false
+let init_with k v = [ (LString.of_string k, v) ]
 
-let user_agent = Printf.sprintf "ocaml-cohttp/%s" Conf.version
-let compare = StringMap.compare Stdlib.compare
+let mem h k =
+  let k = LString.of_string k in
+  let rec loop = function
+    | [] -> false
+    | (k', _) :: h' -> if LString.compare k k' = 0 then true else loop h'
+  in
+  loop h
+
+let add h k v : t = (LString.of_string k, v) :: h
+let add_list h l = List.fold_left (fun h (k, v) -> add h k v) h l
+let add_multi h k l = List.fold_left (fun h v -> add h k v) h l
+
+let add_opt h_opt k v =
+  match h_opt with None -> init_with k v | Some h -> add h k v
+
+let add_unless_exists h k v = if mem h k then h else add h k v
+
+let add_opt_unless_exists h k v =
+  match h with None -> init_with k v | Some h -> add_unless_exists h k v
+
+let get h k =
+  let k = LString.of_string k in
+  let rec loop h =
+    match h with
+    | [] -> None
+    | (k', v) :: h' -> if LString.compare k k' = 0 then Some v else loop h'
+  in
+  loop h
+
+let get_multi (h : t) (k : string) =
+  let rec loop h acc =
+    match h with
+    | [] -> acc
+    | (k', v) :: h' ->
+        if LString.compare (LString.of_string k) k' = 0 then loop h' (v :: acc)
+        else loop h' acc
+  in
+  loop h []
+
+let remove h k =
+  let k = LString.of_string k in
+  let rec loop seen = function
+    | [] -> if seen then [] else raise Not_found
+    | (k', _) :: h when LString.compare k k' = 0 -> loop true h
+    | x :: h -> x :: loop seen h
+  in
+  try loop false h with Not_found -> h
+
+(* Same effect than the previous [replace] function *)
+let replace h k v =
+  let k' = LString.of_string k in
+  let rec loop seen = function
+    | [] -> if seen then [] else raise Not_found
+    | (k'', _) :: h when LString.compare k' k'' = 0 ->
+        if not seen then
+          (k', v) :: loop true h (* First occurrence found is replaced *)
+        else loop seen h (* Others are removed *)
+    | x :: h -> x :: loop seen h
+  in
+  try loop false h with Not_found -> add h k v
+
+(* Different effect than previous [update] function : replace the value is *)
+(* Does not make a lot of sens with the possibilities of duplicate header *)
+(* Maybe use "get_multi" instead ? *)
+let update h k f =
+  let vorig = get h k in
+  match (f vorig, vorig) with
+  | None, None -> h
+  | None, _ -> remove h k
+  | Some s, Some s' when s == s' -> h
+  | Some s, _ -> replace h k s
+
+let map (f : string -> string -> string) (h : t) : t =
+  List.map
+    (fun (k, v) ->
+      let vs' = f (LString.to_string k) v in
+      (k, vs'))
+    h
+
+let iter (f : string -> string -> unit) (h : t) : unit =
+  List.iter (fun (k, v) -> f (LString.to_string k) v) h
+
+let fold (f : string -> string -> 'a -> 'a) (h : t) (init : 'a) : 'a =
+  List.fold_left (fun acc (k, v) -> f (LString.to_string k) v acc) init h
+
+let of_list h =
+  List.fold_left (fun acc (k, v) -> (LString.of_string k, v) :: acc) [] h
+
+let to_list h =
+  List.fold_left (fun acc (k, v) -> (LString.to_string k, v) :: acc) [] h
+
+let to_lines (h : t) =
+  let header_line k v = Printf.sprintf "%s: %s\r\n" k v in
+  List.fold_left
+    (fun acc (k, v) -> header_line (LString.to_string k) v :: acc)
+    [] h
+
+let to_frames h =
+  let to_frame k v = Printf.sprintf "%s: %s" k v in
+  List.fold_left
+    (fun acc (k, v) -> to_frame (LString.to_string k) v :: acc)
+    [] h
+
+let to_string h =
+  let b = Buffer.create 128 in
+  to_list h
+  |> List.iter (fun (k, v) ->
+         Buffer.add_string b k;
+         Buffer.add_string b ": ";
+         Buffer.add_string b v;
+         Buffer.add_string b "\r\n");
+  Buffer.add_string b "\r\n";
+  Buffer.contents b
 
 let headers_with_list_values =
   Array.map LString.of_string
@@ -66,101 +180,32 @@ let headers_with_list_values =
       "www-authenticate";
     |]
 
-let is_transfer_encoding =
-  let k = LString.of_string "transfer-encoding" in
-  fun k' -> LString.compare k k' = 0
-
 let is_header_with_list_value =
   let tbl = Hashtbl.create (Array.length headers_with_list_values) in
   headers_with_list_values |> Array.iter (fun h -> Hashtbl.add tbl h ());
   fun h -> Hashtbl.mem tbl h
 
-let init () = StringMap.empty
-let is_empty x = StringMap.is_empty x
-let init_with k v = StringMap.singleton (LString.of_string k) [ v ]
+let clean_dup (h : t) : t =
+  let add h k v =
+    let to_add = ref false in
+    let rec loop = function
+      | [] ->
+          to_add := true;
+          []
+      | (k', v') :: hs ->
+          if LString.compare k k' = 0 then
+            if is_header_with_list_value k then (k, v' ^ ", " ^ v) :: hs
+            else (
+              to_add := true;
+              hs)
+          else (k', v') :: loop hs
+    in
+    let h = loop h in
+    if !to_add then (k, v) :: h else h
+  in
+  List.rev h |> List.fold_left (fun acc (k, v) -> add acc k v) []
 
-let add h k v =
-  let k = LString.of_string k in
-  try
-    if is_transfer_encoding k then
-      StringMap.add k (StringMap.find k h @ [ v ]) h
-    else StringMap.add k (v :: StringMap.find k h) h
-  with Not_found -> StringMap.add k [ v ] h
-
-let add_list h l = List.fold_left (fun h (k, v) -> add h k v) h l
-let add_multi h k l = List.fold_left (fun h v -> add h k v) h l
-let add_opt h k v = match h with None -> init_with k v | Some h -> add h k v
-
-let remove h k =
-  let k = LString.of_string k in
-  StringMap.remove k h
-
-let replace h k v =
-  let k = LString.of_string k in
-  StringMap.add k [ v ] h
-
-let get h k =
-  let k = LString.of_string k in
-  try
-    let v = StringMap.find k h in
-    if is_header_with_list_value k then Some (String.concat "," v)
-    else Some (List.hd v)
-  with Not_found | Failure _ -> None
-
-let update h k f =
-  let vorig = get h k in
-  let k = LString.of_string k in
-  match (f vorig, vorig) with
-  | None, _ -> StringMap.remove k h
-  | Some s, Some s' when s == s' -> h
-  | Some s, _ ->
-      let v' =
-        if is_header_with_list_value k then String.split_on_char ',' s
-        else [ s ]
-      in
-      StringMap.add k v' h
-
-let mem h k = StringMap.mem (LString.of_string k) h
-let add_unless_exists h k v = if mem h k then h else add h k v
-
-let add_opt_unless_exists h k v =
-  match h with None -> init_with k v | Some h -> add_unless_exists h k v
-
-let get_multi h k =
-  let k = LString.of_string k in
-  try StringMap.find k h with Not_found -> []
-
-let map fn h = StringMap.mapi (fun k v -> fn (LString.to_string k) v) h
-let iter fn h = ignore (map fn h)
-
-let fold fn h acc =
-  StringMap.fold
-    (fun k v acc ->
-      List.fold_left (fun acc v -> fn (LString.to_string k) v acc) acc v)
-    h acc
-
-let of_list l = List.fold_left (fun h (k, v) -> add h k v) (init ()) l
-let to_list h = List.rev (fold (fun k v acc -> (k, v) :: acc) h [])
-let header_line k v = Printf.sprintf "%s: %s\r\n" k v
-let to_lines h = List.rev (fold (fun k v acc -> header_line k v :: acc) h [])
-
-let to_frames =
-  let to_frame k v acc = Printf.sprintf "%s: %s" k v :: acc in
-  fun h -> List.rev (fold to_frame h [])
-
-let to_string h =
-  let b = Buffer.create 128 in
-  h
-  |> iter (fun k v ->
-         v
-         |> List.iter (fun v ->
-                Buffer.add_string b k;
-                Buffer.add_string b ": ";
-                Buffer.add_string b v;
-                Buffer.add_string b "\r\n"));
-  Buffer.add_string b "\r\n";
-  Buffer.contents b
-
+(** original content *)
 let parse_content_range s =
   try
     let start, fini, total =
@@ -269,6 +314,8 @@ let get_links headers =
 
 let add_links headers links =
   add_multi headers "link" (List.map Link.to_string links)
+
+let user_agent = Printf.sprintf "ocaml-cohttp/%s" Conf.version
 
 let prepend_user_agent headers user_agent =
   let k = "user-agent" in

--- a/cohttp/src/header.mli
+++ b/cohttp/src/header.mli
@@ -156,7 +156,7 @@ val to_frames : t -> string list
 val to_string : t -> string
 
 val clean_dup : t -> t
-(** [clean_dup h] cleans duplicates in h following
+(** [clean_dup h] cleans duplicates in [h] following
     {{:https://tools.ietf.org/html/rfc7230#section-3.2.2} RFC7230§3.2.2}; if a
     duplicated header can not have multiple values, only the last value is kept
     in place. Otherwise, the values are concatenated and place at the first

--- a/cohttp/src/header_io.ml
+++ b/cohttp/src/header_io.ml
@@ -25,18 +25,14 @@ module Make (IO : S.IO) = struct
   open IO
   module Transfer_IO = Transfer_io.Make (IO)
 
-  let rev _k v = List.rev v
-
   let parse ic =
     (* consume also trailing "^\r\n$" line *)
     let rec parse_headers' headers =
       read_line ic >>= function
-      | Some "" | None -> return (Header.map rev headers)
+      | Some "" | None -> return headers
       | Some line -> (
           match split_header line with
-          | [ hd; tl ] ->
-              let header = String.lowercase_ascii hd in
-              parse_headers' (Header.add headers header tl)
+          | [ hd; tl ] -> parse_headers' (Header.add headers hd tl)
           | _ -> return headers)
     in
     parse_headers' (Header.init ())

--- a/cohttp/test/dune
+++ b/cohttp/test/dune
@@ -12,7 +12,7 @@
 
 (executable
  (name test_header)
- (modules test_header)
+ (modules unitary_test_header test_header)
  (forbidden_libraries base)
  (libraries cohttp alcotest fmt))
 

--- a/cohttp/test/test_header.ml
+++ b/cohttp/test/test_header.ml
@@ -13,10 +13,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *}}}*)
 
-open Printf
 module String_io = Cohttp__String_io
 module StringResponse = Cohttp.Response.Make (String_io.M)
-module HIO = Cohttp__Header_io.Make (String_io.M)
 module H = Cohttp.Header
 
 let aes = Alcotest.check Alcotest.string
@@ -101,106 +99,6 @@ let get_media_type () =
     Alcotest.(option string)
     "media type" (Some "foo/bar")
     (Cohttp.Header.get_media_type header)
-
-let list_valued_header () =
-  let h = H.init () in
-  let h = H.add h "accept" "foo" in
-  let h = H.add h "accept" "bar" in
-  aeso "list valued header" (H.get h "accept") (Some "bar,foo")
-
-let t_header =
-  Alcotest.testable
-    (fun fmt h ->
-      let sexp = Cohttp.Header.sexp_of_t h in
-      Sexplib0.Sexp.pp_hum fmt sexp)
-    (fun x y -> Cohttp.Header.compare x y = 0)
-
-let large_header () =
-  let sz = 1024 * 1024 * 100 in
-  let h = H.init () in
-  let v1 = String.make sz 'a' in
-  let h = H.add h "x-large" v1 in
-  let h = H.add h v1 "foo" in
-  aeso "x-large" (H.get h "x-large") (Some v1);
-  let obuf = Buffer.create (sz + 1024) in
-  HIO.write h obuf;
-  let ibuf = Buffer.contents obuf in
-  let sbuf = String_io.open_in ibuf in
-  Alcotest.check t_header "large_header" (HIO.parse sbuf) h
-
-let many_headers () =
-  let size = 1000000 in
-  let rec add_header num h =
-    match num with
-    | 0 -> h
-    | n ->
-        let k = sprintf "h%d" n in
-        let v = sprintf "v%d" n in
-        let h = H.add h k v in
-        add_header (num - 1) h
-  in
-  let h = add_header size (H.init ()) in
-  Alcotest.(check int) "many_headers" (List.length (H.to_list h)) size
-
-module Updates = struct
-  let h =
-    H.init () |> fun h ->
-    H.add h "first" "1" |> fun h ->
-    H.add h "second" "2" |> fun h ->
-    H.add h "accept" "foo" |> fun h -> H.add h "accept" "bar"
-
-  let replace_headers_if_exists () =
-    let h = H.replace h "second" "2a" in
-    Alcotest.(check (option string))
-      "replace_existing_header" (Some "2a") (H.get h "second")
-
-  let replace_headers_if_absent () =
-    let h = H.replace h "third" "3" in
-    Alcotest.(check (option string))
-      "replace_new_header" (Some "3") (H.get h "third")
-
-  let update_headers_if_exists () =
-    let h1 =
-      H.update h "second" (function Some _ -> Some "2a" | None -> None)
-    in
-    let h2 = H.replace h "second" "2a" in
-    Alcotest.(check t_header) "update_existing_header" h1 h2
-
-  let update_headers_if_exists_rm () =
-    let h1 =
-      H.update h "second" (function Some _ -> None | None -> Some "3")
-    in
-    let h2 = H.remove h "second" in
-    Alcotest.(check t_header) "update_remove_header" h1 h2
-
-  let update_headers_if_absent_add () =
-    let h = H.update h "third" (function Some _ -> None | None -> Some "3") in
-    Alcotest.(check (option string))
-      "update_add_new_header" (Some "3") (H.get h "third")
-
-  let update_headers_if_absent_rm () =
-    let h1 = H.update h "third" (function _ -> None) in
-    Alcotest.(check t_header) "update_remove_absent_header" h h1
-
-  let update_headers_if_exists_multi () =
-    let h1 =
-      H.update h "accept" (function
-        | Some v -> Some ("baz," ^ v)
-        | None -> None)
-    in
-    let h2 = H.add h "accept" "baz" in
-    Alcotest.(check (option string))
-      "update_existing_header_multivalued" (H.get h1 "accept")
-      (H.get h2 "accept")
-
-  let update_headers_if_absent () =
-    let h1 =
-      H.update h "third" (function Some _ -> Some "3" | None -> None)
-    in
-    Alcotest.(check t_header) "update_new_header: unchanged" h h1;
-    Alcotest.(check (option string))
-      "update_new_header: map unchanged" None (H.get h "third")
-end
 
 module Content_range = struct
   let h1 = H.of_list [ ("Content-Length", "123") ]
@@ -551,18 +449,7 @@ let test_cachecontrol_concat () =
   in
   let h = headers_of_response "concat Cache-Control" resp in
   aeso "test_cachecontrol_concat" (Some "public,max-age:86400")
-    (H.get h "Cache-Control")
-
-let transfer_encoding () =
-  let h =
-    H.of_list
-      [ ("transfer-encoding", "gzip"); ("transfer-encoding", "chunked") ]
-  in
-  let sh = H.to_string h in
-  aes "transfer_encoding_string_is_ordered" sh
-    "transfer-encoding: gzip\r\ntransfer-encoding: chunked\r\n\r\n";
-  let sh = H.get h "transfer-encoding" in
-  aeso "transfer_encoding_get_is_ordered" (Some "gzip,chunked") sh
+    (H.get_multi_concat h "Cache-Control")
 
 let () = Printexc.record_backtrace true
 
@@ -603,24 +490,5 @@ let () =
           ("content-range", `Quick, Content_range.content_range);
         ] );
       ("Cache Control", [ ("concat", `Quick, test_cachecontrol_concat) ]);
-      ( "Header",
-        [
-          ("get list valued", `Quick, list_valued_header);
-          ("trim whitespace", `Quick, trim_ws);
-          ("replace existing", `Quick, Updates.replace_headers_if_exists);
-          ("replace absent", `Quick, Updates.replace_headers_if_absent);
-          ("update existing", `Quick, Updates.update_headers_if_exists);
-          ( "update existing list",
-            `Quick,
-            Updates.update_headers_if_exists_multi );
-          ("update add absent", `Quick, Updates.update_headers_if_absent_add);
-          ("update rm existing", `Quick, Updates.update_headers_if_exists_rm);
-          ("update rm absent", `Quick, Updates.update_headers_if_absent_rm);
-          ("update absent", `Quick, Updates.update_headers_if_absent);
-          ("many headers", `Slow, many_headers);
-          ("transfer encoding is in correct order", `Quick, transfer_encoding);
-        ]
-        @
-        if Sys.word_size = 64 then [ ("large header", `Slow, large_header) ]
-        else [] );
+      Unitary_test_header.tests;
     ]

--- a/cohttp/test/unitary_test_header.ml
+++ b/cohttp/test/unitary_test_header.ml
@@ -1,0 +1,351 @@
+(*{{{ Copyright (c) 2020 Carine Morel <carine@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *}}}*)
+
+module H = Cohttp.Header
+(** These tests try as much as possible to tests each header functions
+    independently. *)
+
+let aes = Alcotest.check Alcotest.string
+let aeso = Alcotest.check Alcotest.(option string)
+let aesl = Alcotest.check Alcotest.(list string)
+let aessl = Alcotest.check Alcotest.(list (pair string string))
+let aeb = Alcotest.check Alcotest.bool
+
+let t_header =
+  Alcotest.testable
+    (fun fmt h ->
+      let sexp = Cohttp.Header.sexp_of_t h in
+      Sexplib0.Sexp.pp_hum fmt sexp)
+    (fun x y -> Cohttp.Header.compare x y = 0)
+
+let aeh = Alcotest.check t_header
+
+let hstr =
+  [
+    ("accept", "application/xml");
+    ("transfer-encoding", "chunked");
+    ("accept", "text/html");
+    ("content-length", "100");
+  ]
+
+let prebuilt = H.of_list hstr
+let to_list_rev h = List.rev (H.to_list h)
+
+let to_list_tests () =
+  aessl "to_list (init ())" [] H.(to_list (init ()));
+  aessl "to_list (add (init ()) k v" [ ("a", "a1") ]
+    H.(to_list (add (init ()) "a" "a1"));
+  aessl "to_list (of_list h) = h" hstr H.(to_list prebuilt)
+
+let is_empty_tests () =
+  aeb "is_empty (init ())" true H.(is_empty (init ()));
+  aeb "is_empty (add (init ()) k v" false H.(is_empty (add (init ()) "a" "a1"));
+  aeb "is_empty (remove (add (init ()) k v) k)" true
+    H.(is_empty (remove (add (init ()) "a" "a1") "a"))
+
+(* [init_with l] *)
+let init_with_tests () =
+  aessl "init_with k v"
+    [ ("transfer-encoding", "chunked") ]
+    H.(to_list (init_with "traNsfer-eNcoding" "chunked"))
+
+let mem_tests () =
+  aeb "mem (init ()) k = false" false H.(mem (init ()) "a");
+  aeb "mem h k" true H.(mem prebuilt "accept");
+  aeb "mem h k" true H.(mem prebuilt "content-length");
+  aeb "mem h k" false H.(mem prebuilt "a")
+
+let add_tests () =
+  aessl "add h k v" (hstr @ [ ("a", "a1") ]) H.(to_list (add prebuilt "a" "a1"));
+  aessl "add (add h k v) k v"
+    (hstr @ [ ("a", "a1"); ("a", "a1") ])
+    H.(to_list (add (add prebuilt "a" "a1") "a" "a1"));
+  aessl "add (add h k' v') k v"
+    (hstr @ [ ("a", "a1"); ("b", "b1") ])
+    H.(to_list (add (add prebuilt "a" "a1") "b" "b1"))
+
+let get_tests () =
+  aeso "get (add (init () k v) k" (Some "a1")
+    H.(get (add (init ()) "a" "a1") "a");
+  aeso "get (add h k v) k when mem h k = false" (Some "a1")
+    H.(get (add prebuilt "a" "a1") "a");
+  aeso "get (add h k v) k when mem h k = true" (Some "text/html")
+    H.(get (add prebuilt "a" "a1") "accept");
+  aeso "get (add (add h k v') k v) k = v" (Some "a2")
+    H.(get (add (add prebuilt "a" "a1") "a" "a2") "a")
+
+(* [add_list h l] is h with l at the end. It is the same than
+   adding each element in l one by one in order. *)
+let add_list_tests () =
+  let l = [ ("a", "a1"); ("b", "b1") ] in
+  aessl "add_list (init ()) []" [] H.(to_list (add_list (init ()) []));
+  aessl "add_list (init ()) l" l H.(to_list (add_list (init ()) l));
+  aessl "add_list h []" hstr H.(to_list (add_list prebuilt []));
+  aessl "add_list h [k, v]"
+    (hstr @ [ ("a", "a1") ])
+    H.(to_list (add_list prebuilt [ ("a", "a1") ]));
+  aessl "add_list h l" (hstr @ l) H.(to_list (add_list prebuilt l))
+
+let add_multi_tests () =
+  let k, vals = ("a", [ "a1"; "a2"; "a3" ]) in
+  let l = List.map (fun v -> ("a", v)) vals in
+  aessl "add_multi (init ()) k []" [] H.(to_list (add_multi (init ()) k []));
+  aessl "add_multi (init ()) k vals" l H.(to_list (add_multi (init ()) k vals));
+  aessl "add_multi h k []" hstr H.(to_list (add_multi prebuilt k []));
+  aessl "add_multi h k vals" (hstr @ l) H.(to_list (add_multi prebuilt k vals))
+
+let add_unless_exists_tests () =
+  let k, v = ("a", "a1") in
+  let k', v' = ("transfer-encoding", "chunked") in
+  let k'', v'' = ("accept", "text/*") in
+  aessl "add_unless_exists (init ()) k v" [ (k, v) ]
+    H.(to_list (add_unless_exists (init ()) k v));
+  aessl "add_unless_exists h k v when mem h k = false"
+    (hstr @ [ (k, v) ])
+    H.(to_list (add_unless_exists prebuilt k v));
+  aessl "add_unless_exists h k v when mem h k = true)" hstr
+    H.(to_list (add_unless_exists prebuilt k' v'));
+  aessl "add_unless_exists h k v when mem h k = true)" hstr
+    H.(to_list (add_unless_exists prebuilt k'' v''))
+
+let remove_tests () =
+  aessl "remove (init ()) k" [] H.(to_list (remove (init ()) "accept"));
+  aessl "remove (add (add (init ()) k v) k v) k" []
+    H.(to_list (remove (add (add (init ()) "k" "v") "k" "v") "k"));
+  aessl "remove h k when mem h k = false" hstr H.(to_list (remove prebuilt "a"));
+  aessl "remove h k when mem h k = true"
+    [
+      ("accept", "application/xml");
+      ("accept", "text/html");
+      ("content-length", "100");
+    ]
+    H.(to_list (remove prebuilt "transfer-encoding"));
+  aessl "remove h k when mem h k = true"
+    [ ("transfer-encoding", "chunked"); ("content-length", "100") ]
+    H.(to_list (remove prebuilt "accept"))
+
+let replace_tests () =
+  let k, v, v' = ("a", "a1", "a2") in
+  aessl "replace (init ()) k v" [ (k, v) ] H.(to_list (replace (init ()) k v));
+  aessl "replace (add (init ()) k v) k v" [ (k, v) ]
+    H.(to_list (replace (add (init ()) k v) k v));
+  aessl "replace (add (init ()) k v) k v'" [ (k, v') ]
+    H.(to_list (replace (add (init ()) k v) k v'));
+  aessl "replace h k v when mem h k = false"
+    (hstr @ [ (k, v) ])
+    H.(to_list (replace prebuilt k v));
+  aessl "replace h k v when mem h k = true"
+    [
+      ("accept", "application/xml");
+      ("transfer-encoding", "gzip");
+      ("accept", "text/html");
+      ("content-length", "100");
+    ]
+    H.(to_list (replace prebuilt "transfer-encoding" "gzip"));
+  aessl "replace h k v when mem h = true"
+    [
+      ("transfer-encoding", "chunked");
+      ("accept", "text/*");
+      ("content-length", "100");
+    ]
+    H.(to_list (replace prebuilt "accept" "text/*"))
+
+let h =
+  H.init () |> fun h ->
+  H.add h "first" "1" |> fun h ->
+  H.add h "second" "2" |> fun h ->
+  H.add h "accept" "foo" |> fun h -> H.add h "accept" "bar"
+
+let update_tests () =
+  let h1 =
+    H.update h "second" (function Some _ -> Some "2a" | None -> None)
+  in
+  let h2 = H.replace h "second" "2a" in
+  aeh "update existing header" h1 h2;
+  let h1 = H.update h "second" (function Some _ -> None | None -> Some "3") in
+  let h2 = H.remove h "second" in
+  aeh "update remove header" h1 h2;
+  let h' = H.update h "third" (function Some _ -> None | None -> Some "3") in
+  aeso "update add new header" (Some "3") (H.get_multi_concat h' "third");
+  let h1 = H.update h "third" (function _ -> None) in
+  aeh "update_remove_absent_header" h h1;
+  let h1 =
+    H.update h "accept" (function Some v -> Some (v ^ ",baz") | None -> None)
+  in
+  let h2 = H.add h "accept" "baz" in
+  aeso "update_all_existing_header_multivalued" (H.get h1 "accept")
+    (H.get_multi_concat h2 "accept");
+  let h1 = H.update h "third" (function Some _ -> Some "3" | None -> None) in
+  aeh "update_new_header: unchanged" h h1;
+  aeso "update_new_header: headers unchanged" None (H.get h "third");
+  let h1 = H.update h "accept" (function Some _ -> None | None -> None) in
+  aeh "update_all_existing_header_multivalue : remove all" (H.remove h "accept")
+    h1;
+  let h1 =
+    H.update_last h "accept" (function Some _ -> None | None -> None)
+  in
+  aeso "update_existing_header_remove_multivalue: remove last" (Some "foo")
+    (H.get h1 "accept")
+
+let get_multi_tests () =
+  aesl "get_multi (init ()) k" [] H.(get_multi (init ()) "a");
+  aesl "get_multi h k when mem h k = false" [] H.(get_multi prebuilt "a");
+  aesl "get_multi h k when mem h k = true" [ "chunked" ]
+    H.(get_multi prebuilt "transfer-encoding");
+  aesl "get_multi h k when mem h k = true"
+    [ "application/xml"; "text/html" ]
+    H.(get_multi prebuilt "accept")
+
+let hstr =
+  [
+    ("accept", "application/xml");
+    ("transfer-encoding", "chunked");
+    ("accept", "text/html");
+    ("content-length", "100");
+  ]
+
+let get_multi_concat_tests () =
+  let h1 = H.(add (add prebuilt "a" "a1") "a" "a2") in
+  aeso "get_multi_concat (init ()) k" None H.(get_multi_concat (init ()) "a");
+  aeso "get_multi_concat h k when mem h k = false" None
+    H.(get_multi_concat prebuilt "a");
+  aeso "get_multi_concat h k when mem h k = true"
+    (Some "application/xml,text/html")
+    H.(get_multi_concat prebuilt "accept");
+  aeso "get_multi_concat ~list_value_only:false h k when mem h k = true"
+    (Some "a1,a2")
+    H.(get_multi_concat h1 "a");
+  aeso "get_multi_concat ~list_value_only:true h k when mem h k = true"
+    (Some "a2")
+    H.(get_multi_concat ~list_value_only:true h1 "a")
+
+let map_tests () =
+  let a = ", a" in
+  aessl "map (fun _ v -> v) (init ())" []
+    H.(to_list (map (fun _k v -> v) (init ())));
+  aessl "map (fun _ v -> v) (init ())" (H.to_list prebuilt)
+    H.(to_list (map (fun _k v -> v) prebuilt));
+  aessl "map (fun _ v -> v ^ a ) (init ())"
+    [
+      ("accept", "application/xml, a");
+      ("transfer-encoding", "chunked, a");
+      ("accept", "text/html, a");
+      ("content-length", "100, a");
+    ]
+    H.(to_list (map (fun _k v -> v ^ a) prebuilt))
+
+let fold_tests () = ()
+let iter_tests () = ()
+
+let to_lines_tests () =
+  aesl "to_lines h"
+    [
+      "accept: application/xml\r\n";
+      "transfer-encoding: chunked\r\n";
+      "accept: text/html\r\n";
+      "content-length: 100\r\n";
+    ]
+    H.(to_lines prebuilt)
+
+let to_frames_tests () =
+  aesl "to_frames h"
+    [
+      "accept: application/xml";
+      "transfer-encoding: chunked";
+      "accept: text/html";
+      "content-length: 100";
+    ]
+    H.(to_frames prebuilt)
+
+let to_string_tests () =
+  aes "to_string h"
+    "accept: application/xml\r\n\
+     transfer-encoding: chunked\r\n\
+     accept: text/html\r\n\
+     content-length: 100\r\n\
+     \r\n"
+    H.(to_string prebuilt)
+
+let many_headers () =
+  let size = 1000000 in
+  let rec add_header num h =
+    match num with
+    | 0 -> h
+    | n ->
+        let k = Printf.sprintf "h%d" n in
+        let v = Printf.sprintf "v%d" n in
+        let h = H.add h k v in
+        add_header (num - 1) h
+  in
+  let h = add_header size (H.init ()) in
+  Alcotest.(check int) "many_headers" (List.length (H.to_list h)) size
+
+let transfer_encoding_tests () =
+  let h =
+    H.of_list
+      [ ("transfer-encoding", "gzip"); ("transfer-encoding", "chunked") ]
+  in
+  let sh = H.to_string h in
+  aes "transfer_encoding_string_is_ordered" sh
+    "transfer-encoding: gzip\r\ntransfer-encoding: chunked\r\n\r\n";
+  let sh = H.get_multi_concat h "transfer-encoding" in
+  aeso "transfer_encoding_get_is_ordered" (Some "gzip,chunked") sh
+
+module String_io = Cohttp__String_io
+module HIO = Cohttp__Header_io.Make (String_io.M)
+
+let large_header () =
+  let sz = 1024 * 1024 * 100 in
+  let h = H.init () in
+  let v1 = String.make sz 'a' in
+  let h = H.add h "x-large" v1 in
+  let h = H.add h v1 "foo" in
+  aeso "x-large" (H.get h "x-large") (Some v1);
+  let obuf = Buffer.create (sz + 1024) in
+  HIO.write h obuf;
+  let ibuf = Buffer.contents obuf in
+  let sbuf = String_io.open_in ibuf in
+  Alcotest.check t_header "large_header" (HIO.parse sbuf) h
+
+let tests =
+  ( "Unitary Header tests",
+    [
+      ("Header.to_list", `Quick, to_list_tests);
+      ("Header.is_empty", `Quick, is_empty_tests);
+      ("Header.init_with", `Quick, init_with_tests);
+      ("Header.mem", `Quick, mem_tests);
+      ("Header.add", `Quick, add_tests);
+      ("Header.get", `Quick, get_tests);
+      ("Header.add_list", `Quick, add_list_tests);
+      ("Header.add_multi", `Quick, add_multi_tests);
+      ("Header.add_unless_exists", `Quick, add_unless_exists_tests);
+      ("Header.remove", `Quick, remove_tests);
+      ("Header.replace", `Quick, replace_tests);
+      ("Header.get_multi", `Quick, get_multi_tests);
+      ("Header.get_multi_concat", `Quick, get_multi_concat_tests);
+      ("Header.to_lines", `Quick, to_lines_tests);
+      ("Header.to_frames", `Quick, to_frames_tests);
+      ("Header.to_string", `Quick, to_string_tests);
+      ("Header.map", `Quick, map_tests);
+      ("Header.update", `Quick, update_tests);
+      ("many headers", `Slow, many_headers);
+      ("transfer encoding is in correct order", `Quick, transfer_encoding_tests);
+      (*todo*)
+      ("Header.fold", `Quick, fold_tests);
+      ("Header.iter", `Quick, iter_tests);
+    ]
+    @
+    if Sys.word_size = 64 then [ ("large header", `Slow, large_header) ] else []
+  )


### PR DESCRIPTION
## Purpose
Right now, headers are represented by a map, which is good to automatically insure certain RFCs properties but is also quite counterintuitive when debugging as it changes the headers order and enforces RFCs without enabling the user to control it.

The purpose of this PR is:
1. to propose a new header implementation
2. to remove every changes on the headers that is not explicitly asked for by the user. That includes, for example, the automatic addition of some headers, that occurs in various modules and can be quite hard to track. To keep some retro-compatibilities those header modifications are either grouped under a new function, that the user can call if needed, or  placed under a condition that the user can explicitly notified. 

## Header as an associative list
### Main changes
Implementing the header with an associative list basically enables to keep the order in which the header are transmitted and so to maintain the invariant  ```to_list (of_list h) = h ```. 

That means: 
- ```add``` function does neither remove nor replace any headers;
- ```get``` function **only retrieves the last transmitted value**. To get all values associated to a key, the functions ```get_multi``` or ```get_multi_concat``` must be used;
-  ```map``` and ```iter``` types have changed to match the new header type; 

### Update function
There are two functions ```update``` and ```update_last``` now. Basically ```update h k f``` calls ```f``` on the concatenated values associated with ```k``` and affects all occurrences of ```k``` (meaning, for example, all are removed if the value returns by ```f``` is ```None```).

In opposition, ```update_last``` works with the last value associated to ```k``` and affects only this value. 

### New functions
- ```get_multi_concat``` concatenates all values associated to a key. The ```~list_value_only``` optional argument enables to get the last value only if the searched header is not a list-value header and all the values otherwise. Though, ```get ~list_value_only:true``` enables to get the same result that the previous ```get``` function.
- ```clean_dup``` enables to remove unauthorized duplicates and concatenated values of list-value headers. In other word, it does the same kind of clean up that a map automatically does but need an active call by the user and preserved order of transmission.

### Related changes
- ```Cohttp/test/header_test.ml``` and ```Cohttp_lwt_unix/test/test_parser.ml``` : some tests have been added and previous ones have been correcting accordingly to the new implementation.
-  ```Cohttp_lwt_jsoo.ml``` and ```Cohttp_curl_async.ml```: the few changes are due to ```iter``` and ```map``` new types.

## Removing and factoring header modifications
WIP


