### PR TITLE
Require higher `crowbar` version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -229,7 +229,7 @@ interoperate with Cohttp.")
   (ppx_here :with-test)
   (core (and :with-test (>= v0.13.0)))
   (core_bench :with-test)
-  (crowbar :with-test)
+  (crowbar (and :with-test (>= 0.2)))
   (sexplib0 :with-test)))
 
 (package

--- a/http.opam
+++ b/http.opam
@@ -31,7 +31,7 @@ depends: [
   "ppx_here" {with-test}
   "core" {with-test & >= "v0.13.0"}
   "core_bench" {with-test}
-  "crowbar" {with-test}
+  "crowbar" {with-test & >= "0.2"}
   "sexplib0" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
As described in https://github.com/ocaml/opam-repository/pull/21344#discussion_r868912162 the signature of `Crowbar.range` changed between 0.1 and 0.2 and Cohttp requires the newer interface.