### PR TITLE
http: Consider the user provided response when considering connection keep-alive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 - Use raise_notrace in header short circuiting exceptions (rgrinberg #802)
 - async(server): allow reading number of active connections (anuragsoni #809)
 - Various internal refactors (rgrinberg, mseri #820, #800, #799, #797)
+- http (all cohttp server backends): Consider the connection header in response in addition to the request when deciding on whether to keep a connection alive (anuragsoni, #843)
+  + The user provided Response can contain a connection header. That header will also be considered in addition to the connection header in requests when deciding whether to use keep-alive. This allows a handler to decide to close a connection even if the client requested a keep-alive in the request.
 - *Breaking changes*
   + refactor: move opam metadata to dune-project (rgrinberg #811)
   + refactor: deprecate Cohttp_async.Io (rgrinberg #807)

--- a/cohttp-async/src/server.ml
+++ b/cohttp-async/src/server.ml
@@ -66,7 +66,10 @@ let handle_client handle_request sock rd wr =
                     rd
                   >>= fun reader -> handler reader wr
               | `Response (res, res_body) ->
-                  let keep_alive = Http.Request.is_keep_alive req in
+                  let keep_alive =
+                    Http.Request.is_keep_alive req
+                    && Http.Response.is_keep_alive res
+                  in
                   let flush = Http.Response.flush res in
                   let res =
                     let headers =

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -126,7 +126,8 @@ module Make (IO : S.IO) = struct
               (fun writer -> Body.write_body (Response.write_body writer) body)
               res oc
             >>= fun () ->
-            if Request.is_keep_alive req then handle_client ic oc conn callback
+            if Http.Request.is_keep_alive req && Http.Response.is_keep_alive res
+            then handle_client ic oc conn callback
             else Lwt.return_unit
         | `Expert (res, io_handler) ->
             Response.write_header res oc >>= fun () ->

--- a/cohttp/src/request.ml
+++ b/cohttp/src/request.ml
@@ -91,10 +91,7 @@ let make ?(meth = `GET) ?(version = `HTTP_1_1) ?encoding ?headers uri =
     encoding;
   }
 
-let is_keep_alive { version; headers; _ } =
-  not
-    (version = `HTTP_1_0
-    || match Header.connection headers with Some `Close -> true | _ -> false)
+let is_keep_alive t = Http.Request.is_keep_alive t
 
 (* Make a client request, which involves guessing encoding and
    adding content headers if appropriate.

--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -400,6 +400,9 @@ module Response : sig
 
   val compare : t -> t -> int
 
+  val is_keep_alive : t -> bool
+  (** Return true whether the connection should be reused *)
+
   val make :
     ?version:Version.t ->
     ?status:Status.t ->


### PR DESCRIPTION
The user response could contain a connection: close.