### PR TITLE
async: add upper bound on core_unix when testing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
   + This new implementation does not depend on conduit and has a simpler and
     more flexible API
 - async: Adapt cohttp-curl-async to work with core_unix.
+- async: Add upper bound to core_kernel when testing to fix the CI
 - *Breaking changes*
   + refactor: move opam metadata to dune-project (rgrinberg #811)
   + refactor: deprecate Cohttp_async.Io (rgrinberg #807)

--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -34,6 +34,7 @@ depends: [
   "base" {>= "v0.11.0"}
   "core" {with-test}
   "core_unix" {>= "v0.14.0"}
+  "core_unix" {with-test & < "v0.15"}
   "conduit-async" {>= "1.2.0"}
   "magic-mime"
   "mirage-crypto" {with-test}

--- a/dune-project
+++ b/dune-project
@@ -172,6 +172,7 @@ client and server respectively.
   (base (>= v0.11.0))
   (core :with-test)
   (core_unix (>= v0.14.0))
+  (core_unix (and :with-test (< v0.15))) 
   (conduit-async (>= 1.2.0))
   magic-mime
   (mirage-crypto :with-test)


### PR DESCRIPTION
The deprecation of Core_unix otherwise breaks the CI

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>