### PR TITLE
cohttp.headers: use faster comparison

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: actions-ml/setup-ocaml@master
+        uses: ocaml/setup-ocaml@v2
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
           opam-depext: false

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
   stack overflow happens in the XHR completion handler (mefyl #762).
 - lwt_jsoo: Add test suite (mefyl #764).
 
-- Cohttp.Header: new implementation (@lyrm #747)
+- Cohttp.Header: new implementation (lyrm #747)
 
   + New implementation of Header modules using an associative list instead of a map, with one major semantic change (function ```get```, see below), and some new functions (```clean_dup```, ```get_multi_concat```)
   + More Alcotest tests as well as fuzzing tests for this particular module.
@@ -38,6 +38,7 @@
 
   + ```clean_dup```  enables the user to clean headers that follows the {{:https://tools.ietf.org/html/rfc7230#section-3.2.2} RFC7230§3.2.2} (no duplicate, except ```set-cookie```)
   + ```get_multi_concat``` has been added to get a result similar to the previous ```get``` function.
+- Cohttp.Header: optimize internal of cohttp.headers (mseri #778)
 
 ## v4.0.0 (2021-03-24)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
   + New implementation of Header modules using an associative list instead of a map, with one major semantic change (function ```get```, see below), and some new functions (```clean_dup```, ```get_multi_concat```)
   + More Alcotest tests as well as fuzzing tests for this particular module.
 
+- Cohttp.Header: performance improvement (mseri, anuragsoni #778)
+  **Breaking** the headers are no-longer lowercased when parsed, the headers key comparison is case insensitive instead.
+
   ### Purpose
 
   The new header implementation uses an associative list instead of a map to represent headers and is focused on predictability and intuitivity: except for some specific and documented functions, the headers are always kept in transmission order, which makes debugging easier and is also important for [RFC7230§3.2.2](https://tools.ietf.org/html/rfc7230#section-3.2.2) that states that multiple values of a header must be kept in order.

--- a/cohttp-lwt-unix/test/test_parser.ml
+++ b/cohttp-lwt-unix/test/test_parser.ml
@@ -246,7 +246,7 @@ let make_simple_req () =
   let open Cohttp in
   let open Cohttp_lwt_unix in
   let expected =
-    "POST /foo/bar HTTP/1.1\r\nfoo: bar\r\nhost: localhost\r\nuser-agent: "
+    "POST /foo/bar HTTP/1.1\r\nFoo: bar\r\nhost: localhost\r\nuser-agent: "
     ^ user_agent
     ^ "\r\ntransfer-encoding: chunked\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n"
   in

--- a/cohttp/fuzz/fuzz_header.ml
+++ b/cohttp/fuzz/fuzz_header.ml
@@ -191,8 +191,7 @@ let init_with_test () =
     (* FS *)
     (* forall k v. to_list (init_with k v) = [k, v] *)
     add_test ~name:"[init_list k v] is [k, v]" [ header_name_gen; word_gen ]
-      (fun k v ->
-        check_eq H.(to_list (init_with k v)) [ (k, v) ]))
+      (fun k v -> check_eq H.(to_list (init_with k v)) [ (k, v) ]))
 
 let mem_test () =
   Crowbar.(
@@ -201,12 +200,16 @@ let mem_test () =
     add_test ~name:"[mem h k] on an empty header is always false"
       [ header_name_gen ] (fun k -> check_eq false H.(mem (init ()) k));
     (* SI *)
-    (* forall h, k. H.mem h k = List.(mem_assoc k (H.to_list h)) *)
+    (* forall h, k. H.mem h k = List.(mem_assoc (String.lowercase_ascii x) (List.map (fun (k, v) -> String.lowercase_ascii k, v) (H.to_list h))) *)
     add_test ~name:"Header.mem has the same behavior than List.mem_assoc"
       [ headers_gen; header_name_gen ] (fun h k ->
         check_eq
           H.(mem h k)
-          List.(mem_assoc k (H.to_list h))))
+          List.(
+            mem_assoc (String.lowercase_ascii k)
+              (List.map
+                 (fun (k, v) -> (String.lowercase_ascii k, v))
+                 (H.to_list h)))))
 
 let add_test () =
   Crowbar.(
@@ -220,9 +223,7 @@ let add_test () =
     (* forall h, k, v. to_list (add h k v) = to_list h @ [lowercase k, v] *)
       ~name:"[add] adds a value at the header end"
       [ headers_gen; header_name_gen; word_gen ] (fun h k v ->
-        check_eq
-          (H.to_list h @ [ (k, v) ])
-          H.(to_list (add h k v))))
+        check_eq (H.to_list h @ [ (k, v) ]) H.(to_list (add h k v))))
 
 let to_list_of_list_test () =
   Crowbar.(

--- a/cohttp/fuzz/fuzz_header.ml
+++ b/cohttp/fuzz/fuzz_header.ml
@@ -189,10 +189,10 @@ let is_empty_test () =
 let init_with_test () =
   Crowbar.(
     (* FS *)
-    (* forall k v. to_list (init_with k v) = [String.lowercase k, v] *)
+    (* forall k v. to_list (init_with k v) = [k, v] *)
     add_test ~name:"[init_list k v] is [k, v]" [ header_name_gen; word_gen ]
       (fun k v ->
-        check_eq H.(to_list (init_with k v)) [ (String.lowercase_ascii k, v) ]))
+        check_eq H.(to_list (init_with k v)) [ (k, v) ]))
 
 let mem_test () =
   Crowbar.(
@@ -206,7 +206,7 @@ let mem_test () =
       [ headers_gen; header_name_gen ] (fun h k ->
         check_eq
           H.(mem h k)
-          List.(mem_assoc (String.lowercase_ascii k) (H.to_list h))))
+          List.(mem_assoc k (H.to_list h))))
 
 let add_test () =
   Crowbar.(
@@ -221,7 +221,7 @@ let add_test () =
       ~name:"[add] adds a value at the header end"
       [ headers_gen; header_name_gen; word_gen ] (fun h k v ->
         check_eq
-          (H.to_list h @ [ (String.lowercase_ascii k, v) ])
+          (H.to_list h @ [ (k, v) ])
           H.(to_list (add h k v))))
 
 let to_list_of_list_test () =

--- a/cohttp/src/header.ml
+++ b/cohttp/src/header.ml
@@ -27,20 +27,7 @@ end = struct
 
   let of_string x = String.lowercase_ascii x
   let to_string x = x
-
-  let equal x y =
-    let len = String.length x in
-    len = String.length y
-    &&
-    let equal_so_far = ref true in
-    let i = ref 0 in
-    while !equal_so_far && !i < len do
-      let c1 = String.unsafe_get x !i in
-      let c2 = String.unsafe_get y !i in
-      equal_so_far := c1 = c2;
-      incr i
-    done;
-    !equal_so_far
+  let equal x y = String.equal x y
 end
 
 type t = (LString.t * string) list

--- a/cohttp/src/header.ml
+++ b/cohttp/src/header.ml
@@ -67,7 +67,6 @@ let get h k =
   loop h
 
 let get_multi (h : t) (k : string) =
-  let k = LString.of_string k in
   let rec loop h acc =
     match h with
     | [] -> acc

--- a/cohttp/src/header.mli
+++ b/cohttp/src/header.mli
@@ -32,7 +32,8 @@ val of_list : (string * string) list -> t
     is true with case insensitive comparison. *)
 
 val to_list : t -> (string * string) list
-(** [to_list h] converts HTTP headers [h] to a list. Order is preserved.
+(** [to_list h] converts HTTP headers [h] to a list. Order and case is
+    preserved.
 
     {e Invariant (with case insensitive comparison):} [to_list (of_list l) = l] *)
 

--- a/cohttp/test/unitary_test_header.ml
+++ b/cohttp/test/unitary_test_header.ml
@@ -58,7 +58,7 @@ let is_empty_tests () =
 
 let init_with_tests () =
   aessl "init_with k v"
-    [ ("transfer-encoding", "chunked") ]
+    [ ("traNsfer-eNcoding", "chunked") ]
     H.(to_list (init_with "traNsfer-eNcoding" "chunked"))
 
 let mem_tests () =


### PR DESCRIPTION
I have benchmarked the latency of cohttp using https://github.com/ocaml-multicore/retro-httpaf-bench/tree/master/cohttp-lwt-unix and, with the new headers module, the measures are ~33% slower on my machine.

With this change, we seem to get ~10% slowdown compared to the old metrics on my laptop. Still suboptimal but it is an improvement.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>