### PR TITLE
fix: stop installing binaries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@
   + fix: deprecate more aliases (rgrinberg #803)
   + refactor: deprecate connection value(rgrinberg #798)
   + refactor: deprecate using attributes (rgrinberg #796)
+  + fix: remove cohttp-{curl,server}-async (rgrinberg #..)
 
 ## v5.0.0 (2021-12-15)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,7 +46,8 @@
   + fix: deprecate more aliases (rgrinberg #803)
   + refactor: deprecate connection value(rgrinberg #798)
   + refactor: deprecate using attributes (rgrinberg #796)
-  + fix: remove cohttp-{curl,server}-async (rgrinberg #..)
+  + cleanup: remove cohttp-{curl,server}-async (rgrinberg #904)
+  + cleanup: remove cohttp-{curl,server,proxy}-lwt (rgrinberg #904)
 
 ## v5.0.0 (2021-12-15)
 

--- a/cohttp-async/bin/dune
+++ b/cohttp-async/bin/dune
@@ -1,7 +1,5 @@
 (executables
  (names cohttp_curl_async cohttp_server_async)
- (package cohttp-async)
- (public_names cohttp-curl-async cohttp-server-async)
  (libraries
   cohttp-async
   async_kernel

--- a/cohttp-curl-async/src/dune
+++ b/cohttp-curl-async/src/dune
@@ -1,4 +1,3 @@
 (library
  (name cohttp_curl_async)
- (public_name cohttp-curl-async)
  (libraries http cohttp-curl core curl stringext async_kernel async_unix))

--- a/cohttp-lwt-unix/bin/dune
+++ b/cohttp-lwt-unix/bin/dune
@@ -9,6 +9,4 @@
   logs.cli
   cmdliner
   conduit-lwt
-  fmt.tty)
- (package cohttp-lwt-unix)
- (public_names cohttp-curl-lwt cohttp-proxy-lwt cohttp-server-lwt))
+  fmt.tty))


### PR DESCRIPTION
All these various curl and server binaries are hardly useful and
shouldn't be installed.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 9579817c-59f0-49d4-8381-c0d905de3a27