### PR TITLE
Adopt ocaml-conduit 5.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## current
 
+- cohttp-lwt-unix: Adopt ocaml-conduit 5.0.0 (smorimoto #787)
 - cohttp-mirage: fix deprecated fmt usage (tmcgilchrist #783)
 - lwt_jsoo: Use logs for the warnings and document it (mseri #776)
 - lwt: Use logs to warn users about leaked bodies and document it (mseri #771)

--- a/cohttp-lwt-unix.opam
+++ b/cohttp-lwt-unix.opam
@@ -27,8 +27,8 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.0"}
-  "conduit-lwt" {>= "1.0.3"}
-  "conduit-lwt-unix" {>= "1.0.3"}
+  "conduit-lwt" {>= "5.0.0"}
+  "conduit-lwt-unix" {>= "5.0.0"}
   "cmdliner"
   "magic-mime"
   "logs"

--- a/cohttp-lwt-unix/src/net.ml
+++ b/cohttp-lwt-unix/src/net.ml
@@ -23,12 +23,15 @@ module IO = Io
 type ctx = { ctx : Conduit_lwt_unix.ctx; resolver : Resolver_lwt.t }
 [@@deriving sexp_of]
 
-let init ?(ctx = Conduit_lwt_unix.default_ctx)
+let init ?(ctx = Lazy.force Conduit_lwt_unix.default_ctx)
     ?(resolver = Resolver_lwt_unix.system) () =
   { ctx; resolver }
 
 let default_ctx =
-  { resolver = Resolver_lwt_unix.system; ctx = Conduit_lwt_unix.default_ctx }
+  {
+    resolver = Resolver_lwt_unix.system;
+    ctx = Lazy.force Conduit_lwt_unix.default_ctx;
+  }
 
 let connect_uri ~ctx:{ ctx; resolver } uri =
   Resolver_lwt.resolve_uri ~uri resolver >>= fun endp ->


### PR DESCRIPTION
This PR follows up the missed @avsm comment from https://github.com/mirage/ocaml-conduit/pull/395.