### PR TITLE
[Preview] upgrade to ocamlformat.0.20.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,4 @@
-version = 0.17.0
+version = 0.20.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true
-module-item-spacing = compact

--- a/cohttp/src/link.ml
+++ b/cohttp/src/link.ml
@@ -382,7 +382,7 @@ let rec params_of_string s i ps =
           let charset, language, v, i = star_of_string s i in
           params_of_string s i
             (Star { Ext.charset; language; value = Link_extension (main, v) }
-             :: ps)
+            :: ps)
         else
           let v, i = quoted_string_of_string s i in
           params_of_string s i (Link_extension (other, v) :: ps)


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.20.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.
The changes are due to:
- `module-item-spacing` is now set to `compact` for the default profile
- `module-item-spacing` is now correctly applied to mutually recursive type definitions
- the `.ocamlformat` file has been simplified using the conventional profile
- formatting of list elements has been improved