### PR TITLE
fix: require \r\n in all parsers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,8 @@
   + refactor: deprecate using attributes (rgrinberg #796)
   + cleanup: remove cohttp-{curl,server}-async (rgrinberg #904)
   + cleanup: remove cohttp-{curl,server,proxy}-lwt (rgrinberg #904)
+  + fix: all parsers now follow the spec and require `\r\n` endings.
+    Previously, the `\r` was optional. (rgrinberg, #921)
 
 ## v5.0.0 (2021-12-15)
 

--- a/cohttp-lwt/test/bytebuffer_tests.ml
+++ b/cohttp-lwt/test/bytebuffer_tests.ml
@@ -1,7 +1,7 @@
 module Bytebuffer = Cohttp_lwt.Private.Bytebuffer
 
 let%expect_test "read" =
-  let line = "foobar\n" in
+  let line = "foobar\r\n" in
   let test buf_size =
     let buf = Bytebuffer.create buf_size in
     let refill =

--- a/http/test/bytebuffer/bytebuffer_tests.ml
+++ b/http/test/bytebuffer/bytebuffer_tests.ml
@@ -40,7 +40,7 @@ let%expect_test "read line" =
     | Some line -> Printf.printf "read line: %S\n" line
     | exception Exit -> print_endline "failed to read - infinite loop"
   in
-  let line = "foobar\n" in
+  let line = "foobar\r\n" in
   test line (String.length line);
   [%expect {| read line: "foobar" |}];
   test line (String.length line - 1);


### PR DESCRIPTION
ps-id: 319871fb-6a40-4df3-a48a-2cde4a7c543d