### PR TITLE
cohttp-eio(client): call Buf_write.flush() after serializing request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Upgrade dune to v3.0 (bikallem #947)
+- cohttp-eio: allow client to optionally configure request pipelining (bikallem #949)
 
 ## v6.0.0~alpha0 (2022-10-24)
 - cohttp-eio: ensure "Host" header is the first header in http client requests (bikallem #939)

--- a/cohttp-eio/src/cohttp_eio.mli
+++ b/cohttp-eio/src/cohttp_eio.mli
@@ -114,6 +114,7 @@ module Client : sig
       "/shop/items", "/shop/categories/" etc. *)
 
   type 'a body_disallowed_call =
+    ?pipeline_requests:bool ->
     ?version:Http.Version.t ->
     ?headers:Http.Header.t ->
     conn:(#Eio.Flow.two_way as 'a) ->
@@ -121,9 +122,15 @@ module Client : sig
     resource_path ->
     response
   (** [body_disallowed_call] denotes HTTP client calls where a request is not
-      allowed to have a request body. *)
+      allowed to have a request body.
+
+      @param pipeline_requests
+        If [true] then attempts to batch multiple client requests to improve
+        request/reponse throughput. Set this to [false] if you want to improve
+        latency of individual client request/response. Default is [false]. *)
 
   type 'a body_allowed_call =
+    ?pipeline_requests:bool ->
     ?version:Http.Version.t ->
     ?headers:Http.Header.t ->
     ?body:Body.t ->
@@ -132,11 +139,17 @@ module Client : sig
     resource_path ->
     response
   (** [body_allowed_call] denotes HTTP client calls where a request can
-      optionally have a request body. *)
+      optionally have a request body.
+
+      @param pipeline_requests
+        If [true] then attempts to batch multiple client requests to improve
+        request/reponse throughput. Set this to [false] if you want to improve
+        latency of individual client request/response. Default is [false]. *)
 
   (** {1 Generic HTTP call} *)
 
   val call :
+    ?pipeline_requests:bool ->
     ?meth:Http.Method.t ->
     ?version:Http.Version.t ->
     ?headers:Http.Header.t ->


### PR DESCRIPTION
Required for https://github.com/mirage/ocaml-cohttp/pull/948