### PR TITLE
lwt.client: log drain body warning instead of printing it to stderr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## current
 
+- lwt: Use logs to warn users about leaked bodies and document it (mseri #771)
 - lwt, lwt_unix: Improve use of logs and the documentation, fix bug in the Debug.enable_debug function (mseri #772)
 - lwt_jsoo: Fix exception on connection errors in chrome (mefyl #761)
 - lwt_jsoo: Fix `Lwt.wakeup_exn` `Invalid_arg` exception when a js

--- a/cohttp-lwt/src/client.mli
+++ b/cohttp-lwt/src/client.mli
@@ -1,6 +1,10 @@
 (** The [Make] functor glues together a {!Cohttp.S.IO} implementation to send
     requests down a connection that is established by the {!Net} module. The
-    resulting module satisfies the {!Client} module type. *)
+    resulting module satisfies the {!Client} module type.
+
+    The {!Logs} source name for this module's logger is ["cohttp.lwt.client"].
+    When logging is enabled (at least {b warning} level), eventual body leaks
+    will be logged and easier to track. *)
 
 module Make (IO : S.IO) (Net : S.Net with module IO = IO) :
   S.Client with type ctx = Net.ctx

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -57,6 +57,10 @@ module type Client = sig
       interface rather than invoke this function directly. See {!head}, {!get}
       and {!post} for some examples.
 
+      To avoid leaks, the body needs to be consumed, using the functions
+      provided in the {!Body} module and, if not necessary, should be explicitly
+      drained calling {!Body.drain_body}.
+
       Depending on [ctx], the library is able to send a simple HTTP request or
       an encrypted one with a secured protocol (such as TLS). Depending on how
       conduit is configured, [ctx] might initiate a secured connection with TLS

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -59,7 +59,14 @@ module type Client = sig
 
       To avoid leaks, the body needs to be consumed, using the functions
       provided in the {!Body} module and, if not necessary, should be explicitly
-      drained calling {!Body.drain_body}.
+      drained calling {!Body.drain_body}. Leaks are logged as debug messages by
+      the client, these can be enabled activating the debug logging. For
+      example, this can be done as follows in [cohttp-lwt-unix]
+
+      {[
+        Cohttp_lwt_unix.Debug.activate_debug ();
+        Logs.set_level (Some Logs.Warning)
+      ]}
 
       Depending on [ctx], the library is able to send a simple HTTP request or
       an encrypted one with a secured protocol (such as TLS). Depending on how

--- a/cohttp-lwt/src/server.mli
+++ b/cohttp-lwt/src/server.mli
@@ -2,7 +2,6 @@
     requests down a connection that is established by the user. The resulting
     module satisfies the {!Server} module type.
 
-    The {!Logs} source name for this module's logger is ["cohttp.lwt.server"].
-    Refer to the {!Debug} module for further details.*)
+    The {!Logs} source name for this module's logger is ["cohttp.lwt.server"].*)
 
 module Make (IO : S.IO) : S.Server with module IO = IO


### PR DESCRIPTION
I think it is worth having the improved warning message and the extra documentation.

But I am not sure logging is better: currently, you are immediately bitten by the error messages appearing everywhere in the tests, by hiding it in the logging you need to consciously look for the problem.