### PR TITLE
lwt_jsoo: use log instead of always printing the warnings on the console

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## current
 
+- lwt_jsoo: Use logs for the warnings and document it (mseri #776)
 - lwt, lwt_unix: Improve use of logs and the documentation, fix bug in the Debug.enable_debug function (mseri #772)
 - lwt_jsoo: Fix exception on connection errors in chrome (mefyl #761)
 - lwt_jsoo: Fix `Lwt.wakeup_exn` `Invalid_arg` exception when a js

--- a/cohttp-lwt-jsoo.opam
+++ b/cohttp-lwt-jsoo.opam
@@ -26,6 +26,7 @@ depends: [
   "dune" {>= "2.0"}
   "cohttp" {= version}
   "cohttp-lwt" {= version}
+  "logs"
   "lwt" {>= "3.0.0"}
   "lwt_ppx" {with-test}
   "conf-npm" {with-test}

--- a/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.mli
+++ b/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.mli
@@ -15,7 +15,16 @@
  *
   }}}*)
 
-(** HTTP client for JavaScript using XMLHttpRequest. *)
+(** {1 HTTP client for JavaScript using XMLHttpRequest.}
+
+    The {!Logs} source name for this module's logger is ["cohttp.lwt.jsoo"]. To
+    log the current warnings using the browser's console log, you can write a
+    custom reporter or use:
+
+    {[
+      let reporter = Logs_browser.console_reporter () in
+      Logs.set_reporter reporter
+    ]} *)
 
 (** Configuration parameters for the XmlHttpRequest engines *)
 module type Params = sig

--- a/cohttp-lwt-jsoo/src/dune
+++ b/cohttp-lwt-jsoo/src/dune
@@ -4,4 +4,4 @@
  (synopsis "XHR/Lwt based http client")
  (preprocess
   (pps js_of_ocaml-ppx))
- (libraries js_of_ocaml cohttp-lwt))
+ (libraries js_of_ocaml cohttp-lwt logs))


### PR DESCRIPTION
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>