### PR TITLE
Use package core_unix instead of core, to prepare for core release 0.15.

### DIFF
--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -30,6 +30,7 @@ depends: [
   "async" {>= "v0.14.0"}
   "base" {>= "v0.11.0"}
   "core" {with-test}
+  "core_unix" {>= "v0.14.0"}
   "cohttp" {= version}
   "conduit-async" {>= "1.2.0"}
   "magic-mime"

--- a/cohttp-async/bin/cohttp_curl_async.ml
+++ b/cohttp-async/bin/cohttp_curl_async.ml
@@ -52,4 +52,4 @@ let _ =
            (optional_with_default "" string)
            ~doc:" Data to send when using POST")
     make_net_req
-  |> run
+  |> Command_unix.run

--- a/cohttp-async/bin/cohttp_server_async.ml
+++ b/cohttp-async/bin/cohttp_server_async.ml
@@ -126,7 +126,7 @@ let start_server docroot port index cert_file key_file verbose () =
 
 let () =
   let open Async_command in
-  run
+  Command_unix.run
   @@ async_spec ~summary:"Serve the local directory contents via HTTP or HTTPS"
        Spec.(
          empty

--- a/cohttp-async/bin/dune
+++ b/cohttp-async/bin/dune
@@ -3,4 +3,4 @@
  (package cohttp-async)
  (public_names cohttp-curl-async cohttp-server-async)
  (libraries cohttp-async async_kernel async.async_command async_unix base
-   cohttp cohttp_server fmt.tty))
+   cohttp cohttp_server fmt.tty core_unix.command_unix))


### PR DESCRIPTION
In the upcoming Jane Street release, many of the libraries move from package `core` to `core_unix` (package preview: https://github.com/janestreet/core_unix).

`core_unix.v0.14.0` is a compatibility package that is already on opam, so it should be possible to release this change before Jane Street packages v0.15 land.

In fact some of our packages depend on `cohttp-async`, so we'd appreciate it if a minor release that includes this change was made before we can release v0.15.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>