### PR TITLE
Use package core_unix in examples

### DIFF
--- a/examples/async/dune
+++ b/examples/async/dune
@@ -1,6 +1,6 @@
 (executables
  (names hello_world receive_post)
- (libraries mirage-crypto http cohttp-async base async_kernel))
+ (libraries mirage-crypto http cohttp-async base async_kernel core_unix.command_unix))
 
 (alias
  (name runtest)

--- a/examples/async/hello_world.ml
+++ b/examples/async/hello_world.ml
@@ -40,4 +40,4 @@ let () =
            (optional_with_default 8080 int)
            ~doc:"int Source port to listen on")
     start_server
-  |> Command.run
+  |> Command_unix.run

--- a/examples/async/receive_post.ml
+++ b/examples/async/receive_post.ml
@@ -28,4 +28,4 @@ let () =
            (optional_with_default 8080 int)
            ~doc:"int Source port to listen on")
     start_server
-  |> Command.run
+  |> Command_unix.run


### PR DESCRIPTION
Similar to #791, but for the examples directory, which is a dependency
of @runtest for cohttp-async.

Signed-off-by: Aaron L. Zeng <me@bcc32.com>