### PR TITLE
Do not systematically create a XMLHttpRequest object.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,7 @@
   + cleanup: remove cohttp-{curl,server,proxy}-lwt (rgrinberg #904)
   + fix: all parsers now follow the spec and require `\r\n` endings.
     Previously, the `\r` was optional. (rgrinberg, #921)
+- `cohttp-lwt-jsoo`: do not instantiate `XMLHttpRequest` object on boot (mefyl #922)
 
 ## v5.0.0 (2021-12-15)
 


### PR DESCRIPTION
Once linked, the library would always create a XMLHttpRequest on boot to check for supported features. This would force a runtime dependency on XHR even if the feature is not actually used.

A problematic exemple would be running some library unit tests with node, which does not include XHR by default. Loading the library will fail right upon importing it, no matter whether we actually use requests or not.

This patch make this feature check lazy so that we only fail if we actually try to perform a request.