### PR TITLE
http: add pretty printer functions 

### DIFF
--- a/cohttp-eio/tests/test_chunk_server.ml
+++ b/cohttp-eio/tests/test_chunk_server.ml
@@ -1,22 +1,6 @@
 open Cohttp_eio
 open Cohttp_eio.Server
 
-let pp_method fmt meth = Format.fprintf fmt "%s" (Http.Method.to_string meth)
-let pp_version fmt v = Format.fprintf fmt "%s" (Http.Version.to_string v)
-
-let pp fmt (req : Http.Request.t) =
-  let fields =
-    [
-      Fmt.field "meth" (fun (t : Http.Request.t) -> t.meth) pp_method;
-      Fmt.field "resource" (fun (t : Http.Request.t) -> t.resource) Fmt.string;
-      Fmt.field "version" (fun (t : Http.Request.t) -> t.version) pp_version;
-      Fmt.field "headers"
-        (fun (t : Http.Request.t) -> t.headers)
-        Http.Header.pp_hum;
-    ]
-  in
-  Fmt.record fields fmt req
-
 let dump_chunk buf chunk =
   let s = Format.asprintf "\n%a" Body.pp_chunk chunk in
   Buffer.add_string buf s
@@ -29,7 +13,7 @@ let app (req, reader) =
       | headers ->
           let req = { req with headers } in
           Buffer.contents chunk_buf
-          |> Format.asprintf "%a@ %s%!" pp req
+          |> Format.asprintf "%a@ %s%!" Http.Request.pp req
           |> Server.text_response
       | exception Invalid_argument _ -> Server.bad_request_response)
   | _ -> Server.not_found_response

--- a/cohttp-eio/tests/test_server.ml
+++ b/cohttp-eio/tests/test_server.ml
@@ -1,26 +1,10 @@
 open Cohttp_eio
 
-let pp_method fmt meth = Format.fprintf fmt "%s" (Http.Method.to_string meth)
-let pp_version fmt v = Format.fprintf fmt "%s" (Http.Version.to_string v)
-
-let pp fmt (req : Http.Request.t) =
-  let fields =
-    [
-      Fmt.field "meth" (fun (t : Http.Request.t) -> t.meth) pp_method;
-      Fmt.field "resource" (fun (t : Http.Request.t) -> t.resource) Fmt.string;
-      Fmt.field "version" (fun (t : Http.Request.t) -> t.version) pp_version;
-      Fmt.field "headers"
-        (fun (t : Http.Request.t) -> t.headers)
-        Http.Header.pp_hum;
-    ]
-  in
-  Fmt.record fields fmt req
-
 let read_body (req, reader) =
   let body = Server.read_fixed (req, reader) in
   let buf = Buffer.create 0 in
   let fmt = Format.formatter_of_buffer buf in
-  pp fmt req;
+  Http.Request.pp fmt req;
   Format.fprintf fmt "\n\n%s%!" (Bytes.unsafe_to_string body);
   Server.text_response (Buffer.contents buf)
 
@@ -29,7 +13,7 @@ let app (req, reader) =
   | "/get" ->
       let buf = Buffer.create 0 in
       let fmt = Format.formatter_of_buffer buf in
-      pp fmt req;
+      Http.Request.pp fmt req;
       Format.fprintf fmt "%!";
       Server.text_response (Buffer.contents buf)
   | "/get_error" -> (

--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -4,6 +4,7 @@ module Version : sig
   val compare : t -> t -> int
   val of_string : string -> t
   val to_string : t -> string
+  val pp : Format.formatter -> t -> unit
 end
 
 module Method : sig
@@ -22,6 +23,7 @@ module Method : sig
   val compare : t -> t -> int
   val of_string : string -> t
   val to_string : t -> string
+  val pp : Format.formatter -> t -> unit
 end
 
 module Status : sig
@@ -147,6 +149,7 @@ module Status : sig
   val to_int : t -> int
   val of_int : int -> t
   val reason_phrase_of_code : int -> string
+  val pp : Format.formatter -> t -> unit
 end
 
 module Transfer : sig
@@ -383,6 +386,8 @@ module Request : sig
 
   val is_keep_alive : t -> bool
   (** Return true whether the connection should be reused *)
+
+  val pp : Format.formatter -> t -> unit
 end
 
 module Response : sig
@@ -427,6 +432,8 @@ module Response : sig
       present, using the value of [encoding]. Checked headers are
       "content-length", "content-range" and "transfer-encoding". The default
       value of [encoding] is chunked. *)
+
+  val pp : Format.formatter -> t -> unit
 end
 
 module Private : sig


### PR DESCRIPTION
This commit adds pretty printer functions to the following module types:

1. Version.t
2. Status.t
3. Method.t
4. Request.t
5. Response.t

The `pp` functions are used in cram/expect based testing. They are also generally convenient to have while debugging cohttp web apps.