### PR TITLE
Fix Invalid_arg exception on stack overflow when waking up a request.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## current
+
+- lwt_jsoo: Fix `Lwt.wakeup_exn` `Invalid_arg` exception when a js
+  stack overflow happens in the XHR completion handler (@mefyl #762).
+
 ## v4.0.0 (2021-03-24)
 
 - cohttp.response: fix malformed status header for custom status codes (@mseri @aalekseyev #752)


### PR DESCRIPTION
This one is a bit of a brain twister : if you trigger a javascript stack overflow in `Lwt.wakeup` - which I do on a daily basis at this precise point in the code - the promise will still be marked as completed. Trying to wake it again with the Stack_overflow exception will raise Invalid_arg as you may not wake a promise twice, ending up with a very strange exception in the javascript toplevel. Letting the exception through if the promise was already woken seems like a better option.

Side note: this is definitely not entirely satisfactory since the promise is in a completely broken state : it is considered woken, but not all callbacks have been entirely called. That would require fixing in Lwt though, which knows no exception can escape from callbacks and thus is not exception safe in this regard. Running OCaml code through Jsoo makes ANY call susceptible to throwing an exception, but we're probably not going to alter all existing OCaml code for this possibility. I would argue that getting a `Stack_overflow` exception implies undefined behavior from the program and everything needs to be started over.