### PR TITLE
cohttp-lwt-unix: remove unused variable to ensure ci passes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 ## Unreleased
-
+- Remove unused values to help ci(@bikallem #873)
 - New curl based clients (@rgrinberg #813)
   + cohttp-curl-lwt for an Lwt backend
   + cohttp-curl-async for an Async backend

--- a/cohttp-lwt-unix/bin/cohttp_proxy_lwt.ml
+++ b/cohttp-lwt-unix/bin/cohttp_proxy_lwt.ml
@@ -53,10 +53,6 @@ let handler ~verbose _ req body =
   in
   Server.respond ~headers ~status ~body ()
 
-let sockaddr_of_host_and_port host port =
-  let inet_addr = Unix.inet_addr_of_string host in
-  Unix.ADDR_INET (inet_addr, port)
-
 let start_proxy port host verbose cert key () =
   printf "Listening for HTTP request on: %s %d\n%!" host port;
   let conn_closed (ch, _conn) =


### PR DESCRIPTION
Remove unused value to ensure ci passes - https://github.com/bikallem/ocaml-cohttp/runs/6173993159?check_suite_focus=true#step:7:21

*Required as a pre-requisite for https://github.com/mirage/ocaml-cohttp/pull/857