### PR TITLE
refactor: remove some Stringext usage

### DIFF
--- a/cohttp/src/accept_parser.mly
+++ b/cohttp/src/accept_parser.mly
@@ -94,7 +94,7 @@ encodings :
 
 language :
 | TOK params {
-  (get_q $2, Language (Stringext.split ~on:'-' (String.lowercase_ascii $1)))
+  (get_q $2, Language (String.split_on_char '-' (String.lowercase_ascii $1)))
 }
 | STAR params { (get_q $2, AnyLanguage) }
 

--- a/cohttp/src/cookie.ml
+++ b/cohttp/src/cookie.ml
@@ -93,7 +93,7 @@ module Set_cookie_hdr = struct
     let attrs =
       List.map
         (fun attr ->
-          match Stringext.split ~on:'=' attr with
+          match String.split_on_char '=' attr with
           | [] -> ("", "")
           | n :: v -> (n, String.concat "=" v))
         attrs

--- a/cohttp/src/link.ml
+++ b/cohttp/src/link.ml
@@ -299,7 +299,7 @@ let quoted_string_of_string s q =
 
 let rels_of_string_ s q =
   let qs, i = quoted_string_of_string s q in
-  let rels = Stringext.split qs ~on:' ' in
+  let rels = String.split_on_char ' ' qs in
   (List.map rel_of_string (List.filter (fun s -> String.length s > 0) rels), i)
 
 let rels_of_string s i =

--- a/cohttp/src/request.ml
+++ b/cohttp/src/request.ml
@@ -174,7 +174,7 @@ module Make (IO : S.IO) = struct
     let open Code in
     read_line ic >>= function
     | Some request_line -> (
-        match Stringext.split request_line ~on:' ' with
+        match String.split_on_char ' ' request_line with
         | [ meth_raw; path; http_ver_raw ] -> (
             let m = method_of_string meth_raw in
             match version_of_string http_ver_raw with

--- a/cohttp/src/response.ml
+++ b/cohttp/src/response.ml
@@ -68,7 +68,7 @@ module Make (IO : S.IO) = struct
     let open Code in
     read_line ic >>= function
     | Some response_line -> (
-        match Stringext.split response_line ~on:' ' with
+        match String.split_on_char ' ' response_line with
         | version_raw :: code_raw :: _ -> (
             match version_of_string version_raw with
             | (`HTTP_1_0 | `HTTP_1_1) as v ->


### PR DESCRIPTION
String.split_on_char now exists in the stdlib