### PR TITLE
Merge resolve_file / resolve_local_file implementations (fixes #755)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,10 +76,10 @@
 
 - `Cohttp_async.resolve_local_file`, `Cohttp_lwt.resolve_local_file` and `Cohttp_lwt_unix.resolve_file`
   are now the same code under the hood (`Cohttp.Path.resolve_local_file`). The old names
-  have been preserved for compatibility, but marked as deprecated. This changes the behavior of
-  `Cohttp_lwt_unix.resolve_file`: it now percent-decodes the paths and blocks escaping from the
-  docroot correctly. This also fixes and tests the corner cases in these methods when the docroot
-  is empty. (#755)
+  have been preserved for compatibility, but will be marked as deprecated in the next release. This
+  changes the behavior of `Cohttp_lwt_unix.resolve_file`: it now percent-decodes the paths and blocks
+  escaping from the docroot correctly. This also fixes and tests the corner cases in these methods
+  when the docroot is empty. (@ewanmellor #755)
 
 ## v2.5.4 (2020-07-21)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,15 @@
 - improve media type parsing (@seliopou #542, @dinosaure #725)
 - add comparison functions for Request.t and Response.t via ppx_compare (@msaffer-js @dinosaure #686)
 
+## v2.5.5 (2021-03-15)
+
+- `Cohttp_async.resolve_local_file`, `Cohttp_lwt.resolve_local_file` and `Cohttp_lwt_unix.resolve_file`
+  are now the same code under the hood (`Cohttp.Path.resolve_local_file`). The old names
+  have been preserved for compatibility, but marked as deprecated. This changes the behavior of
+  `Cohttp_lwt_unix.resolve_file`: it now percent-decodes the paths and blocks escaping from the
+  docroot correctly. This also fixes and tests the corner cases in these methods when the docroot
+  is empty. (#755)
+
 ## v2.5.4 (2020-07-21)
 
 - cohttp: a change in #694 modified the semantics of Header.replace.

--- a/cohttp-async/bin/cohttp_server_async.ml
+++ b/cohttp-async/bin/cohttp_server_async.ml
@@ -25,11 +25,11 @@ let method_filter meth (res, body) =
   match meth with `HEAD -> return (res, `Empty) | _ -> return (res, body)
 
 let serve_file ~docroot ~uri =
-  Server.resolve_local_file ~docroot ~uri |> Server.respond_with_file
+  Cohttp.Path.resolve_local_file ~docroot ~uri |> Server.respond_with_file
 
 let serve ~info ~docroot ~index uri path =
   (* Get a canonical filename from the URL and docroot *)
-  let file_name = Server.resolve_local_file ~docroot ~uri in
+  let file_name = Cohttp.Path.resolve_local_file ~docroot ~uri in
   try_with (fun () ->
       Unix.stat file_name >>= fun stat ->
       Logs.debug (fun f ->

--- a/cohttp-async/src/server.ml
+++ b/cohttp-async/src/server.ml
@@ -125,10 +125,9 @@ let respond_with_redirect ?headers uri =
   in
   respond ~flush:false ~headers `Found
 
+(* Deprecated *)
 let resolve_local_file ~docroot ~uri =
-  (* This normalises the Uri and strips out .. characters *)
-  Uri.(pct_decode (path (resolve "" (of_string "/") uri)))
-  |> Caml.Filename.concat docroot
+  Cohttp.Path.resolve_local_file ~docroot ~uri
 
 let error_body_default = "<html><body><h1>404 Not Found</h1></body></html>"
 

--- a/cohttp-async/src/server.mli
+++ b/cohttp-async/src/server.mli
@@ -37,7 +37,9 @@ type response_action =
 val respond : response respond_t
 
 val resolve_local_file : docroot:string -> uri:Uri.t -> string
-(** Resolve a URI and a docroot into a concrete local filename. *)
+(** Resolve a URI and a docroot into a concrete local filename.
+
+    Deprecated. Please use Cohttp.Path.resolve_local_file. *)
 
 val respond_with_pipe :
   ?flush:bool ->

--- a/cohttp-lwt-unix/bin/cohttp_server_lwt.ml
+++ b/cohttp-lwt-unix/bin/cohttp_server_lwt.ml
@@ -30,7 +30,7 @@ let method_filter meth (res, body) =
   | _ -> Lwt.return (res, body)
 
 let serve_file ~docroot ~uri =
-  let fname = Server.resolve_local_file ~docroot ~uri in
+  let fname = Cohttp.Path.resolve_local_file ~docroot ~uri in
   Server.respond_file ~fname ()
 
 let ls_dir dir =
@@ -38,7 +38,7 @@ let ls_dir dir =
     (Lwt_stream.filter (( <> ) ".") (Lwt_unix.files_of_directory dir))
 
 let serve ~info ~docroot ~index uri path =
-  let file_name = Server.resolve_local_file ~docroot ~uri in
+  let file_name = Cohttp.Path.resolve_local_file ~docroot ~uri in
   Lwt.catch
     (fun () ->
       Lwt_unix.stat file_name >>= fun stat ->

--- a/cohttp-lwt-unix/src/server.ml
+++ b/cohttp-lwt-unix/src/server.ml
@@ -6,12 +6,8 @@ let src = Logs.Src.create "cohttp.lwt.server" ~doc:"Cohttp Lwt server module"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let blank_uri = Uri.of_string ""
-
-let resolve_file ~docroot ~uri =
-  (* This normalises the Uri and strips out .. characters *)
-  let frag = Uri.path (Uri.resolve "" blank_uri uri) in
-  Filename.concat docroot frag
+(* Deprecated *)
+let resolve_file ~docroot ~uri = Cohttp.Path.resolve_local_file ~docroot ~uri
 
 exception Isnt_a_file
 

--- a/cohttp-lwt-unix/src/server.mli
+++ b/cohttp-lwt-unix/src/server.mli
@@ -4,6 +4,7 @@
 include Cohttp_lwt.S.Server with module IO = Io
 
 val resolve_file : docroot:string -> uri:Uri.t -> string
+(** Deprecated. Please use Cohttp.Path.resolve_local_file. *)
 
 val respond_file :
   ?headers:Cohttp.Header.t ->

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -166,7 +166,9 @@ module type Server = sig
     t
 
   val resolve_local_file : docroot:string -> uri:Uri.t -> string
-  (** Resolve a URI and a docroot into a concrete local filename. *)
+  (** Resolve a URI and a docroot into a concrete local filename.
+
+      Deprecated. Please use Cohttp.Path.resolve_local_file. *)
 
   val respond :
     ?headers:Cohttp.Header.t ->

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -38,10 +38,9 @@ module Make (IO : S.IO) = struct
 
   module Transfer_IO = Cohttp__Transfer_io.Make (IO)
 
+  (* Deprecated *)
   let resolve_local_file ~docroot ~uri =
-    let path = Uri.(pct_decode (path (resolve "http" (of_string "/") uri))) in
-    let rel_path = String.sub path 1 (String.length path - 1) in
-    Filename.concat docroot rel_path
+    Cohttp.Path.resolve_local_file ~docroot ~uri
 
   let respond ?headers ?(flush = true) ~status ~body () =
     let encoding =

--- a/cohttp/src/cohttp.ml
+++ b/cohttp/src/cohttp.ml
@@ -10,4 +10,5 @@ module Link = Link
 module Request = Request
 module Response = Response
 module S = S
+module Path = Path
 module Transfer = Transfer

--- a/cohttp/src/path.ml
+++ b/cohttp/src/path.ml
@@ -1,0 +1,7 @@
+let resolve_local_file ~docroot ~uri =
+  let path = Uri.(pct_decode (path (resolve "http" (of_string "/") uri))) in
+  let rel_path =
+    if String.length path > 0 then String.sub path 1 (String.length path - 1)
+    else ""
+  in
+  Filename.concat docroot rel_path

--- a/cohttp/src/path.mli
+++ b/cohttp/src/path.mli
@@ -1,0 +1,6 @@
+val resolve_local_file : docroot:string -> uri:Uri.t -> string
+(** Resolve the given URI to a local file in the given docroot.
+
+    This decodes and normalises the Uri. It strips out .. characters so that the
+    request will not escape the docroot. The returned filepath is fully
+    qualified iff the given docroot is fully qualified. *)

--- a/cohttp/test/dune
+++ b/cohttp/test/dune
@@ -45,3 +45,15 @@
  (package cohttp)
  (action
   (run ./test_body.exe)))
+
+(executable
+ (name test_path)
+ (modules test_path)
+ (forbidden_libraries base)
+ (libraries cohttp alcotest fmt))
+
+(rule
+ (alias runtest)
+ (package cohttp)
+ (action
+  (run ./test_path.exe)))

--- a/cohttp/test/test_path.ml
+++ b/cohttp/test/test_path.ml
@@ -1,0 +1,88 @@
+let test_resolve_local_file () =
+  let tests =
+    [
+      ( "full URL simple",
+        "/foo/bar/baz",
+        "https://example.com/images/buzz",
+        "/foo/bar/baz/images/buzz" );
+      ( "full URL cwd",
+        "/foo/bar/baz",
+        "https://example.com/./buzz",
+        "/foo/bar/baz/buzz" );
+      ( "full URL parent blocked",
+        "/foo/bar/baz",
+        "https://example.com/../buzz",
+        "/foo/bar/baz/buzz" );
+      ( "full URL grandparent blocked",
+        "/foo/bar/baz",
+        "https://example.com/../../buzz",
+        "/foo/bar/baz/buzz" );
+      ( "trailing-slash-docroot full URL simple",
+        "/foo/bar/baz/",
+        "https://example.com/images/buzz",
+        "/foo/bar/baz/images/buzz" );
+      ( "trailing-slash-docroot full URL cwd",
+        "/foo/bar/baz/",
+        "https://example.com/./buzz",
+        "/foo/bar/baz/buzz" );
+      ( "trailing-slash-docroot full URL parent blocked",
+        "/foo/bar/baz/",
+        "https://example.com/../buzz",
+        "/foo/bar/baz/buzz" );
+      ( "trailing-slash-docroot full URL grandparent blocked",
+        "/foo/bar/baz/",
+        "https://example.com/../../buzz",
+        "/foo/bar/baz/buzz" );
+      ( "filepath simple",
+        "/foo/bar/baz",
+        "/images/buzz",
+        "/foo/bar/baz/images/buzz" );
+      ("filepath cwd", "/foo/bar/baz", "./buzz", "/foo/bar/baz/buzz");
+      ("filepath parent blocked", "/foo/bar/baz", "../buzz", "/foo/bar/baz/buzz");
+      ( "filepath grandparent blocked",
+        "/foo/bar/baz",
+        "../../buzz",
+        "/foo/bar/baz/buzz" );
+      ( "trailing-slash-docroot filepath simple",
+        "/foo/bar/baz/",
+        "/images/buzz",
+        "/foo/bar/baz/images/buzz" );
+      ( "trailing-slash-docroot filepath cwd",
+        "/foo/bar/baz/",
+        "./buzz",
+        "/foo/bar/baz/buzz" );
+      ( "trailing-slash-docroot filepath parent blocked",
+        "/foo/bar/baz/",
+        "../buzz",
+        "/foo/bar/baz/buzz" );
+      ( "trailing-slash-docroot filepath grandparent blocked",
+        "/foo/bar/baz/",
+        "../../buzz",
+        "/foo/bar/baz/buzz" );
+      ("root-docroot simple", "/", "/images/buzz", "/images/buzz");
+      ("root-docroot cwd", "/", "./buzz", "/buzz");
+      ("root-docroot grandparent blocked", "/", "../../buzz", "/buzz");
+      ("blank-docroot simple", "", "/images/buzz", "images/buzz");
+      ("blank-docroot cwd", "", "./buzz", "buzz");
+      ("blank-docroot blank-path", "", "https://example.com", "");
+      ("blank-docroot blank-uri", "", "", "");
+      ("cwd-docroot simple", ".", "/images/buzz", "./images/buzz");
+      ("cwd-docroot cwd", ".", "./buzz", "./buzz");
+      ("cwd-docroot blank-path", ".", "https://example.com", "./");
+      ("cwd-docroot blank-uri", ".", "", "./");
+    ]
+  in
+  List.iter
+    (fun (name, docroot, uri, expected) ->
+      Alcotest.(check string)
+        name expected
+        (Cohttp.Path.resolve_local_file ~docroot ~uri:(Uri.of_string uri)))
+    tests
+
+let () = Printexc.record_backtrace true
+
+let () =
+  Alcotest.run "test_path"
+    [
+      ("Path", [ ("Check resolve_local_file", `Quick, test_resolve_local_file) ]);
+    ]


### PR DESCRIPTION
Merge Cohttp_async.resolve_local_file, Cohttp_lwt.resolve_local_file,
and Cohttp_lwt_unix.resolve_file into one new function,
Cohttp.Server_utils.resolve_local_file.  (This adds Server_utils as a
new module, since there didn't seem to be any other good place for this
code).

The implementation now correctly handles ../ in the URI
(Cohttp_lwt_unix.resolve_file claimed to do so, but actually didn't
for file URIs). It percent-decodes the URI path
(Cohttp_lwt_unix.resolve_file did not, but the other two already did).
It correctly handles the path separators so that we don't get two slashes
together (both Cohttp_lwt_unix.resolve_file and
Cohttp_async.resolve_local_file got that one wrong).  It also doesn't
crash if the URI is blank (Cohttp_lwt.resolve_local_file got that wrong).

Signed-off-by: Ewan Mellor <ewan@tarides.com>