### PR TITLE
cohttp-eio(client): add User-Agent header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- cohttp-eio: add User-Agent header to request from Client (bikallem #940)
 - cohttp-eio: add Content-Length header to request/response (bikallem #929)
 - cohttp-eio: add cohttp-eio client api - Cohttp_eio.Client (bikallem #879)
 - http: add requires_content_length function for requests and responses (bikallem #879)

--- a/cohttp-eio/src/client.ml
+++ b/cohttp-eio/src/client.ml
@@ -82,6 +82,9 @@ let call ?meth ?version ?(headers = Http.Header.init ()) ?(body = Body.Empty)
       Http.Header.add headers "Host" host
     else headers
   in
+  let headers =
+    Http.Header.add_unless_exists headers "User-Agent" "cohttp-eio"
+  in
   let request = Http.Request.make ?meth ?version ~headers resource_path in
   Buf_write.with_flow ~initial_size:0x1000 conn (fun writer ->
       write_request writer request body;

--- a/cohttp-eio/tests/test_client.t
+++ b/cohttp-eio/tests/test_client.t
@@ -7,7 +7,9 @@ Test Client.get
   meth: GET
   resource: /get
   version: HTTP/1.1
-  headers: Header { Accept = "application/json"; Host = "localhost:8082" }
+  headers: Header {
+   Accept = "application/json"; Host = "localhost:8082";
+   User-Agent = "cohttp-eio" }
 
   $ kill ${running_pid}
 
@@ -21,8 +23,8 @@ Test Client.post
   resource: /post
   version: HTTP/1.1
   headers: Header {
-   Accept = "application/json"; Content-Length = "12"; Host = "localhost:8082"
-   }
+   Accept = "application/json"; Content-Length = "12"; Host = "localhost:8082";
+   User-Agent = "cohttp-eio" }
   
   hello world!
 
@@ -39,7 +41,8 @@ Test posting "chunked" data
   version: HTTP/1.1
   headers: Header {
    Content-Length = "23"; Header1 = "Header1 value text";
-   Content-Type = "text/plain"; Host = "localhost:8082" }
+   Content-Type = "text/plain"; Host = "localhost:8082";
+   User-Agent = "cohttp-eio" }
   
   size: 7
    data: Mozilla


### PR DESCRIPTION
Adds "User-Agent" header to requests from Client.

Fixes https://github.com/mirage/ocaml-cohttp/issues/937