### PR TITLE
Preview: upgrade to ocamlformat.0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.20.1
+version = 0.21.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/cohttp-lwt-unix/src/server.mli
+++ b/cohttp-lwt-unix/src/server.mli
@@ -32,7 +32,9 @@ val create :
 
     To create a simple HTTP server listening on port 8089:
 
-    {[ let run = create (`TCP 8080) ]}
+    {[
+      let run = create (`TCP 8080)
+    ]}
 
     When provided, the [stop] thread will terminate the server if it ever
     becomes determined.


### PR DESCRIPTION
This is a preview of the formatting of your project codebase with the upcoming `ocamlformat.0.21.0`. Note that this package is not yet released in opam (so the linting/formatting task of your CI won't pass), the formatting might also change slightly in the released version as we try to integrate feedback from our users.

The changes on this project are due to:
- the separators of codeblocks `{[]}` in doc-comments are now placed on their own line, this is the new syntax agreed upon with other tools handling odoc comments.

As always, we are happy to hear your feedback!  Thank you for using ocamlformat!