### PR TITLE
bench(http): optimize to_frames and to_lines functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
     create a server without going through Conduit. This allows creating an
     async TCP server using the Tcp module from `Async_unix` and lets the user
     have more control over how the `Reader.t` and `Writer.t` are created.
+- http(header): faster `to_lines` and `to_frames` implementation (mseri, #847)
 - *Breaking changes*
   + refactor: move opam metadata to dune-project (rgrinberg #811)
   + refactor: deprecate Cohttp_async.Io (rgrinberg #807)

--- a/http/src/http.ml
+++ b/http/src/http.ml
@@ -168,11 +168,19 @@ module Header = struct
   let to_list h = List.rev h
 
   let to_lines (h : t) =
-    let header_line k v = Printf.sprintf "%s: %s\r\n" k v in
+    let b = Buffer.create 128 in
+    let header_line k v =
+      Buffer.clear b;
+      Buffer.add_string b k;
+      Buffer.add_string b ": ";
+      Buffer.add_string b v;
+      Buffer.add_string b "\r\n";
+      Buffer.contents b
+    in
     List.fold_left (fun acc (k, v) -> header_line k v :: acc) [] h
 
   let to_frames h =
-    let to_frame k v = Printf.sprintf "%s: %s" k v in
+    let to_frame k v = String.concat ": " [ k; v ] in
     List.fold_left (fun acc (k, v) -> to_frame k v :: acc) [] h
 
   let to_string h =

--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -301,7 +301,7 @@ module Header : sig
   val fold : (string -> string -> 'a -> 'a) -> t -> 'a -> 'a
 
   val to_lines : t -> string list
-  (** [to_lines h] returns header fieds as a list of lines. Beware that each
+  (** [to_lines h] returns header fields as a list of lines. Beware that each
       line ends with "\r\n" characters. *)
 
   val to_frames : t -> string list


### PR DESCRIPTION
The benchmark for `to_frame` resulted in a slightly better performance for string concatenation, in line with https://discuss.ocaml.org/t/whats-the-fastest-way-to-concatenate-strings/2616/12
```
Estimated testing time 30s (3 benchmarks x 10s). Change using '-quota'.
┌─────────┬──────────┬───────────┬─────────┬──────────┬──────────┬────────────┐
│ Name    │ Time/Run │ Cycls/Run │ mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├─────────┼──────────┼───────────┼─────────┼──────────┼──────────┼────────────┤
│ Sprintf │ 902.10ns │    2.34kc │ 660.00w │    0.13w │    0.13w │    100.00% │
│ Buffer  │ 480.78ns │    1.25kc │ 116.00w │          │          │     53.29% │
│ Concat  │ 429.12ns │    1.11kc │ 166.00w │          │          │     47.57% │
└─────────┴──────────┴───────────┴─────────┴──────────┴──────────┴────────────┘
```

The `to_lines` function gave the following result, also much better using a buffer.
```
Estimated testing time 20s (2 benchmarks x 10s). Change using '-quota'.
┌─────────┬────────────┬───────────┬─────────┬──────────┬──────────┬────────────┐
│ Name    │   Time/Run │ Cycls/Run │ mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├─────────┼────────────┼───────────┼─────────┼──────────┼──────────┼────────────┤
│ Sprintf │ 1_015.62ns │    2.63kc │ 702.00w │    0.13w │    0.13w │    100.00% │
│ Buffer  │   579.60ns │    1.50kc │ 119.00w │          │          │     57.07% │
└─────────┴────────────┴───────────┴─────────┴──────────┴──────────┴────────────┘
```

The patch to reproduce the first benchmark is:
```patch
From 4d8c894f1de73558966bf64ccaaf6c90013f5bf7 Mon Sep 17 00:00:00 2001
From: Marcello Seri <marcello.seri@gmail.com>
Date: Mon, 17 Jan 2022 22:23:05 +0100
Subject: [PATCH] temp

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>
---
 bench/bench.ml    | 18 +++++++++++++++++-
 http/src/http.ml  | 15 +++++++++++++++
 http/src/http.mli |  4 ++++
 3 files changed, 36 insertions(+), 1 deletion(-)

diff --git a/bench/bench.ml b/bench/bench.ml
index 57deedda..2aee104b 100644
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -26,4 +26,20 @@ let bench_header_mem =
   Bench.Test.create ~name:"Header.mem" (fun () ->
       List.iter (fun key -> assert (Http.Header.mem header key)) header_names)
 
-let () = Command.run @@ Bench.make_command [ bench_header_mem ]
+let bench_header_to_frames_sprintf =
+  Bench.Test.create ~name:"Sprintf" (fun () -> Http.Header.to_frames header |> ignore)
+
+let bench_header_to_frames_buffer =
+  Bench.Test.create ~name:"Buffer" (fun () -> Http.Header.to_frames_buffer header |> ignore)
+
+let bench_header_to_frames_concat =
+  Bench.Test.create ~name:"Concat" (fun () -> Http.Header.to_frames_concat header |> ignore)
+
+let () =
+  Command.run @@ Bench.make_command [ bench_header_mem ];
+  Command.run @@ Bench.make_command [
+    bench_header_to_frames_sprintf;
+    bench_header_to_frames_buffer;
+    bench_header_to_frames_concat
+  ]
+
diff --git a/http/src/http.ml b/http/src/http.ml
index eab18dce..65251bdb 100644
--- a/http/src/http.ml
+++ b/http/src/http.ml
@@ -175,6 +175,21 @@ module Header = struct
     let to_frame k v = Printf.sprintf "%s: %s" k v in
     List.fold_left (fun acc (k, v) -> to_frame k v :: acc) [] h
 
+  let to_frames_concat h =
+    let to_frame k v = String.concat ": " [ k; v ] in
+    List.fold_left (fun acc (k, v) -> to_frame k v :: acc) [] h
+
+  let to_frames_buffer h =
+    let b = Buffer.create 128 in
+    let to_frame k v =
+      Buffer.clear b;
+      Buffer.add_string b k;
+      Buffer.add_string b ": ";
+      Buffer.add_string b v;
+      Buffer.contents b
+    in
+    List.fold_left (fun acc (k, v) -> to_frame k v :: acc) [] h
+
   let to_string h =
     let b = Buffer.create 128 in
     to_list h
diff --git a/http/src/http.mli b/http/src/http.mli
index d5297d53..09d914a0 100644
--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -308,6 +308,10 @@ module Header : sig
   (** [to_frames h] returns the same as {!to_lines} but lines do not end with
       "\r\n" characters. *)
 
+
+  val to_frames_concat : t -> string list
+  val to_frames_buffer : t -> string list
+
   val to_string : t -> string
 
   val clean_dup : t -> t
-- 
2.32.0 (Apple Git-132)
```

While the second is
```diff
From 07537b48b7aaa79555997047d92cd962df7d3494 Mon Sep 17 00:00:00 2001
From: Marcello Seri <marcello.seri@gmail.com>
Date: Mon, 17 Jan 2022 22:23:05 +0100
Subject: [PATCH] temp

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>
---
 bench/bench.ml    | 14 +++++++++++++-
 http/src/http.ml  | 16 ++++++++++++++--
 http/src/http.mli |  2 ++
 3 files changed, 29 insertions(+), 3 deletions(-)

diff --git a/bench/bench.ml b/bench/bench.ml
index 57deedda..0ea1e511 100644
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -26,4 +26,16 @@ let bench_header_mem =
   Bench.Test.create ~name:"Header.mem" (fun () ->
       List.iter (fun key -> assert (Http.Header.mem header key)) header_names)
 
-let () = Command.run @@ Bench.make_command [ bench_header_mem ]
+let bench_header_to_lines_sprintf =
+  Bench.Test.create ~name:"Sprintf" (fun () -> Http.Header.to_lines header |> ignore)
+
+let bench_header_to_lines_buffer =
+  Bench.Test.create ~name:"Buffer" (fun () -> Http.Header.to_lines_buffer header |> ignore)
+
+let () =
+  Command.run @@ Bench.make_command [ bench_header_mem ];
+  Command.run @@ Bench.make_command [
+    bench_header_to_lines_sprintf;
+    bench_header_to_lines_buffer;
+  ]
+
diff --git a/http/src/http.ml b/http/src/http.ml
index eab18dce..fa830c15 100644
--- a/http/src/http.ml
+++ b/http/src/http.ml
@@ -167,12 +167,24 @@ module Header = struct
   let of_list h = List.rev h
   let to_list h = List.rev h
 
-  let to_lines (h : t) =
+let to_lines (h : t) =
     let header_line k v = Printf.sprintf "%s: %s\r\n" k v in
     List.fold_left (fun acc (k, v) -> header_line k v :: acc) [] h
 
+  let to_lines_buffer (h : t) =
+     let b = Buffer.create 128 in
+   let header_line k v =
+     Buffer.clear b;
+     Buffer.add_string b k;
+     Buffer.add_string b ": ";
+     Buffer.add_string b v;
+     Buffer.add_string b "\r\n";
+     Buffer.contents b
+   in
+    List.fold_left (fun acc (k, v) -> header_line k v :: acc) [] h
+
   let to_frames h =
-    let to_frame k v = Printf.sprintf "%s: %s" k v in
+    let to_frame k v = String.concat ": " [ k; v ] in
     List.fold_left (fun acc (k, v) -> to_frame k v :: acc) [] h
 
   let to_string h =
diff --git a/http/src/http.mli b/http/src/http.mli
index d5297d53..44de52a9 100644
--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -304,6 +304,8 @@ module Header : sig
   (** [to_lines h] returns header fieds as a list of lines. Beware that each
       line ends with "\r\n" characters. *)
 
+  val to_lines_buffer : t -> string list
+
   val to_frames : t -> string list
   (** [to_frames h] returns the same as {!to_lines} but lines do not end with
       "\r\n" characters. *)
-- 
2.32.0 (Apple Git-132)
```

It felt a bit pointless to leave the benchmarks in, but I am happy to add them back if you think it is worth it