### PR TITLE
generate: add space to string_of_status

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## current
 
+- cohttp.response: fix malformed status header for custom status codes (@mseri @aalekseyev #752)
 - Remove dependency to base (@samoht #745)
 - fix opam files and dependencies
 - add GitHub Actions workflow (@smorimoto #739)

--- a/cohttp/scripts/generate.ml
+++ b/cohttp/scripts/generate.ml
@@ -239,7 +239,9 @@ let output_string_of_status oc ~mli s =
     append oc "let string_of_status: status_code -> string = function";
     iter (fun c -> append oc "  | %s -> \"%d %s\"" c.constr c.code c.descr) s;
     (* the response status must include an extra space even if no description is present, cf. #752 *)
-    append oc "  | `Code cod ->  string_of_int cod ^ \" \"");
+    append oc "  | `Code cod ->";
+    append oc "      let code = string_of_int cod in";
+    append oc "      code ^ \" Status \" ^ code");
   append oc ""
 
 let output_reason_phrase_of_code oc ~mli s =

--- a/cohttp/scripts/generate.ml
+++ b/cohttp/scripts/generate.ml
@@ -238,7 +238,8 @@ let output_string_of_status oc ~mli s =
   else (
     append oc "let string_of_status: status_code -> string = function";
     iter (fun c -> append oc "  | %s -> \"%d %s\"" c.constr c.code c.descr) s;
-    append oc "  | `Code cod -> string_of_int cod");
+    (* the response status must include an extra space even if no description is present, cf. #752 *)
+    append oc "  | `Code cod ->  string_of_int cod ^ \" \"");
   append oc ""
 
 let output_reason_phrase_of_code oc ~mli s =


### PR DESCRIPTION
This is required by the spec.
The change could have gone into the response module,
adding a specific logic checking the presence of the
space before the string termination, but it seemed
cleaner to add it here.

Should fix #752. 

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>