### PR TITLE
Switch back cohttp-async expert response to use reader

### DIFF
--- a/cohttp-async/src/cohttp_async.ml
+++ b/cohttp-async/src/cohttp_async.ml
@@ -5,7 +5,3 @@ module Io = Io [@@deprecated "This module is not for public consumption"]
 module Request = Cohttp.Request [@@deprecated "Use Cohttp.Request directly"]
 module Response = Cohttp.Response [@@deprecated "Use Cohttp.Response directly"]
 module Server = Server
-
-module Private = struct
-  module Input_channel = Input_channel
-end

--- a/cohttp-async/src/input_channel.mli
+++ b/cohttp-async/src/input_channel.mli
@@ -10,3 +10,4 @@ val with_input_buffer : t -> f:(string -> pos:int -> len:int -> 'a * int) -> 'a
 val is_closed : t -> bool
 val close : t -> unit Deferred.t
 val close_finished : t -> unit Deferred.t
+val to_reader : Core_kernel.Info.t -> t -> Reader.t Deferred.t

--- a/cohttp-async/src/server.mli
+++ b/cohttp-async/src/server.mli
@@ -20,7 +20,9 @@ type 'r respond_t =
 type response_action =
   [ `Expert of
     Http.Response.t
-    * (Input_channel.t -> Async_unix.Writer.t -> unit Async_kernel.Deferred.t)
+    * (Async_unix.Reader.t ->
+      Async_unix.Writer.t ->
+      unit Async_kernel.Deferred.t)
   | `Response of response ]
 (** A request handler can respond in two ways:
 

--- a/cohttp-async/test/test_async_integration.ml
+++ b/cohttp-async/test/test_async_integration.ml
@@ -47,8 +47,7 @@ let server =
         Async_unix.Writer.flushed oc);
     expert (fun ic oc ->
         Async_unix.Writer.write oc "8\r\nexpert 2\r\n0\r\n\r\n";
-        Async_unix.Writer.flushed oc >>= fun () ->
-        Cohttp_async.Private.Input_channel.close ic);
+        Async_unix.Writer.flushed oc >>= fun () -> Async_unix.Reader.close ic);
   ]
   |> response_sequence
 

--- a/cohttp_async_test/src/cohttp_async_test.ml
+++ b/cohttp_async_test/src/cohttp_async_test.ml
@@ -5,7 +5,7 @@ module Server = Cohttp_async.Server
 module Body = Cohttp_async.Body
 
 type 'a io = 'a Deferred.t
-type ic = Cohttp_async.Private.Input_channel.t
+type ic = Async_unix.Reader.t
 type oc = Async_unix.Writer.t
 type body = Body.t
 

--- a/cohttp_async_test/src/cohttp_async_test.mli
+++ b/cohttp_async_test/src/cohttp_async_test.mli
@@ -4,7 +4,7 @@ include
   Cohttp_test.S
     with type 'a io = 'a Deferred.t
      and type body = Cohttp_async.Body.t
-     and type ic = Cohttp_async.Private.Input_channel.t
+     and type ic = Async_unix.Reader.t
      and type oc = Async_unix.Writer.t
 
 val run_async_tests : OUnit.test io -> OUnit.test_result list Deferred.t


### PR DESCRIPTION
This allows us to remove Input_channel from the public api altogether. One interesting change here is the change in behavior in the server module where we no longer attempt to continue the server loop after the user provided `Expert` handler returns. I think this behavior is okay for use-cases where the expert handler is used for connection upgrades (web sockets etc), and I am not sure if there are other common uses of the expert response_action outside of connection upgrades.


With this change I think we'll maintain compatibility with any existing cohttp-async consumer that was using the expert response (ex: for websockets), so I think the additional complication of performing the conversion to a reader, and the switch in behavior of not attempting to continue the server loop after the expert handler returns is worth it