### PR TITLE
Improve the opam files

### DIFF
--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -24,14 +24,14 @@ doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "1.1.0"}
+  "dune" {>= "2.0"}
   "async_kernel" {>= "v0.14.0"}
   "async_unix" {>= "v0.14.0"}
   "async" {>= "v0.14.0"}
   "base" {>= "v0.11.0"}
   "core" {with-test}
-  "cohttp" {=version}
-  "conduit-async" {>="1.2.0" & <"3.0.0"}
+  "cohttp" {= version}
+  "conduit-async" {>= "1.2.0" & < "3.0.0"}
   "magic-mime"
   "mirage-crypto" {with-test}
   "logs"
@@ -44,7 +44,7 @@ depends: [
   "ipaddr"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/cohttp-lwt-jsoo.opam
+++ b/cohttp-lwt-jsoo.opam
@@ -23,16 +23,16 @@ doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "1.1.0"}
-  "cohttp" {=version}
-  "cohttp-lwt" {=version}
+  "dune" {>= "2.0"}
+  "cohttp" {= version}
+  "cohttp-lwt" {= version}
   "lwt" {>= "3.0.0"}
   "js_of_ocaml" {>= "3.3.0"}
   "js_of_ocaml-ppx" {>= "3.3.0"}
   "js_of_ocaml-lwt" {>= "3.5.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/cohttp-lwt-unix.opam
+++ b/cohttp-lwt-unix.opam
@@ -26,21 +26,21 @@ doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "1.1.0"}
+  "dune" {>= "2.0"}
   "conduit-lwt" {>= "1.0.3" & < "3.0.0"}
   "conduit-lwt-unix" {>= "1.0.3" & < "3.0.0"}
   "cmdliner"
   "magic-mime"
   "logs"
   "fmt" {>= "0.8.2"}
-  "cohttp-lwt" {=version}
+  "cohttp-lwt" {= version}
   "ppx_sexp_conv" {>= "v0.13.0"}
   "lwt" {>= "3.0.0"}
   "base-unix"
   "ounit" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/cohttp-lwt.opam
+++ b/cohttp-lwt.opam
@@ -26,8 +26,8 @@ doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "1.1.0"}
-  "cohttp" {=version}
+  "dune" {>= "2.0"}
+  "cohttp" {= version}
   "lwt" {>= "2.5.0"}
   "sexplib0"
   "ppx_sexp_conv" {>= "v0.13.0"}
@@ -35,7 +35,7 @@ depends: [
   "uri" {>= "2.0.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/cohttp-mirage.opam
+++ b/cohttp-mirage.opam
@@ -19,21 +19,21 @@ Please see <https://mirage.io> for a self-hosted explanation
 and instructions on how to use this library."""
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "1.1.0"}
+  "dune" {>= "2.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2" & <"3.0.0"}
-  "conduit-mirage" {>= "2.0.2" & <"3.0.0"}
+  "conduit" {>= "2.0.2" & < "3.0.0"}
+  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
-  "cohttp" {=version}
-  "cohttp-lwt" {=version}
+  "cohttp" {= version}
+  "cohttp-lwt" {= version}
   "astring"
   "magic-mime"
   "ppx_sexp_conv" {>= "v0.13.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/cohttp-top.opam
+++ b/cohttp-top.opam
@@ -22,11 +22,11 @@ doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "1.1.0"}
-  "cohttp" {=version}
+  "dune" {>= "2.0"}
+  "cohttp" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/cohttp.opam
+++ b/cohttp.opam
@@ -33,7 +33,7 @@ doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "2.0.0"}
+  "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}
   "uri-sexp"
@@ -46,7 +46,7 @@ depends: [
   "alcotest" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]


### PR DESCRIPTION
dune subst should be used only in the dev case, reformat and synchronise the dune constraint accross packages