### PR TITLE
Update for Eio 0.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- cohttp-eio: update to Eio 0.3 (talex5 #886)
 - cohttp-eio: convert to Eio.Buf_read (talex5 #882)
 - cohttp lwt client: Connection cache and explicit pipelining (madroach #853)
 - http: add Http.Request.make and simplify Http.Response.make (bikallem mseri #878)

--- a/cohttp-eio.opam
+++ b/cohttp-eio.opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "dune" {>= "2.9"}
   "base-domains"
-  "eio" {>= "0.2"}
+  "eio" {>= "0.3"}
   "eio_main" {with_test}
   "cstruct"
   "bigstringaf"

--- a/dune-project
+++ b/dune-project
@@ -339,7 +339,7 @@ should also be fine under Windows too.
   "A CoHTTP server and client implementation based on `eio` library. `cohttp-eio`features a multicore capable HTTP 1.1 server. The library promotes and is built with direct style of coding as opposed to a monadic.")
  (depends
   base-domains
-  (eio (>= 0.2))
+  (eio (>= 0.3))
   (eio_main :with_test)
   cstruct
   bigstringaf


### PR DESCRIPTION
- Use `accept_fork` instead of deprecated `accept_sub`.

- Remove unnecessary calls to `Flow.close`; it will get closed anyway when the connection handler returns.

Doing the close manually triggers a bug in eio 0.3: https://github.com/ocaml-multicore/eio/issues/244 - I didn't notice because I was testing a version of cohttp where I already removed the extra closes.

This PR is just the minimal changes to fix the build. I'll submit another PR on top of this that makes use of the new features soon.