### PR TITLE
http.bench: extra test and faster benchmark

### DIFF
--- a/http/bench/bench.ml
+++ b/http/bench/bench.ml
@@ -10,6 +10,7 @@ let header_mem =
       [ ("traNsfer-eNcoding", "bar") ];
       [ ("traNsfer eNcoding", "bar") ];
       [ ("traNsfer-eNcodkng", "bar") ];
+      [ ("transfer-encodinG", "bar") ];
     ]
   in
   let key = "transfer-encoding" in

--- a/http/bench/dune
+++ b/http/bench/dune
@@ -8,4 +8,4 @@
  (enabled_if
   (= %{ocaml-config:word_size} 64))
  (action
-  (run ./bench.exe)))
+  (run ./bench.exe -quota 5s)))


### PR DESCRIPTION
For the current benchmark, from tests on a recent and an old computer, picking a 1s quota introduces a little variability, but picking 2s is practically indistinguishable from picking 10s.