### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/cohttp_server/dune
+++ b/cohttp_server/dune
@@ -1,3 +1,3 @@
 (library
  (name cohttp_server)
- (libraries cohttp))
+ (libraries cohttp unix))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.