### PR TITLE
Random test ports

### DIFF
--- a/test_helpers/cohttp_test/src/cohttp_test.ml
+++ b/test_helpers/cohttp_test/src/cohttp_test.ml
@@ -27,7 +27,7 @@ module type S = sig
   val run_async_tests : OUnit.test io -> OUnit.test_results io
 end
 
-let port = ref 9193
+let port = Random.self_init (); ref (1024 + Random.int 40000)
 
 let next_port () =
   let current_port = !port in


### PR DESCRIPTION
Dune runs tests in parallel. This intermittently causes collisions of listening ports of the test server.
An easy fix is to use random ports. This is what this pull request does.

A nice fix would require the ability to bind to an os-selected port, which `Cohttp_lwt_unix.serv` currently cannot do.

What would you think about adding the possibility to use os-selected ports this way:

``` ocaml
val Server.create :
  ?timeout:int ->
  ?backlog:int ->
  ?stop:unit Lwt.t ->
  ?on_exn:(exn -> unit) ->
  ?ctx:Net.ctx ->
  ?conn:Conduit.IO.conn Lwt.u ->
  ?mode:Conduit_lwt_unix.server ->
  t ->
  unit Lwt.t
```

Then one could bind to os-selected port by doing:
``` ocaml
let my_conn, conn = Lwt.wait in
let server = Server.create ~conn ~mode:(`TCP (`Port 0)) resp in
my_conn >>= function
| TCP { ip; port; _ } ->
    ...
| _ -> assert false
```
This effectively adds a callback reporting the listening sockaddr.