### PR TITLE
[backport] Use package core_unix instead of core, to prepare for core release 0.15.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## current
+
+- Use package core_unix instead of core, to prepare for core release 0.15 (#791 aalekseyev)
+
 ## v2.5.5 (2021-03-15)
 
 - `Cohttp_async.resolve_local_file`, `Cohttp_lwt.resolve_local_file` and `Cohttp_lwt_unix.resolve_file`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## current
 
-- Use package core_unix instead of core, to prepare for core release 0.15 (#791 aalekseyev)
+- cohttp-async: use package core_unix instead of core, to prepare for core release 0.15 (aalekseyev #791 - backport)
+- cohttp-mirage: fix deprecated fmt usage (tmcgilchrist #791 - backport)
 
 ## v2.5.5 (2021-03-15)
 

--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -32,6 +32,7 @@ depends: [
   "core" {with-test}
   "cohttp" {=version}
   "conduit-async" {>="1.2.0" & < "3.0.0"}
+  "core_unix" {>= "v0.14.0"}
   "magic-mime"
   "logs"
   "fmt" {>= "0.8.2"}

--- a/cohttp-async/bin/cohttp_curl_async.ml
+++ b/cohttp-async/bin/cohttp_curl_async.ml
@@ -49,4 +49,4 @@ let _ =
         ~doc:" Data to send when using POST"
     )
     make_net_req
-  |> run
+  |> Command_unix.run

--- a/cohttp-async/bin/cohttp_server_async.ml
+++ b/cohttp-async/bin/cohttp_server_async.ml
@@ -126,7 +126,6 @@ let start_server docroot port index cert_file key_file verbose () =
 
 let () =
   let open Async_command in
-  run @@
   async_spec ~summary:"Serve the local directory contents via HTTP or HTTPS"
     Spec.(
       empty
@@ -137,3 +136,4 @@ let () =
       +> flag "-key-file" (optional string) ~doc:"File of private key for https"
       +> flag "-v" no_arg ~doc:" Verbose logging output to console"
     ) start_server
+  |> Command_unix.run

--- a/cohttp-async/bin/dune
+++ b/cohttp-async/bin/dune
@@ -3,4 +3,4 @@
   (package      cohttp-async)
   (public_names cohttp-curl-async cohttp-server-async)
   (libraries    cohttp-async async_kernel async.async_command async_unix base
-                cohttp cohttp_server fmt.tty))
+                cohttp cohttp_server fmt.tty core_unix.command_unix))

--- a/cohttp-mirage.opam
+++ b/cohttp-mirage.opam
@@ -30,6 +30,7 @@ depends: [
   "cohttp-lwt" {=version}
   "astring"
   "magic-mime"
+  "fmt" {>= "0.8.7"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/cohttp-mirage/src/static.ml
+++ b/cohttp-mirage/src/static.ml
@@ -24,7 +24,7 @@ module HTTP(FS: Mirage_kv.RO)(S: Cohttp_lwt.S.Server) = struct
   open Lwt.Infix
   open Astring
 
-  let failf fmt = Fmt.kstrf Lwt.fail_with fmt
+  let failf fmt = Fmt.kstr Lwt.fail_with fmt
 
   let read_fs t name =
     FS.get t (Key.v name) >>= function
@@ -57,7 +57,7 @@ module HTTP(FS: Mirage_kv.RO)(S: Cohttp_lwt.S.Server) = struct
          | Some fn -> fn uri headers in
         S.respond_string ~status:`OK ~body ~headers ()
       ) (fun _exn ->
-         let with_index = Fmt.strf "%s/index.html" path in
+         let with_index = Fmt.str "%s/index.html" path in
          exists fs with_index >>= function
          | true -> fn fs (Uri.with_path uri with_index)
          | false ->  S.respond_not_found ()


### PR DESCRIPTION
Backport #791