### PR TITLE
response: add extra space after http response status

### DIFF
--- a/cohttp-lwt-unix/test/test_parser.ml
+++ b/cohttp-lwt-unix/test/test_parser.ml
@@ -19,7 +19,7 @@ open OUnit
 let basic_req = "GET /index.html HTTP/1.1\r\nHost: www.example.com\r\n\r\n"
 
 let basic_res =
-  "HTTP/1.1 200 OK\r\n\
+  "HTTP/1.1 200 OK \r\n\
    Date: Mon, 23 May 2005 22:38:34 GMT\r\n\
    Server: Apache/1.3.3.7 (Unix) (Red-Hat/Linux)\r\n\
    Last-Modified: Wed, 08 Jan 2003 23:11:55 GMT\r\n\
@@ -30,7 +30,7 @@ let basic_res =
    Content-Type: text/html; charset=UTF-8"
 
 let basic_res_content =
-  "HTTP/1.1 200 OK\r\n\
+  "HTTP/1.1 200 OK \r\n\
    Date: Mon, 23 May 2005 22:38:34 GMT\r\n\
    Server: Apache/1.3.3.7 (Unix) (Red-Hat/Linux)\r\n\
    Last-Modified: Wed, 08 Jan 2003 23:11:55 GMT\r\n\
@@ -75,7 +75,7 @@ let post_chunked_req =
    \r\n"
 
 let chunked_res =
-  "HTTP/1.1 200 OK\r\n\
+  "HTTP/1.1 200 OK \r\n\
    Date: Fri, 31 Dec 1999 23:59:59 GMT\r\n\
    Content-Type: text/plain\r\n\
    Transfer-Encoding: chunked\r\n\
@@ -283,7 +283,7 @@ let make_simple_res () =
   let open Cohttp in
   let open Cohttp_lwt_unix in
   let expected =
-    "HTTP/1.1 200 OK\r\n\
+    "HTTP/1.1 200 OK \r\n\
      foo: bar\r\n\
      transfer-encoding: chunked\r\n\
      \r\n\

--- a/cohttp/src/response.ml
+++ b/cohttp/src/response.ml
@@ -105,7 +105,7 @@ module Make (IO : S.IO) = struct
 
   let write_header res oc =
     write oc
-      (Printf.sprintf "%s %s\r\n"
+      (Printf.sprintf "%s %s \r\n"
          (Code.string_of_version res.version)
          (Code.string_of_status res.status))
     >>= fun () ->


### PR DESCRIPTION
This is required, according to the spec: https://tools.ietf.org/html/rfc7230#section-3.1.2
The rest of the code seems to (correctly) ignore this extra space so the change should not affect anything except maybe some too restrictive tests

Should fix #752