### PR TITLE
cohttp-eio: Add Content-Length header to request/response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Unreleased
 - cohttp-eio: add Content-Length header to request/response (bikallem #929)
 - cohttp-eio: add cohttp-eio client api - Cohttp_eio.Client (bikallem #879)
+- http: add requires_content_length function for requests and responses (bikallem #879)
 - cohttp-eio: use Eio.Buf_write and improve server API (talex5 #887)
 - cohttp-eio: update to Eio 0.3 (talex5 #886)
 - cohttp-eio: convert to Eio.Buf_read (talex5 #882)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- cohttp-eio: add Content-Length header to request/response (bikallem #929)
 - cohttp-eio: add cohttp-eio client api - Cohttp_eio.Client (bikallem #879)
 - cohttp-eio: use Eio.Buf_write and improve server API (talex5 #887)
 - cohttp-eio: update to Eio 0.3 (talex5 #886)

--- a/cohttp-eio/src/body.ml
+++ b/cohttp-eio/src/body.ml
@@ -250,3 +250,20 @@ let write_body writer body =
   | Chunked chunk_writer -> write_chunked writer chunk_writer
   | Custom f -> f writer
   | Empty -> ()
+
+(* Adds "Content-Length" header if required. *)
+let add_content_length (requires_content_length : unit -> bool) headers body :
+    Http.Header.t =
+  let content_length_hdr = "Content-Length" in
+  if
+    requires_content_length ()
+    && not (Http.Header.mem headers content_length_hdr)
+  then
+    match body with
+    | Fixed s ->
+        String.length s
+        |> string_of_int
+        |> Http.Header.add headers content_length_hdr
+    | Empty -> Http.Header.add headers content_length_hdr "0"
+    | _ -> headers
+  else headers

--- a/cohttp-eio/src/body.ml
+++ b/cohttp-eio/src/body.ml
@@ -251,13 +251,9 @@ let write_body writer body =
   | Custom f -> f writer
   | Empty -> ()
 
-(* Adds "Content-Length" header if required. *)
-let add_content_length (requires_content_length : unit -> bool) headers body :
-    Http.Header.t =
+let add_content_length requires_content_length headers body : Http.Header.t =
   let content_length_hdr = "Content-Length" in
-  if
-    requires_content_length ()
-    && not (Http.Header.mem headers content_length_hdr)
+  if requires_content_length && not (Http.Header.mem headers content_length_hdr)
   then
     match body with
     | Fixed s ->

--- a/cohttp-eio/src/client.ml
+++ b/cohttp-eio/src/client.ml
@@ -116,13 +116,9 @@ let patch ?version ?headers ?body ~conn host resource_path =
 (* Response Body *)
 
 let read_fixed ((response, reader) : Http.Response.t * Buf_read.t) =
-  match
-    Http.Header.get response.headers "Content-Length"
-    |> Option.get
-    |> int_of_string
-  with
-  | content_length -> Buf_read.take content_length reader
-  | exception _ -> Buf_read.take_all reader
+  match Http.Response.content_length response with
+  | Some content_length -> Buf_read.take content_length reader
+  | None -> Buf_read.take_all reader
 
 let read_chunked : response -> (Body.chunk -> unit) -> Http.Header.t option =
  fun (response, reader) f -> Body.read_chunked reader response.headers f

--- a/cohttp-eio/src/server.ml
+++ b/cohttp-eio/src/server.ml
@@ -65,14 +65,20 @@ let internal_server_error_response =
 let bad_request_response =
   (Http.Response.make ~status:`Bad_request (), Body.Empty)
 
-let write_response writer ((response, body) : Http.Response.t * Body.t) =
+let write_response writer ?request_meth (response, body) =
+  let headers =
+    Body.add_content_length
+      (Http.Response.requires_content_length ?request_meth response)
+      (Http.Response.headers response)
+      body
+  in
   let version = Http.Version.to_string response.version in
   let status = Http.Status.to_string response.status in
   Buf_write.string writer version;
   Buf_write.char writer ' ';
   Buf_write.string writer status;
   Buf_write.string writer "\r\n";
-  Rwer.write_headers writer response.headers;
+  Rwer.write_headers writer headers;
   Buf_write.string writer "\r\n";
   Body.write_body writer body
 
@@ -102,7 +108,9 @@ let rec handle_request client_addr reader writer flow handler =
   match http_request reader with
   | request ->
       let response, body = handler (request, reader, client_addr) in
-      write_response writer (response, body);
+      write_response writer
+        ~request_meth:(Http.Request.meth request)
+        (response, body);
       if Http.Request.is_keep_alive request then
         handle_request client_addr reader writer flow handler
   | (exception End_of_file) | (exception Eio.Net.Connection_reset _) -> ()

--- a/cohttp-eio/tests/server.md
+++ b/cohttp-eio/tests/server.md
@@ -81,6 +81,7 @@ A missing page:
 +socket: read "GET /missing HTTP/1.1\r\n"
 +             "\r\n"
 +socket: wrote "HTTP/1.1 404 Not Found\r\n"
++              "Content-Length: 0\r\n"
 +              "\r\n"
 - : unit = ()
 ```

--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -392,6 +392,15 @@ module Request : sig
   val is_keep_alive : t -> bool
   (** Return true whether the connection should be reused *)
 
+  val requires_content_length : t -> bool
+  (** [requires_content_length t] is [true] if [t.meth] is one of
+      [`POST, `PUT or `PATCH]. Otherwise it is [false].
+
+      A [true] value indicates that a request must include a "Content-Length"
+      header.
+
+      See https://www.rfc-editor.org/rfc/rfc7230#section-3.3.2 *)
+
   val make :
     ?meth:Method.t ->
     ?version:Version.t ->
@@ -436,6 +445,17 @@ module Response : sig
 
   val is_keep_alive : t -> bool
   (** Return true whether the connection should be reused *)
+
+  val requires_content_length : ?request_meth:Method.t -> t -> bool
+  (** [requires_content_length ~request_meth t] is [true] if a combination of
+      [t] and [request_meth] indicates that a response message must include
+      "Content-Length" header. However, please note exceptions to this:
+
+      - Response with status code of [304] may or may not include the header.
+      - Response to request with method [HEAD] may or may not include the
+        header.
+
+      https://www.rfc-editor.org/rfc/rfc7230#section-3.3.2 *)
 
   val make :
     ?version:Version.t ->

--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -401,6 +401,15 @@ module Request : sig
 
       See https://www.rfc-editor.org/rfc/rfc7230#section-3.3.2 *)
 
+  val content_length : t -> int option
+  (** [content_length t] is [Some x] if the "Content-Length" header in [t]
+      exists and its value [x] is a non negative integer, [x>=0]
+
+      It is [None] if [requires_content_length t = false] or the value encoded
+      in "Content-Length" is not a valid integer value, i.e [>= 0].
+
+      See https://www.rfc-editor.org/rfc/rfc7230#section-3.3.2 *)
+
   val make :
     ?meth:Method.t ->
     ?version:Version.t ->
@@ -456,6 +465,15 @@ module Response : sig
         header.
 
       https://www.rfc-editor.org/rfc/rfc7230#section-3.3.2 *)
+
+  val content_length : t -> int option
+  (** [content_length t] is [Some x] if the "Content-Length" header in [t]
+      exists and its value [x] is a non negative integer, [x>=0]
+
+      It is [None] if [requires_content_length t = false] or the value encoded
+      in "Content-Length" is not a valid integer value, i.e [>= 0].
+
+      See https://www.rfc-editor.org/rfc/rfc7230#section-3.3.2 *)
 
   val make :
     ?version:Version.t ->

--- a/http/test/dune
+++ b/http/test/dune
@@ -22,3 +22,15 @@
    ppx_compare
    ppx_here))
  (libraries http core base_quickcheck alcotest))
+
+(test
+ (name test_request)
+ (modules test_request)
+ (package http)
+ (libraries http alcotest))
+
+(test
+ (name test_response)
+ (modules test_response)
+ (package http)
+ (libraries http alcotest))

--- a/http/test/test_request.ml
+++ b/http/test/test_request.ml
@@ -1,0 +1,25 @@
+open Http
+
+let aeb = Alcotest.check Alcotest.bool
+
+let requires_content_length () =
+  [ `POST; `PUT; `PATCH ]
+  |> List.map (fun meth ->
+         Request.make ~meth "p" |> Request.requires_content_length)
+  |> List.for_all Fun.id
+  |> aeb "requires_content_length m = true, where m is `POST, `PUT or `PATCH"
+       true;
+
+  [ `GET; `HEAD; `DELETE; `OPTIONS; `TRACE; `CONNECT; `Other "h" ]
+  |> List.map (fun meth ->
+         Request.make ~meth "p" |> Request.requires_content_length)
+  |> List.for_all not
+  |> aeb
+       {| requires_content_length m = false, where m is `GET; `HEAD;`DELETE;`OPTIONS;`TRACE; `CONNECT;`Other "h" |}
+       true
+
+let tests =
+  ( "requires_content_length tests",
+    [ ("Request.requires_content_length", `Quick, requires_content_length) ] )
+
+let () = Alcotest.run "test_request" [ tests ]

--- a/http/test/test_request.ml
+++ b/http/test/test_request.ml
@@ -2,24 +2,76 @@ open Http
 
 let aeb = Alcotest.check Alcotest.bool
 
-let requires_content_length () =
-  [ `POST; `PUT; `PATCH ]
-  |> List.map (fun meth ->
-         Request.make ~meth "p" |> Request.requires_content_length)
-  |> List.for_all Fun.id
-  |> aeb "requires_content_length m = true, where m is `POST, `PUT or `PATCH"
-       true;
+let requires_content_length_tests =
+  let valid_meth () =
+    [ `POST; `PUT; `PATCH ]
+    |> List.map (fun meth ->
+           Request.make ~meth "p" |> Request.requires_content_length)
+    |> List.for_all Fun.id
+    |> aeb "requires_content_length m = true, where m is `POST, `PUT or `PATCH"
+         true
+  in
+  let invalid_meth () =
+    [ `GET; `HEAD; `DELETE; `OPTIONS; `TRACE; `CONNECT; `Other "h" ]
+    |> List.map (fun meth ->
+           Request.make ~meth "p" |> Request.requires_content_length)
+    |> List.for_all not
+    |> aeb
+         {| requires_content_length m = false, where m is `GET; `HEAD;`DELETE;`OPTIONS;`TRACE; `CONNECT;`Other "h" |}
+         true
+  in
+  ( "requires_content_length",
+    [
+      ("Valid meth", `Quick, valid_meth); ("Invalid meth", `Quick, invalid_meth);
+    ] )
 
-  [ `GET; `HEAD; `DELETE; `OPTIONS; `TRACE; `CONNECT; `Other "h" ]
-  |> List.map (fun meth ->
-         Request.make ~meth "p" |> Request.requires_content_length)
-  |> List.for_all not
-  |> aeb
-       {| requires_content_length m = false, where m is `GET; `HEAD;`DELETE;`OPTIONS;`TRACE; `CONNECT;`Other "h" |}
-       true
+let content_length_tests =
+  let some_x () =
+    [ (`POST, "0"); (`PUT, "233"); (`PATCH, "012345") ]
+    |> List.map (fun (meth, len) ->
+           match
+             Request.make ~meth
+               ~headers:(Header.of_list [ ("Content-Length", len) ])
+               "p"
+             |> Request.content_length
+           with
+           | Some x -> int_of_string len = x
+           | None -> false)
+    |> List.for_all Fun.id
+    |> aeb "content_length t = Some x" true
+  in
 
-let tests =
-  ( "requires_content_length tests",
-    [ ("Request.requires_content_length", `Quick, requires_content_length) ] )
+  let none () =
+    [ (`POST, "-1"); (`PUT, "-233"); (`PATCH, "abc") ]
+    |> List.map (fun (meth, len) ->
+           match
+             Request.make ~meth
+               ~headers:(Header.of_list [ ("Content-Length", len) ])
+               "p"
+             |> Request.content_length
+           with
+           | Some _ -> false
+           | None -> true)
+    |> List.for_all Fun.id
+    |> aeb "content_length t = None" true
+  in
 
-let () = Alcotest.run "test_request" [ tests ]
+  let method_ () =
+    [ `GET; `HEAD; `DELETE; `OPTIONS; `TRACE; `CONNECT; `Other "h" ]
+    |> List.map (fun meth ->
+           match Request.make ~meth "p" |> Request.content_length with
+           | Some _ -> false
+           | None -> true)
+    |> List.for_all Fun.id
+    |> aeb "content_length t = None" true
+  in
+  ( "content_length",
+    [
+      ("Some content_length", `Quick, some_x);
+      ("None : Invalid content_length integer", `Quick, none);
+      ("None : Method", `Quick, method_);
+    ] )
+
+let () =
+  Alcotest.run "test_request"
+    [ requires_content_length_tests; content_length_tests ]

--- a/http/test/test_response.ml
+++ b/http/test/test_response.ml
@@ -1,0 +1,30 @@
+open Http
+
+let aeb = Alcotest.check Alcotest.bool
+
+let requires_content_length () : unit =
+  let response = Response.make ~status:`No_content () in
+  Response.requires_content_length response
+  |> aeb "requires_content_length m = true, where s is `No_content (204)" false;
+
+  let response = Response.make ~status:`Continue () in
+  Response.requires_content_length response
+  |> aeb "requires_content_length m = true, where s is `Continue (100)" false;
+
+  let response = Response.make ~status:`OK () in
+  Response.requires_content_length response
+  |> aeb "requires_content_length s = true, where s is `OK (200" true;
+
+  let headers =
+    let headers = Http.Header.init () in
+    Http.Header.add headers "Transfer-Encoding" "chunked"
+  in
+  Response.make ~status:`OK ~headers ()
+  |> Response.requires_content_length
+  |> aeb "requires_content_length s = true, where s is `OK (200" false
+
+let tests =
+  ( "requires_content_length tests",
+    [ ("Response.requires_content_length", `Quick, requires_content_length) ] )
+
+let () = Alcotest.run "test_request" [ tests ]

--- a/http/test/test_response.ml
+++ b/http/test/test_response.ml
@@ -1,30 +1,61 @@
 open Http
 
 let aeb = Alcotest.check Alcotest.bool
+let aeo = Alcotest.check Alcotest.(option int)
+let no_content_status = Response.make ~status:`No_content ()
+let continue_status = Response.make ~status:`Continue ()
+let ok_status = Response.make ~status:`OK ()
 
-let requires_content_length () : unit =
-  let response = Response.make ~status:`No_content () in
-  Response.requires_content_length response
-  |> aeb "requires_content_length m = true, where s is `No_content (204)" false;
-
-  let response = Response.make ~status:`Continue () in
-  Response.requires_content_length response
-  |> aeb "requires_content_length m = true, where s is `Continue (100)" false;
-
-  let response = Response.make ~status:`OK () in
-  Response.requires_content_length response
-  |> aeb "requires_content_length s = true, where s is `OK (200" true;
-
+let chunked_transport_encoding =
   let headers =
     let headers = Http.Header.init () in
     Http.Header.add headers "Transfer-Encoding" "chunked"
   in
   Response.make ~status:`OK ~headers ()
-  |> Response.requires_content_length
-  |> aeb "requires_content_length s = true, where s is `OK (200" false
 
-let tests =
-  ( "requires_content_length tests",
-    [ ("Response.requires_content_length", `Quick, requires_content_length) ] )
+let requires_content_length_tests =
+  let no_content_status () =
+    Response.requires_content_length no_content_status
+    |> aeb "requires_content_length m = true, where s is `No_content (204)"
+         false
+  in
+  let continue_status () =
+    Response.requires_content_length continue_status
+    |> aeb "requires_content_length m = true, where s is `Continue (100)" false
+  in
+  let ok_status () =
+    Response.requires_content_length ok_status
+    |> aeb "requires_content_length s = true, where s is `OK (200" true
+  in
+  let chunked_transport_encoding () =
+    Response.requires_content_length chunked_transport_encoding
+    |> aeb "requires_content_length s = true, where s is `OK (200" false
+  in
+  ( "requires_content_length",
+    [
+      ("`No_content", `Quick, no_content_status);
+      ("`Continue", `Quick, continue_status);
+      ("`OK", `Quick, ok_status);
+      ("Transport-Encoding: chunked", `Quick, chunked_transport_encoding);
+    ] )
 
-let () = Alcotest.run "test_request" [ tests ]
+let content_length_tests =
+  let ok_status () =
+    Response.
+      {
+        ok_status with
+        headers = Header.add ok_status.headers "Content-Length" "20";
+      }
+    |> Response.content_length
+    |> aeo "Some len" (Some 20)
+  in
+  let no_content_status () =
+    Response.content_length no_content_status |> aeo "`No_content : None" None
+  in
+
+  ( "content_length",
+    [ ("OK", `Quick, ok_status); ("`No_content", `Quick, no_content_status) ] )
+
+let () =
+  Alcotest.run "test_response"
+    [ requires_content_length_tests; content_length_tests ]


### PR DESCRIPTION
This PR adds "Content-Length" header to request and responses as required by the HTTP RFC, specifically as specified in https://www.rfc-editor.org/rfc/rfc7230#section-3.3.2. 

Fixes https://github.com/mirage/ocaml-cohttp/issues/926
Fixes https://github.com/mirage/ocaml-cohttp/issues/913 
Fixes https://github.com/mirage/ocaml-cohttp/issues/883
Fixes https://github.com/mirage/ocaml-cohttp/issues/930

/cc @talex5