### PR TITLE
fix(bytebuffer): stripping \r correctly

### DIFF
--- a/http/test/bytebuffer/bytebuffer_tests.ml
+++ b/http/test/bytebuffer/bytebuffer_tests.ml
@@ -47,9 +47,14 @@ let%expect_test "read line" =
   [%expect {| read line: "foobar" |}];
   let line = "foobar\r\n" in
   test line (String.length line - 1);
-  [%expect {| read line: "foobar\r" |}];
+  [%expect {| read line: "foobar" |}];
   test line (String.length line);
-  [%expect {| read line: "foobar" |}]
+  [%expect {| read line: "foobar" |}];
+  let line = "foobar\r" in
+  test line (String.length line + 10);
+  [%expect {| failed to read line |}];
+  test line (String.length line - 1);
+  [%expect {| failed to read line |}]
 
 let%expect_test "read fixed" =
   let src = "foobar" in


### PR DESCRIPTION
fix the slow path for reading lines to strip \r correctly

cc @anuragsoni