### PR TITLE
Use new request parser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Unreelased
+
+- Completely new IO & Parsing layers (@anuragsoni #819)
+  + Cohttp now uses an optimized parser for requests and responses.
+  + The new IO layer produces much less temporary buffers.
+
 ## v5.0.0 (2021-12-15)
 
 - Cohttp.Header: new implementation (lyrm #747)

--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -17,6 +17,7 @@ authors: [
   "David Scott"
   "Rudi Grinberg"
   "Andy Ray"
+  "Anurag Soni"
 ]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-cohttp"

--- a/cohttp-async/src/cohttp_async.ml
+++ b/cohttp-async/src/cohttp_async.ml
@@ -5,3 +5,7 @@ module Io = Io [@@deprecated "This module is not for public consumption"]
 module Request = Cohttp.Request [@@deprecated "Use Cohttp.Request directly"]
 module Response = Cohttp.Response [@@deprecated "Use Cohttp.Response directly"]
 module Server = Server
+
+module Private = struct
+  module Input_channel = Input_channel
+end

--- a/cohttp-async/src/input_channel.ml
+++ b/cohttp-async/src/input_channel.ml
@@ -1,0 +1,118 @@
+open! Core
+open! Async
+
+module Bytebuffer = struct
+  open Core
+  open Async
+
+  type t = {
+    mutable buf : Bytes.t;
+    mutable pos_read : int;
+    mutable pos_fill : int;
+  }
+
+  let create size =
+    let buf = Bytes.create size in
+    { buf; pos_read = 0; pos_fill = 0 }
+
+  let unsafe_buf t = t.buf
+  let pos t = t.pos_read
+
+  let compact t =
+    if t.pos_read > 0 then (
+      let len = t.pos_fill - t.pos_read in
+      Bytes.blit ~src:t.buf ~dst:t.buf ~src_pos:t.pos_read ~dst_pos:0 ~len;
+      t.pos_read <- 0;
+      t.pos_fill <- len)
+
+  let length t = t.pos_fill - t.pos_read
+
+  let drop t len =
+    if len < 0 || len > length t then
+      invalid_arg "Bytebuffer.drop: Index out of bounds";
+    t.pos_read <- t.pos_read + len
+
+  let refill t reader =
+    compact t;
+    Reader.read reader t.buf ~pos:t.pos_fill
+      ~len:(Bytes.length t.buf - t.pos_fill)
+    >>| function
+    | `Ok count ->
+        assert (count > 0);
+        t.pos_fill <- t.pos_fill + count;
+        `Ok
+    | `Eof -> `Eof
+
+  let rec index_rec t ch idx len =
+    if idx = len then -1
+    else if Char.equal (Bytes.unsafe_get t.buf (t.pos_read + idx)) ch then
+      idx + t.pos_read
+    else index_rec t ch (idx + 1) len
+
+  let index t ch = index_rec t ch 0 (length t)
+  let to_string t = Bytes.To_string.sub t.buf ~pos:t.pos_read ~len:(length t)
+
+  let rec read_line t reader =
+    let idx = index t '\n' in
+    if idx = -1 then (
+      refill t reader >>= function
+      | `Ok ->
+          Logs.debug (fun m -> m "Read Refill: %S" (to_string t));
+          read_line t reader
+      | `Eof ->
+          Logs.debug (fun m -> m "Read Eof: %S" (to_string t));
+          let len = length t in
+          if len = 0 then return None
+          else
+            let line = Bytes.To_string.sub t.buf ~pos:t.pos_read ~len in
+            drop t len;
+            return (Some line))
+    else
+      let len = idx - t.pos_read in
+      Logs.debug (fun m -> m "Read found: %S" (to_string t));
+      Logs.debug (fun m ->
+          m "Index: %d, pos_read: %d, length: %d" idx t.pos_read (length t));
+      if len >= 1 && Char.equal (Bytes.unsafe_get t.buf (idx - 1)) '\r' then (
+        let line = Bytes.To_string.sub t.buf ~pos:t.pos_read ~len:(len - 1) in
+        drop t (len + 1);
+        return (Some line))
+      else
+        let line = Bytes.To_string.sub t.buf ~pos:t.pos_read ~len in
+        drop t (len + 1);
+        return (Some line)
+
+  let rec read t reader len =
+    let length = length t in
+    if length > 0 then (
+      let to_read = min length len in
+      let buf = Bytes.To_string.sub t.buf ~pos:t.pos_read ~len:to_read in
+      drop t to_read;
+      return buf)
+    else
+      refill t reader >>= function
+      | `Ok -> read t reader len
+      | `Eof -> return ""
+end
+
+type t = { buf : Bytebuffer.t; reader : Reader.t }
+
+let create ?(buf_len = 0x4000) reader =
+  { buf = Bytebuffer.create buf_len; reader }
+
+let read_line_opt t = Bytebuffer.read_line t.buf t.reader
+let read t count = Bytebuffer.read t.buf t.reader count
+let refill t = Bytebuffer.refill t.buf t.reader
+
+let with_input_buffer t ~f =
+  let buf = Bytebuffer.unsafe_buf t.buf in
+  let pos = Bytebuffer.pos t.buf in
+  let len = Bytebuffer.length t.buf in
+  let res, consumed =
+    f (Bytes.unsafe_to_string ~no_mutation_while_string_reachable:buf) ~pos ~len
+  in
+  Bytebuffer.drop t.buf consumed;
+  res
+
+let is_closed t = Reader.is_closed t.reader
+let close t = Reader.close t.reader
+let close_finished t = Reader.close_finished t.reader

--- a/cohttp-async/src/input_channel.mli
+++ b/cohttp-async/src/input_channel.mli
@@ -1,0 +1,12 @@
+open Async
+
+type t
+
+val create : ?buf_len:int -> Reader.t -> t
+val read_line_opt : t -> string option Deferred.t
+val read : t -> int -> string Deferred.t
+val refill : t -> [> `Eof | `Ok ] Deferred.t
+val with_input_buffer : t -> f:(string -> pos:int -> len:int -> 'a * int) -> 'a
+val is_closed : t -> bool
+val close : t -> unit Deferred.t
+val close_finished : t -> unit Deferred.t

--- a/cohttp-async/src/io.mli
+++ b/cohttp-async/src/io.mli
@@ -16,7 +16,7 @@
 module IO :
   Cohttp.S.IO
     with type 'a t = 'a Async_kernel.Deferred.t
-     and type ic = Async_unix.Reader.t
+     and type ic = Input_channel.t
      and type oc = Async_unix.Writer.t
 
 module Request :

--- a/cohttp-async/src/server.mli
+++ b/cohttp-async/src/server.mli
@@ -20,9 +20,7 @@ type 'r respond_t =
 type response_action =
   [ `Expert of
     Cohttp.Response.t
-    * (Async_unix.Reader.t ->
-      Async_unix.Writer.t ->
-      unit Async_kernel.Deferred.t)
+    * (Input_channel.t -> Async_unix.Writer.t -> unit Async_kernel.Deferred.t)
   | `Response of response ]
 (** A request handler can respond in two ways:
 

--- a/cohttp-async/test/test_async_integration.ml
+++ b/cohttp-async/test/test_async_integration.ml
@@ -47,7 +47,8 @@ let server =
         Async_unix.Writer.flushed oc);
     expert (fun ic oc ->
         Async_unix.Writer.write oc "8\r\nexpert 2\r\n0\r\n\r\n";
-        Async_unix.Writer.flushed oc >>= fun () -> Async_unix.Reader.close ic);
+        Async_unix.Writer.flushed oc >>= fun () ->
+        Cohttp_async.Private.Input_channel.close ic);
   ]
   |> response_sequence
 

--- a/cohttp-lwt-jsoo.opam
+++ b/cohttp-lwt-jsoo.opam
@@ -16,6 +16,7 @@ authors: [
   "David Scott"
   "Rudi Grinberg"
   "Andy Ray"
+  "Anurag Soni"
 ]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-cohttp"

--- a/cohttp-lwt-unix.opam
+++ b/cohttp-lwt-unix.opam
@@ -20,6 +20,7 @@ authors: [
   "David Scott"
   "Rudi Grinberg"
   "Andy Ray"
+  "Anurag Soni"
 ]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-cohttp"

--- a/cohttp-lwt-unix/src/cohttp_lwt_unix.ml
+++ b/cohttp-lwt-unix/src/cohttp_lwt_unix.ml
@@ -33,3 +33,7 @@ module Server = Server
 module Debug = Debug
 module Net = Net
 module IO = Io
+
+module Private = struct
+  module Input_channel = Input_channel
+end

--- a/cohttp-lwt-unix/src/input_channel.ml
+++ b/cohttp-lwt-unix/src/input_channel.ml
@@ -1,0 +1,25 @@
+open Lwt.Infix
+module Bytebuffer = Cohttp_lwt.Private.Bytebuffer
+
+type t = { buf : Bytebuffer.t; chan : Lwt_io.input_channel }
+
+let refill ic buf ~pos ~len =
+  Lwt.catch
+    (fun () ->
+      Lwt_io.read_into ic buf pos len >|= fun c -> if c > 0 then `Ok c else `Eof)
+    (function Lwt_io.Channel_closed _ -> Lwt.return `Eof | exn -> raise exn)
+
+let create ?(buf_len = 0x4000) chan = { buf = Bytebuffer.create buf_len; chan }
+let read_line_opt t = Bytebuffer.read_line t.buf (refill t.chan)
+let read t count = Bytebuffer.read t.buf (refill t.chan) count
+let refill t = Bytebuffer.refill t.buf (refill t.chan)
+
+let with_input_buffer t ~f =
+  let buf = Bytebuffer.unsafe_buf t.buf in
+  let pos = Bytebuffer.pos t.buf in
+  let len = Bytebuffer.length t.buf in
+  let res, consumed = f (Bytes.unsafe_to_string buf) ~pos ~len in
+  Bytebuffer.drop t.buf consumed;
+  res
+
+let close t = Lwt_io.close t.chan

--- a/cohttp-lwt-unix/src/io.ml
+++ b/cohttp-lwt-unix/src/io.ml
@@ -27,7 +27,7 @@ type 'a t = 'a Lwt.t
 let ( >>= ) = Lwt.bind
 let return = Lwt.return
 
-type ic = Lwt_io.input_channel
+type ic = Input_channel.t
 type oc = Lwt_io.output_channel
 type conn = Conduit_lwt_unix.flow
 
@@ -50,7 +50,7 @@ let wrap_write f =
 
 let read_line ic =
   wrap_read ~if_closed:None (fun () ->
-      Lwt_io.read_line_opt ic >>= function
+      Input_channel.read_line_opt ic >>= function
       | None ->
           Log.debug (fun f -> f "<<< EOF");
           Lwt.return_none
@@ -61,9 +61,12 @@ let read_line ic =
 let read ic count =
   let count = min count Sys.max_string_length in
   wrap_read ~if_closed:"" (fun () ->
-      Lwt_io.read ~count ic >>= fun buf ->
+      Input_channel.read ic count >>= fun buf ->
       Log.debug (fun f -> f "<<<[%d] %s" count buf);
       Lwt.return buf)
+
+let refill ic = Input_channel.refill ic
+let with_input_buffer ic = Input_channel.with_input_buffer ic
 
 let write oc buf =
   wrap_write @@ fun () ->

--- a/cohttp-lwt-unix/src/io.mli
+++ b/cohttp-lwt-unix/src/io.mli
@@ -21,7 +21,7 @@
 
 include
   Cohttp_lwt.S.IO
-    with type ic = Lwt_io.input_channel
+    with type ic = Input_channel.t
      and type oc = Lwt_io.output_channel
      and type conn = Conduit_lwt_unix.flow
      and type error = exn

--- a/cohttp-lwt-unix/src/net.mli
+++ b/cohttp-lwt-unix/src/net.mli
@@ -36,10 +36,7 @@ val init : ?ctx:Conduit_lwt_unix.ctx -> ?resolver:Resolver_lwt.t -> unit -> ctx
 val connect_uri :
   ctx:ctx ->
   Uri.t ->
-  (Conduit_lwt_unix.flow
-  * Lwt_io.input Lwt_io.channel
-  * Lwt_io.output Lwt_io.channel)
-  Lwt.t
+  (Conduit_lwt_unix.flow * Input_channel.t * Lwt_io.output Lwt_io.channel) Lwt.t
 (** [connect_uri ~ctx uri] starts a {i flow} on the given [uri]. The choice of
     the protocol (with or without encryption) is done by the {i scheme} of the
     given [uri]:
@@ -55,6 +52,6 @@ val connect_uri :
     able to fill its own [ctx] and we don't overlap resolution functions from
     the given [ctx]. *)
 
-val close_in : 'a Lwt_io.channel -> unit
+val close_in : Input_channel.t -> unit
 val close_out : 'a Lwt_io.channel -> unit
-val close : 'a Lwt_io.channel -> 'b Lwt_io.channel -> unit
+val close : Input_channel.t -> 'b Lwt_io.channel -> unit

--- a/cohttp-lwt-unix/src/server.ml
+++ b/cohttp-lwt-unix/src/server.ml
@@ -67,4 +67,6 @@ let log_on_exn = function
 let create ?timeout ?backlog ?stop ?(on_exn = log_on_exn)
     ?(ctx = Net.default_ctx) ?(mode = `TCP (`Port 8080)) spec =
   Conduit_lwt_unix.serve ?backlog ?timeout ?stop ~on_exn ~ctx:ctx.Net.ctx ~mode
-    (callback spec)
+    (fun flow ic oc ->
+      let ic = Input_channel.create ic in
+      callback spec flow ic oc)

--- a/cohttp-lwt-unix/test/test_parser.ml
+++ b/cohttp-lwt-unix/test/test_parser.ml
@@ -93,7 +93,11 @@ let chunked_res =
 
 let user_agent = Cohttp.Header.user_agent
 let basic_res_plus_crlf = basic_res ^ "\r\n\r\n"
-let ic_of_buffer buf = Lwt_io.of_bytes ~mode:Lwt_io.input buf
+
+let ic_of_buffer buf =
+  Cohttp_lwt_unix.Private.Input_channel.create
+    (Lwt_io.of_bytes ~mode:Lwt_io.input buf)
+
 let oc_of_buffer buf = Lwt_io.of_bytes ~mode:Lwt_io.output buf
 
 open Lwt

--- a/cohttp-lwt-unix/test/test_sanity.ml
+++ b/cohttp-lwt-unix/test/test_sanity.ml
@@ -63,7 +63,8 @@ let server =
             ( Cohttp.Response.make (),
               fun ic oc ->
                 Lwt_io.write oc "8\r\nexpert 2\r\n0\r\n\r\n" >>= fun () ->
-                Lwt_io.flush oc >>= fun () -> Lwt_io.close ic )));
+                Lwt_io.flush oc >>= fun () ->
+                Cohttp_lwt_unix.Private.Input_channel.close ic )));
     ]
   @ (* client_close *)
   [

--- a/cohttp-lwt.opam
+++ b/cohttp-lwt.opam
@@ -18,6 +18,7 @@ authors: [
   "David Scott"
   "Rudi Grinberg"
   "Andy Ray"
+  "Anurag Soni"
 ]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-cohttp"

--- a/cohttp-lwt/src/bytebuffer.ml
+++ b/cohttp-lwt/src/bytebuffer.ml
@@ -1,0 +1,107 @@
+module Bytes = BytesLabels
+open Lwt.Infix
+
+type refill = bytes -> pos:int -> len:int -> [ `Ok of int | `Eof ] Lwt.t
+
+(* Bytebuffer is split into three regions using two separate indices that are used
+   to support read and write operations.
+   +--------------------+---------------------------+----------------------------+
+   | Consumed Bytes     | Bytes available to read   | Empty space for writing    |
+   +--------------------+---------------------------+----------------------------+
+   |     0 <=       pos_read         <=          pos_fill              <= capacity
+
+   Consumed Bytes: This is content that's already consumed via a get/read operation.
+   This space can be safely reclaimed.
+
+   Bytes available to read: This is the actual content that will be surfaced to users via
+   get/read operations on the bytebuffer.
+
+   Empty space for writing: This is space that will be filled by any set/write operations
+   on the bytebuffer.
+*)
+
+type t = {
+  mutable buf : Bytes.t;
+  mutable pos_read : int;
+  mutable pos_fill : int;
+}
+
+let create size =
+  let buf = Bytes.create size in
+  { buf; pos_read = 0; pos_fill = 0 }
+
+let unsafe_buf t = t.buf
+let pos t = t.pos_read
+
+let compact t =
+  if t.pos_read > 0 then (
+    let len = t.pos_fill - t.pos_read in
+    Bytes.blit ~src:t.buf ~dst:t.buf ~src_pos:t.pos_read ~dst_pos:0 ~len;
+    t.pos_read <- 0;
+    t.pos_fill <- len)
+
+let length t = t.pos_fill - t.pos_read
+
+let drop t len =
+  if len < 0 || len > length t then
+    invalid_arg "Bytebuffer.drop: Index out of bounds";
+  t.pos_read <- t.pos_read + len
+
+let refill t read_into =
+  compact t;
+  read_into t.buf ~pos:t.pos_fill ~len:(Bytes.length t.buf - t.pos_fill)
+  >|= function
+  | `Ok count ->
+      t.pos_fill <- t.pos_fill + count;
+      `Ok
+  | `Eof -> `Eof
+
+let rec index_rec t ch idx len =
+  if idx = len then -1
+  else if Char.equal (Bytes.unsafe_get t.buf (t.pos_read + idx)) ch then
+    idx + t.pos_read
+  else index_rec t ch (idx + 1) len
+
+let index t ch = index_rec t ch 0 (length t)
+let to_string t = Bytes.sub_string t.buf ~pos:t.pos_read ~len:(length t)
+
+let rec read_line t reader =
+  let idx = index t '\n' in
+  if idx = -1 then (
+    refill t reader >>= function
+    | `Ok ->
+        Logs.debug (fun m -> m "Read Refill: %S" (to_string t));
+        read_line t reader
+    | `Eof ->
+        Logs.debug (fun m -> m "Read Eof: %S" (to_string t));
+        let len = length t in
+        if len = 0 then Lwt.return None
+        else
+          let line = Bytes.sub_string t.buf ~pos:t.pos_read ~len in
+          drop t len;
+          Lwt.return (Some line))
+  else
+    let len = idx - t.pos_read in
+    Logs.debug (fun m -> m "Read found: %S" (to_string t));
+    Logs.debug (fun m ->
+        m "Index: %d, pos_read: %d, length: %d" idx t.pos_read (length t));
+    if len >= 1 && Char.equal (Bytes.unsafe_get t.buf (idx - 1)) '\r' then (
+      let line = Bytes.sub_string t.buf ~pos:t.pos_read ~len:(len - 1) in
+      drop t (len + 1);
+      Lwt.return (Some line))
+    else
+      let line = Bytes.sub_string t.buf ~pos:t.pos_read ~len in
+      drop t (len + 1);
+      Lwt.return (Some line)
+
+let rec read t reader len =
+  let length = length t in
+  if length > 0 then (
+    let to_read = min length len in
+    let buf = Bytes.sub_string t.buf ~pos:t.pos_read ~len:to_read in
+    drop t to_read;
+    Lwt.return buf)
+  else
+    refill t reader >>= function
+    | `Ok -> read t reader len
+    | `Eof -> Lwt.return ""

--- a/cohttp-lwt/src/bytebuffer.mli
+++ b/cohttp-lwt/src/bytebuffer.mli
@@ -1,0 +1,13 @@
+type t
+type refill = bytes -> pos:int -> len:int -> [ `Ok of int | `Eof ] Lwt.t
+
+val create : int -> t
+val unsafe_buf : t -> Bytes.t
+val pos : t -> int
+val compact : t -> unit
+val length : t -> int
+val drop : t -> int -> unit
+val refill : t -> refill -> [ `Ok | `Eof ] Lwt.t
+val to_string : t -> string
+val read_line : t -> refill -> string option Lwt.t
+val read : t -> refill -> int -> string Lwt.t

--- a/cohttp-lwt/src/cohttp_lwt.ml
+++ b/cohttp-lwt/src/cohttp_lwt.ml
@@ -24,5 +24,6 @@ module S = S
 module Body = Body
 
 module Private = struct
+  module Bytebuffer = Bytebuffer
   module String_io = String_io
 end

--- a/cohttp-lwt/src/string_io.ml
+++ b/cohttp-lwt/src/string_io.ml
@@ -26,6 +26,8 @@ type ic = Sio.M.ic
 type oc = Sio.M.oc
 type conn = Sio.M.conn
 
+let refill ic = return (Sio.M.refill ic)
+let with_input_buffer ic ~f = Sio.M.with_input_buffer ic ~f
 let read_line ic = return (Sio.M.read_line ic)
 let read ic n = return (Sio.M.read ic n)
 let write oc str = return (Sio.M.write oc str)

--- a/cohttp-mirage.opam
+++ b/cohttp-mirage.opam
@@ -20,6 +20,7 @@ authors: [
   "David Scott"
   "Rudi Grinberg"
   "Andy Ray"
+  "Anurag Soni"
 ]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-cohttp"

--- a/cohttp-mirage/src/client.ml
+++ b/cohttp-mirage/src/client.ml
@@ -26,6 +26,7 @@ module Make
 struct
   module Channel = Mirage_channel.Make (S.Flow)
   module HTTP_IO = Io.Make (Channel)
+  module Input_channel = Input_channel.Make (Channel)
   module Endpoint = Conduit_mirage.Endpoint (P)
 
   module Net_IO = struct
@@ -50,7 +51,7 @@ struct
       | Some c ->
           S.connect c client >>= fun flow ->
           let ch = Channel.create flow in
-          Lwt.return (flow, ch, ch)
+          Lwt.return (flow, Input_channel.create ch, ch)
 
     let close_in _ = ()
     let close_out _ = ()
@@ -58,7 +59,7 @@ struct
     let close ic _oc =
       Lwt.ignore_result
       @@ Lwt.catch
-           (fun () -> Channel.close ic)
+           (fun () -> Input_channel.close ic)
            (fun e ->
              Logs.warn (fun f ->
                  f "Closing channel failed: %s" (Printexc.to_string e));

--- a/cohttp-mirage/src/input_channel.ml
+++ b/cohttp-mirage/src/input_channel.ml
@@ -1,0 +1,34 @@
+open Lwt.Infix
+module Bytebuffer = Cohttp_lwt.Private.Bytebuffer
+
+module Make (Channel : Mirage_channel.S) = struct
+  exception Read_exn of Channel.error
+
+  type t = { chan : Channel.t; buf : Bytebuffer.t }
+
+  let refill chan buf ~pos ~len =
+    Channel.read_some ~len chan >>= function
+    | Ok (`Data v) ->
+        let len = Cstruct.length v in
+        Cstruct.blit_to_bytes v 0 buf pos len;
+        Lwt.return (`Ok len)
+    | Ok `Eof -> Lwt.return `Eof
+    | Error e -> Lwt.fail (Read_exn e)
+
+  let create ?(buf_len = 0x4000) chan =
+    { buf = Bytebuffer.create buf_len; chan }
+
+  let read_line_opt t = Bytebuffer.read_line t.buf (refill t.chan)
+  let read t count = Bytebuffer.read t.buf (refill t.chan) count
+  let refill t = Bytebuffer.refill t.buf (refill t.chan)
+
+  let with_input_buffer t ~f =
+    let buf = Bytebuffer.unsafe_buf t.buf in
+    let pos = Bytebuffer.pos t.buf in
+    let len = Bytebuffer.length t.buf in
+    let res, consumed = f (Bytes.unsafe_to_string buf) ~pos ~len in
+    Bytebuffer.drop t.buf consumed;
+    res
+
+  let close t = Channel.close t.chan
+end

--- a/cohttp-mirage/src/io.mli
+++ b/cohttp-mirage/src/io.mli
@@ -21,6 +21,6 @@
 
 module Make (Channel : Mirage_channel.S) :
   Cohttp_lwt.S.IO
-    with type ic = Channel.t
+    with type ic = Input_channel.Make(Channel).t
      and type oc = Channel.t
      and type conn = Channel.flow

--- a/cohttp-mirage/src/make.ml
+++ b/cohttp-mirage/src/make.ml
@@ -3,11 +3,12 @@ open Lwt.Infix
 module Server (Flow : Mirage_flow.S) = struct
   module Channel = Mirage_channel.Make (Flow)
   module HTTP_IO = Io.Make (Channel)
+  module Input_channel = Input_channel.Make (Channel)
   include Cohttp_lwt.Make_server (HTTP_IO)
 
   let listen spec flow =
     let ch = Channel.create flow in
     Lwt.finalize
-      (fun () -> callback spec flow ch ch)
+      (fun () -> callback spec flow (Input_channel.create ch) ch)
       (fun () -> Channel.close ch >|= fun _ -> ())
 end

--- a/cohttp-mirage/src/server.ml
+++ b/cohttp-mirage/src/server.ml
@@ -9,12 +9,13 @@ end
 module Flow (F : Mirage_flow.S) = struct
   module Channel = Mirage_channel.Make (F)
   module HTTP_IO = Io.Make (Channel)
+  module Input_channel = Input_channel.Make (Channel)
   include Cohttp_lwt.Make_server (HTTP_IO)
 
   let callback spec flow =
     let ch = Channel.create flow in
     Lwt.finalize
-      (fun () -> callback spec flow ch ch)
+      (fun () -> callback spec flow (Input_channel.create ch) ch)
       (fun () -> Channel.close ch >|= fun _ -> ())
 end
 

--- a/cohttp-top.opam
+++ b/cohttp-top.opam
@@ -16,6 +16,7 @@ authors: [
   "David Scott"
   "Rudi Grinberg"
   "Andy Ray"
+  "Anurag Soni"
 ]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-cohttp"

--- a/cohttp.opam
+++ b/cohttp.opam
@@ -27,6 +27,7 @@ authors: [
   "David Scott"
   "Rudi Grinberg"
   "Andy Ray"
+  "Anurag Soni"
 ]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-cohttp"

--- a/cohttp/src/s.ml
+++ b/cohttp/src/s.ml
@@ -39,6 +39,11 @@ module type IO = sig
   type conn
   (** [conn] represents the underlying network flow *)
 
+  val refill : ic -> [ `Ok | `Eof ] t
+
+  val with_input_buffer :
+    ic -> f:(string -> pos:int -> len:int -> 'a * int) -> 'a
+
   val read_line : ic -> string option t
   (** [read_line ic] will read a single line terminated by CR or CRLF from the
       input channel [ic]. It returns {!None} if EOF or other error condition is

--- a/cohttp/src/string_io.ml
+++ b/cohttp/src/string_io.ml
@@ -66,6 +66,13 @@ module M = struct
       x.pos <- x.pos + n;
       Some s
 
+  let refill _ = `Eof
+
+  let with_input_buffer t ~f =
+    let res, count = f t.str ~pos:t.pos ~len:(t.len - t.pos) in
+    t.pos <- t.pos + count;
+    res
+
   let read x n =
     match read_exactly' x n with
     | None when x.pos >= x.len -> raise End_of_file

--- a/cohttp/test/test_request.ml
+++ b/cohttp/test/test_request.ml
@@ -218,7 +218,7 @@ let parse_request_uri_host_query_no_slash _ =
   parse_request_uri_ r bad_request "parse_request_uri_host_query_no_slash"
 
 let parse_request_connect _ =
-  let r = "CONNECT vpn.example.net:443 HTTP/1.1\r\n" in
+  let r = "CONNECT vpn.example.net:443 HTTP/1.1\r\n\r\n" in
   let uri = `Ok (Uri.of_string "//vpn.example.net:443") in
   parse_request_uri_ r uri "parse_request_connect"
 

--- a/cohttp_async_test/src/cohttp_async_test.ml
+++ b/cohttp_async_test/src/cohttp_async_test.ml
@@ -5,7 +5,7 @@ module Server = Cohttp_async.Server
 module Body = Cohttp_async.Body
 
 type 'a io = 'a Deferred.t
-type ic = Async_unix.Reader.t
+type ic = Cohttp_async.Private.Input_channel.t
 type oc = Async_unix.Writer.t
 type body = Body.t
 

--- a/cohttp_async_test/src/cohttp_async_test.mli
+++ b/cohttp_async_test/src/cohttp_async_test.mli
@@ -4,7 +4,7 @@ include
   Cohttp_test.S
     with type 'a io = 'a Deferred.t
      and type body = Cohttp_async.Body.t
-     and type ic = Async_unix.Reader.t
+     and type ic = Cohttp_async.Private.Input_channel.t
      and type oc = Async_unix.Writer.t
 
 val run_async_tests : OUnit.test io -> OUnit.test_result list Deferred.t

--- a/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.ml
+++ b/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.ml
@@ -3,7 +3,7 @@ open OUnit
 open Cohttp_lwt_unix
 
 type 'a io = 'a Lwt.t
-type ic = Lwt_io.input_channel
+type ic = Cohttp_lwt_unix.Private.Input_channel.t
 type oc = Lwt_io.output_channel
 type body = Cohttp_lwt.Body.t
 

--- a/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.mli
+++ b/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.mli
@@ -2,5 +2,5 @@ include
   Cohttp_test.S
     with type 'a io = 'a Lwt.t
      and type body = Cohttp_lwt.Body.t
-     and type ic = Lwt_io.input_channel
+     and type ic = Cohttp_lwt_unix.Private.Input_channel.t
      and type oc = Lwt_io.output_channel

--- a/dune-project
+++ b/dune-project
@@ -10,7 +10,8 @@
   "Thomas Gazagnaire"
   "David Scott"
   "Rudi Grinberg"
-  "Andy Ray")
+  "Andy Ray"
+  "Anurag Soni")
 (source (github mirage/ocaml-cohttp))
 (documentation "https://mirage.github.io/ocaml-cohttp/")
 
@@ -200,6 +201,11 @@ interoperate with Cohttp.")
  (depends
   (ocaml (>= 4.08))
   (alcotest :with-test)
+  (base_quickcheck :with-test)
+  (ppx_assert :with-test)
+  (ppx_sexp_conv :with-test)
+  (ppx_compare :with-test)
+  (ppx_here :with-test)
   (core (and :with-test (>= v0.13.0)))
   (core_bench :with-test)
   (crowbar :with-test)

--- a/examples/bench/async_server.ml
+++ b/examples/bench/async_server.ml
@@ -1,0 +1,27 @@
+open Core
+open Async
+open Cohttp_async
+
+let text = String.make 2053 'a'
+let handler ~body:_ _sock _req = Server.respond_string text
+
+let start_server port () =
+  Cohttp_async.Server.create ~on_handler_error:`Raise
+    (Tcp.Where_to_listen.of_port port)
+    handler
+  >>= fun server ->
+  Deferred.forever () (fun () ->
+      after Time.Span.(of_sec 0.5) >>| fun () ->
+      Log.Global.printf "Active connections: %d" (Server.num_connections server));
+  Deferred.never ()
+
+let () =
+  let module Command = Async_command in
+  Command.async_spec ~summary:"Start a hello world Async server"
+    Command.Spec.(
+      empty
+      +> flag "-p"
+           (optional_with_default 8080 int)
+           ~doc:"int Source port to listen on")
+    start_server
+  |> Command.run

--- a/examples/bench/dune
+++ b/examples/bench/dune
@@ -1,0 +1,9 @@
+(executable
+ (name lwt_unix_server)
+ (modules lwt_unix_server)
+ (libraries cohttp-lwt-unix logs.fmt fmt.tty))
+
+(executable
+ (name async_server)
+ (modules async_server)
+ (libraries cohttp-async logs.fmt fmt.tty))

--- a/examples/bench/lwt_unix_server.ml
+++ b/examples/bench/lwt_unix_server.ml
@@ -1,0 +1,15 @@
+open Cohttp_lwt_unix
+
+let text = String.make 2053 'a'
+
+let server_callback _conn _req _body =
+  Server.respond_string ~status:`OK ~body:text ()
+
+let main () =
+  Server.create ~backlog:11_000 (Server.make ~callback:server_callback ())
+
+let () =
+  Printexc.record_backtrace true;
+  Logs.set_level (Some Info);
+  Logs.set_reporter (Logs_fmt.reporter ());
+  ignore (Lwt_main.run (main ()))

--- a/http.opam
+++ b/http.opam
@@ -14,6 +14,7 @@ authors: [
   "David Scott"
   "Rudi Grinberg"
   "Andy Ray"
+  "Anurag Soni"
 ]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-cohttp"
@@ -23,6 +24,11 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08"}
   "alcotest" {with-test}
+  "base_quickcheck" {with-test}
+  "ppx_assert" {with-test}
+  "ppx_sexp_conv" {with-test}
+  "ppx_compare" {with-test}
+  "ppx_here" {with-test}
   "core" {with-test & >= "v0.13.0"}
   "core_bench" {with-test}
   "crowbar" {with-test}

--- a/http/src/http.ml
+++ b/http/src/http.ml
@@ -732,3 +732,317 @@ module Response = struct
   let status t = t.status
   let flush t = t.flush
 end
+
+module Parser = struct
+  let[@inline always] is_tchar = function
+    | '0' .. '9'
+    | 'a' .. 'z'
+    | 'A' .. 'Z'
+    | '!' | '#' | '$' | '%' | '&' | '\'' | '*' | '+' | '-' | '.' | '^' | '_'
+    | '`' | '|' | '~' ->
+        true
+    | _ -> false
+
+  module Source = struct
+    type t = { buffer : string; mutable pos : int; upper_bound : int }
+
+    let of_bytes ~pos ?len buffer =
+      let buf_len = String.length buffer in
+      if pos < 0 || pos > buf_len then
+        invalid_arg
+          (Printf.sprintf
+             "Http_parser.Source.of_bigstring: Invalid offset %d. Buffer \
+              length: %d"
+             pos buf_len);
+      let len = Option.value len ~default:(buf_len - pos) in
+      if len < 0 || pos + len > buf_len then
+        invalid_arg
+          (Printf.sprintf
+             "Http_parser.Source.of_bigstring: Invalid len %d. offset: %d, \
+              buffer_length: %d, requested_length: %d"
+             len pos buf_len (pos + len));
+      { buffer; pos; upper_bound = pos + len }
+
+    let[@inline always] get_unsafe t idx =
+      String.unsafe_get t.buffer (t.pos + idx)
+
+    let[@inline always] get t idx =
+      if idx < 0 || t.pos + idx >= t.upper_bound then
+        invalid_arg "Http_parser.Source.get: Index out of bounds";
+      String.unsafe_get t.buffer (t.pos + idx)
+
+    let[@inline always] advance_unsafe t count = t.pos <- t.pos + count
+
+    let[@inline always] advance t count =
+      if count < 0 || t.pos + count > t.upper_bound then
+        invalid_arg
+          (Printf.sprintf
+             "Http_parser.Source.advance: Index out of bounds. Requested \
+              count: %d"
+             count);
+      t.pos <- t.pos + count
+
+    let[@inline always] length t = t.upper_bound - t.pos
+    let[@inline always] is_empty t = t.pos = t.upper_bound
+
+    let[@inline always] to_string t ~pos ~len =
+      if
+        pos < 0
+        || t.pos + pos >= t.upper_bound
+        || len < 0
+        || t.pos + pos + len > t.upper_bound
+      then
+        invalid_arg
+          (Format.asprintf
+             "Http_parser.Source.substring: Index out of bounds., Requested \
+              off: %d, len: %d"
+             pos len);
+      String.sub t.buffer (t.pos + pos) len
+
+    let[@inline always] is_space = function
+      | ' ' | '\012' | '\n' | '\r' | '\t' -> true
+      | _ -> false
+
+    let[@inline always] to_string_trim t ~pos ~len =
+      if
+        pos < 0
+        || t.pos + pos >= t.upper_bound
+        || len < 0
+        || t.pos + pos + len > t.upper_bound
+      then
+        invalid_arg
+          (Format.asprintf
+             "Http_parser.Source.substring: Index out of bounds., Requested \
+              off: %d, len: %d"
+             pos len);
+      let last = ref (t.pos + len - 1) in
+      let pos = ref (t.pos + pos) in
+      while is_space (String.unsafe_get t.buffer !pos) do
+        incr pos
+      done;
+      while is_space (String.unsafe_get t.buffer !last) do
+        decr last
+      done;
+      let len = !last - !pos + 1 in
+      String.sub t.buffer !pos len
+
+    let rec index_rec t ch idx len =
+      if idx = len then -1
+      else if String.unsafe_get t.buffer (t.pos + idx) = ch then idx
+      else index_rec t ch (idx + 1) len
+
+    let index t ch = index_rec t ch 0 (length t)
+
+    let for_all_is_tchar t ~pos ~len =
+      if
+        pos < 0
+        || t.pos + pos >= t.upper_bound
+        || len < 0
+        || t.pos + pos + len > t.upper_bound
+      then
+        invalid_arg
+          (Format.asprintf
+             "Http_parser.Source.substring: Index out of bounds. Requested \
+              off: %d, len: %d"
+             pos len);
+      let pos = ref (t.pos + pos) in
+      let len = t.pos + len in
+      while !pos < len && is_tchar (String.unsafe_get t.buffer !pos) do
+        incr pos
+      done;
+      !pos = len
+
+    let unsafe_memcmp t pos str =
+      let rec loop t pos str len =
+        if pos = len then true
+        else
+          Char.equal (get_unsafe t pos) (String.unsafe_get str pos)
+          && loop t (pos + 1) str len
+      in
+      loop t pos str (String.length str)
+  end
+
+  exception Msg of string
+  exception Partial
+
+  let string str source =
+    let len = String.length str in
+    if Source.length source < len then raise_notrace Partial
+    else if Source.unsafe_memcmp source 0 str then Source.advance source len
+    else raise_notrace (Msg (Printf.sprintf "Could not match: %S" str))
+
+  let any_char source =
+    if Source.is_empty source then raise_notrace Partial
+    else
+      let c = Source.get_unsafe source 0 in
+      Source.advance_unsafe source 1;
+      c
+
+  let eol = string "\r\n"
+
+  (* token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^"
+     / "_" / "`" / "|" / "~" / DIGIT / ALPHA ; any VCHAR, except delimiters *)
+
+  let token source =
+    let pos = Source.index source ' ' in
+    if pos = -1 then raise_notrace Partial
+    else
+      let res = Source.to_string source ~pos:0 ~len:pos in
+      Source.advance source (pos + 1);
+      res
+
+  let meth source =
+    let token = token source in
+    Method.of_string token
+
+  let version_source source =
+    string "HTTP/1." source;
+    any_char source
+
+  let version source =
+    let ch = version_source source in
+    match ch with
+    | '1' -> `HTTP_1_1
+    | '0' -> `HTTP_1_0
+    | _ -> raise_notrace (Msg "Invalid http version")
+
+  let header source =
+    let pos = Source.index source ':' in
+    if pos = -1 then raise_notrace Partial
+    else if pos = 0 then raise_notrace (Msg "Invalid header: Empty header key")
+    else if Source.for_all_is_tchar source ~pos:0 ~len:pos then (
+      let key = Source.to_string source ~pos:0 ~len:pos in
+      Source.advance_unsafe source (pos + 1);
+      while
+        (not (Source.is_empty source)) && Source.get_unsafe source 0 = ' '
+      do
+        Source.advance_unsafe source 1
+      done;
+      let pos = Source.index source '\r' in
+      if pos = -1 then raise_notrace Partial
+      else
+        let v = Source.to_string_trim source ~pos:0 ~len:pos in
+        Source.advance_unsafe source pos;
+        (key, v))
+    else raise_notrace (Msg "Invalid Header Key")
+
+  let headers =
+    let rec loop source acc =
+      if (not (Source.is_empty source)) && Source.get_unsafe source 0 = '\r'
+      then (
+        eol source;
+        Header.of_list (List.rev acc))
+      else
+        let v = header source in
+        eol source;
+        loop source (v :: acc)
+    in
+    fun source -> loop source []
+
+  let chunk_length source =
+    let ( lsl ) = Int64.shift_left in
+    let ( lor ) = Int64.logor in
+    let length = ref 0L in
+    let stop = ref false in
+    let state = ref `Ok in
+    let count = ref 0 in
+    let processing_chunk = ref true in
+    let in_chunk_extension = ref false in
+    while not !stop do
+      if Source.is_empty source then (
+        stop := true;
+        state := `Partial)
+      else if !count = 16 && not !in_chunk_extension then (
+        stop := true;
+        state := `Chunk_too_big)
+      else
+        let ch = Source.get source 0 in
+        Source.advance source 1;
+        incr count;
+        match ch with
+        | '0' .. '9' as ch when !processing_chunk ->
+            let curr = Int64.of_int (Char.code ch - Char.code '0') in
+            length := (!length lsl 4) lor curr
+        | 'a' .. 'f' as ch when !processing_chunk ->
+            let curr = Int64.of_int (Char.code ch - Char.code 'a' + 10) in
+            length := (!length lsl 4) lor curr
+        | 'A' .. 'F' as ch when !processing_chunk ->
+            let curr = Int64.of_int (Char.code ch - Char.code 'A' + 10) in
+            length := (!length lsl 4) lor curr
+        | ';' when not !in_chunk_extension ->
+            in_chunk_extension := true;
+            processing_chunk := false
+        | ('\t' | ' ') when !processing_chunk -> processing_chunk := false
+        | ('\t' | ' ') when (not !in_chunk_extension) && not !processing_chunk
+          ->
+            ()
+        | '\r' ->
+            if Source.is_empty source then (
+              stop := true;
+              state := `Partial)
+            else if Source.get source 0 = '\n' then (
+              Source.advance source 1;
+              stop := true)
+            else (
+              stop := true;
+              state := `Expected_newline)
+        | _ when !in_chunk_extension ->
+            (* Chunk extensions aren't very common, see:
+               https://tools.ietf.org/html/rfc7230#section-4.1.1 Chunk extensions aren't
+               pre-defined, and they are specific to invidividual connections. In the future
+               we might surface these to the user somehow, but for now we will ignore any
+               extensions. TODO: Should there be any limit on the size of chunk extensions we
+               parse? We might want to error if a request contains really large chunk
+               extensions. *)
+            ()
+        | ch ->
+            stop := true;
+            state := `Invalid_char ch
+    done;
+    match !state with
+    | `Ok -> !length
+    | `Partial -> raise_notrace Partial
+    | `Expected_newline -> raise_notrace (Msg "Expected_newline")
+    | `Chunk_too_big -> raise_notrace (Msg "Chunk size is too large")
+    | `Invalid_char ch ->
+        raise_notrace
+          (Msg (Printf.sprintf "Invalid chunk_length character %C" ch))
+
+  let version source =
+    let version = version source in
+    eol source;
+    version
+
+  let[@warning "-3"] request source =
+    let meth = meth source in
+    let path = token source in
+    let version = version source in
+    let headers = headers source in
+    {
+      Request.headers;
+      meth;
+      scheme = None;
+      resource = path;
+      version;
+      encoding = Header.get_transfer_encoding headers;
+    }
+
+  type error = Partial | Msg of string
+
+  let run_parser ?pos ?len buf p =
+    let pos = Option.value pos ~default:0 in
+    let source = Source.of_bytes ~pos ?len buf in
+    match p source with
+    | exception Partial -> Error Partial
+    | exception Msg m -> Error (Msg m)
+    | v ->
+        let consumed = source.pos - pos in
+        Ok (v, consumed)
+
+  let parse_request ?pos ?len buf = run_parser ?pos ?len buf request
+  let parse_chunk_length ?pos ?len buf = run_parser ?pos ?len buf chunk_length
+end
+
+module Private = struct
+  module Parser = Parser
+end

--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -405,3 +405,19 @@ module Response : sig
       "content-length", "content-range" and "transfer-encoding". The default
       value of [encoding] is chunked. *)
 end
+
+module Private : sig
+  module Parser : sig
+    (** Attempts to parse a buffer into a HTTP request. If successful, it
+        returns the parsed request and an offset value that indicates the
+        starting point of unconsumed content left in the buffer. *)
+
+    type error = Partial | Msg of string
+
+    val parse_request :
+      ?pos:int -> ?len:int -> string -> (Request.t * int, error) result
+
+    val parse_chunk_length :
+      ?pos:int -> ?len:int -> string -> (int64 * int, error) result
+  end
+end

--- a/http/test/dune
+++ b/http/test/dune
@@ -9,3 +9,16 @@
  (package http)
  (action
   (run ./test_header.exe)))
+
+(test
+ (name test_parser)
+ (modules test_parser)
+ (package http)
+ (preprocess
+  (pps
+   base_quickcheck.ppx_quickcheck
+   ppx_assert
+   ppx_sexp_conv
+   ppx_compare
+   ppx_here))
+ (libraries http core base_quickcheck alcotest))

--- a/http/test/test_parser.ml
+++ b/http/test/test_parser.ml
@@ -1,0 +1,267 @@
+open Base
+module Parser = Http.Private.Parser
+
+let req =
+  "GET /wp-content/uploads/2010/03/hello-kitty-darth-vader-pink.jpg HTTP/1.1\r\n\
+   Host: www.kittyhell.com   \r\n\
+   User-Agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; ja-JP-mac; \
+   rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 Pathtraq/0.9\r\n\
+   Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n\
+   Accept-Language: ja,en-us;q=0.7,en;q=0.3\r\n\
+   Accept-Encoding: gzip,deflate\r\n\
+   Accept-Charset: Shift_JIS,utf-8;q=0.7,*;q=0.7\r\n\
+   Keep-Alive: 115\r\n\
+   Connection: keep-alive\r\n\
+   Cookie: wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; \
+   __utma=xxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.x; \
+   __utmz=xxxxxxxxx.xxxxxxxxxx.x.x.utmccn=(referral)|utmcsr=reader.livedoor.com|utmcct=/reader/|utmcmd=referral\r\n\
+   \r\n"
+
+let assert_req_success ~here ~expected_req ~expected_consumed ?pos ?len buf =
+  let buf = String.subo ?pos ?len buf in
+  let req, consumed =
+    match Parser.parse_request buf with
+    | Error Parser.Partial -> failwith "Unexpected partial parse"
+    | Error (Parser.Msg msg) -> failwith msg
+    | Ok res -> res
+  in
+  [%test_result: string] ~here ~message:"HTTP Method mismatch"
+    ~expect:(Http.Method.to_string @@ Http.Request.meth expected_req)
+    (Http.Method.to_string @@ Http.Request.meth req);
+  [%test_result: string] ~here ~message:"path mismatch"
+    ~expect:(Http.Request.resource expected_req)
+    (Http.Request.resource req);
+  [%test_result: (string * string) list] ~here ~message:"header mismatch"
+    ~expect:(Http.Header.to_list @@ Http.Request.headers expected_req)
+    (Http.Header.to_list @@ Http.Request.headers req);
+  [%test_result: int] ~here ~expect:expected_consumed consumed
+
+let[@warning "-3"] make_req ~headers ?(encoding = Http.Transfer.Fixed 0L) meth
+    resource =
+  {
+    Http.Request.headers;
+    meth;
+    resource;
+    scheme = None;
+    encoding;
+    version = `HTTP_1_1;
+  }
+
+let req_expected =
+  make_req
+    ~headers:
+      (Http.Header.of_list
+         [
+           ("Host", "www.kittyhell.com");
+           ( "User-Agent",
+             "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; ja-JP-mac; \
+              rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 Pathtraq/0.9" );
+           ( "Accept",
+             "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+           );
+           ("Accept-Language", "ja,en-us;q=0.7,en;q=0.3");
+           ("Accept-Encoding", "gzip,deflate");
+           ("Accept-Charset", "Shift_JIS,utf-8;q=0.7,*;q=0.7");
+           ("Keep-Alive", "115");
+           ("Connection", "keep-alive");
+           ( "Cookie",
+             "wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; \
+              __utma=xxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.x; \
+              __utmz=xxxxxxxxx.xxxxxxxxxx.x.x.utmccn=(referral)|utmcsr=reader.livedoor.com|utmcct=/reader/|utmcmd=referral"
+           );
+         ])
+    `GET "/wp-content/uploads/2010/03/hello-kitty-darth-vader-pink.jpg"
+
+let parse_single_request () =
+  assert_req_success
+    ~here:[ [%here] ]
+    ~expected_req:req_expected ~expected_consumed:706 req
+
+let reject_headers_with_space_before_colon () =
+  let req =
+    "GET / HTTP/1.1\r\nHost : www.kittyhell.com\r\nKeep-Alive: 115\r\n\r\n"
+  in
+  match Parser.parse_request req with
+  | Error (Parser.Msg msg) ->
+      [%test_result: string] ~expect:"Invalid Header Key" msg
+  | _ -> assert false
+
+let more_requests =
+  "GET / HTTP/1.1\r\n\
+   Host: www.reddit.com\r\n\
+   User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:15.0) \r\n\
+  \   Gecko/20100101 Firefox/15.0.1\r\n\
+   Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n\
+   Accept-Language: en-us,en;q=0.5\r\n\
+   Accept-Encoding: gzip, deflate\r\n\
+   Connection: keep-alive\r\n\
+   \r\n\
+   GET /reddit.v_EZwRzV-Ns.css HTTP/1.1\r\n\
+   Host: www.redditstatic.com\r\n\
+   User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:15.0) \
+   Gecko/20100101 Firefox/15.0.1\r\n\
+   Accept: text/css,*/*;q=0.1\r\n\
+   Accept-Language: en-us,en;q=0.5\r\n\
+   Accept-Encoding: gzip, deflate\r\n\
+   Connection: keep-alive\r\n\
+   Referer: http://www.reddit.com/\r\n\
+   \r\n"
+
+let parse_at_offset () =
+  let expected_req =
+    make_req
+      ~headers:
+        (Http.Header.of_list
+           [
+             ("Host", "www.redditstatic.com");
+             ( "User-Agent",
+               "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:15.0) \
+                Gecko/20100101 Firefox/15.0.1" );
+             ("Accept", "text/css,*/*;q=0.1");
+             ("Accept-Language", "en-us,en;q=0.5");
+             ("Accept-Encoding", "gzip, deflate");
+             ("Connection", "keep-alive");
+             ("Referer", "http://www.reddit.com/");
+           ])
+      `GET "/reddit.v_EZwRzV-Ns.css"
+  in
+  assert_req_success
+    ~here:[ [%here] ]
+    ~expected_req ~expected_consumed:315 ~pos:304 more_requests
+
+let report_partial_parse () =
+  let buf = req in
+  let err =
+    match Parser.parse_request ~pos:0 ~len:50 buf with
+    | Error Parser.Partial -> Some "Partial"
+    | Error (Parser.Msg msg) -> Some msg
+    | Ok _ -> None
+  in
+  [%test_result: string option] ~expect:(Some "Partial") err
+
+let validate_http_version () =
+  let req =
+    "GET / HTTP/1.4\r\nHost: www.kittyhell.com\r\nKeep-Alive: 115\r\n\r\n"
+  in
+  let buf = req in
+  let err =
+    match Parser.parse_request buf with
+    | Error (Parser.Msg msg) -> msg
+    | Error Parser.Partial -> failwith "Unexpected partial"
+    | Ok _ -> assert false
+  in
+  [%test_result: String.Caseless.t] ~expect:"Invalid http version" err
+
+let parse_result_notifies_start_of_body () =
+  let buf =
+    "POST / HTTP/1.1\r\n\
+     Host: localhost:8080\r\n\
+     User-Agent: curl/7.64.1\r\n\
+     Accept: */*\r\n\
+     Content-Length: 6\r\n\
+     Content-Type: application/x-www-form-urlencoded\r\n\
+     \r\n\
+     foobar"
+  in
+  let v = Parser.parse_request buf |> Result.ok in
+  let _req, count = Option.value_exn v in
+  [%test_result: string] ~expect:"foobar"
+    (String.sub buf ~pos:count ~len:(String.length buf - count))
+
+open Base_quickcheck
+
+let parse_chunk_length () =
+  Test.run_exn
+    (module struct
+      type t = int64 [@@deriving quickcheck, sexp_of]
+    end)
+    ~f:(fun num ->
+      let payload =
+        let s = Printf.sprintf "%Lx\r\n" num in
+        s
+      in
+      match Parser.parse_chunk_length payload with
+      | Ok res ->
+          [%test_eq: int64 * int] res
+            (num, String.length (Printf.sprintf "%Lx" num) + 2)
+      | Error (Parser.Msg _) -> ()
+      | Error _ -> assert false)
+
+let chunk_length_parse_case_insensitive () =
+  let run_test num str =
+    let buf = str in
+    match Parser.parse_chunk_length buf with
+    | Ok res ->
+        [%test_eq: int64 * int] res
+          (num, String.length (Printf.sprintf "%Lx" num) + 2)
+    | Error (Parser.Msg _) -> ()
+    | Error _ -> assert false
+  in
+  Test.run_exn
+    (module struct
+      type t = int64 [@@deriving quickcheck, sexp_of]
+    end)
+    ~f:(fun num ->
+      let payload = Printf.sprintf "%Lx\r\n" num in
+      run_test num (String.uppercase payload);
+      run_test num (String.lowercase payload))
+
+type parse_res = [ `Ok of int64 * int | `Msg of string | `Partial ]
+[@@deriving sexp, compare]
+
+let parse_chunk_lengths () =
+  let run_parser buf =
+    match Parser.parse_chunk_length buf with
+    | Ok res -> `Ok res
+    | Error Parser.Partial -> `Partial
+    | Error (Parser.Msg msg) -> `Msg msg
+  in
+  [%test_result: parse_res] ~expect:(`Ok (2738L, 5)) (run_parser "ab2\r\n");
+  [%test_result: parse_res]
+    ~expect:(`Ok (4526507L, 8))
+    (run_parser "4511ab\r\n");
+  (* We will try to use the same chunk length, but this time with a chunk extension. This
+     should not result in any change in our output. *)
+  [%test_result: parse_res]
+    ~expect:(`Ok (4526507L, 13))
+    (run_parser "4511ab  ; a\r\n");
+  [%test_result: parse_res]
+    ~expect:(`Ok (4526507L, 26))
+    (run_parser "4511ab; now in extension\r\n");
+  [%test_result: parse_res] ~expect:(`Msg "Invalid chunk_length character 'a'")
+    (run_parser "4511ab a ; now in extension\r\n");
+  [%test_result: parse_res]
+    ~expect:(`Ok (76861433640456465L, 17))
+    (run_parser "111111111111111\r\n");
+  [%test_result: parse_res] ~expect:(`Msg "Chunk size is too large")
+    (run_parser "1111111111111111\r\n");
+  [%test_result: parse_res] ~expect:(`Msg "Expected_newline")
+    (run_parser "abc\r12");
+  [%test_result: parse_res]
+    ~expect:(`Msg "Invalid chunk_length character '\\n'") (run_parser "abc\n12");
+  [%test_result: parse_res] ~expect:`Partial (run_parser "121");
+  [%test_result: parse_res] ~expect:`Partial (run_parser "121\r")
+
+let () =
+  let open Alcotest in
+  run "Parser"
+    [
+      ( "parse request",
+        [
+          test_case "single request" `Quick parse_single_request;
+          test_case "parse at offset" `Quick parse_at_offset;
+          test_case "reject headers with invalid character in key" `Quick
+            reject_headers_with_space_before_colon;
+          test_case "report partial parse" `Quick report_partial_parse;
+          test_case "validate http version" `Quick validate_http_version;
+          test_case "parse result notified offset of start of optional body"
+            `Quick parse_result_notifies_start_of_body;
+        ] );
+      ( "chunked encoding",
+        [
+          test_case "can parse chunk length" `Quick parse_chunk_length;
+          test_case "chunk length parsing is case insensitive" `Quick
+            chunk_length_parse_case_insensitive;
+          test_case "parse chunk lengths" `Quick parse_chunk_lengths;
+        ] );
+    ]


### PR DESCRIPTION
Hello,

I'll preface this by saying that this is far from being ready, and I've had to comment/break a lot of things to get a minimal server example working. 

#### Background
I've been working on a HTTP request (and chunked body) parser and prototype for a [HTTP 1.1 server](https://github.com/anuragsoni/shuttle/tree/d850f414ef5e3c750fe74bfe3434d97674e3841e/http/src) and I decided to use the Cohttp types as the base layer for my explorations. The server experiments in `shuttle` have shown promise, but instead of adding yet another server library I'd like to explore if it's possible to integrate some of that work directly into Cohttp. I'm opening this really early in the process to see if an approach similar to what I'm proposing here will fit well with the Cohttp maintainer's vision (and to hear if there are suggestions on improving the IO layer even further).

I am starting with `cohttp-lwt-unix` first as that's the cohttp backend I use at work, and I wanted to try my work on a non async backend to validate that the work in `shuttle` can be ported to non async libraries as well. All of the new code in this diff is a direct port of implementations from the `shuttle` library.

I am using the test payload referenced in https://github.com/mirage/ocaml-cohttp/issues/328 to measure progress.

**Disclaimer**: All of these test runs were made on my laptop, and if someone has a better hardware setup for such benchmarking then I'd appreciate getting some more measurements from there.

**Library Versions:** Cohttp (the version in the current trunk as of January 6 2022), LWT (5.5.0), OCaml (4.13.1)

I ran an initial set of tests using `wrk2` using 1000 active connections and two different request rates (80_000, and 100_000). The results from the runs on my laptop can be seen at https://gist.github.com/anuragsoni/eb095a7f4c3aec1f4ba65b9866d9f9d3 . The summary from that gist is:
* Cohttp_lwt_unix from the current trunk had trouble getting more than 60,000 requests per second and had average latencies around 4-7 seconds with tail latencies > 10 seconds at times
* Cohttp_lwt_unix with the new request parser and still using Lwt_io via conduit was able to comfortable serve 80_000 RPS with average latency around 2ms and tail latencies around 7ms. When attempting to server 100_000 RPS the average latencies degraded to 1.2 seconds with tail latencies of 2 seconds
* As an experiment I tried to run cohttp-lwt-unix server that doesn't use conduit + Lwt_io for the read path, and instead just uses `Lwt_unix.file_descr` paired with the buffer that's part of this PR. With that the server was able to handle 100_000. RPS with average latencies of 2ms with tail latencies of 7.6ms - link [here](https://github.com/mirage/ocaml-cohttp/pull/819/commits/8876adb574e973ce661b41296d167e2c556fcbfe)
* Httpaf_lwt_unix has been used as the benchmark here and it can easily server 100_000 rps with an average latency of 2.5ms with a tail of 9ms

Apologies for wall of text, but I wanted to start a discussion even if I only have a partially working solution so far, as I'd like to get some insights into whether the proposed implementation here makes sense as a starting point, and I'm also hoping to learn how best to test/benchmark such work so we can have an accurate picture of any potential improvements.

Thanks,
Anurag