### PR TITLE
ci: cancel in-progress workflow when a new one is started

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,6 +8,10 @@ on:
     # Prime the caches every Monday
     - cron: 0 1 * * MON
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' || github.sha }}
+  cancel-in-progress: true      
+
 jobs:
   build-test-default:
     strategy:


### PR DESCRIPTION
This PR cancels in-progress workflows for a PR when a new push/commit starts a new workflow for the PR. This should hopefully make the CI a little bit more performant due to not doing unnecessary work.

More details : https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

/cc @mseri 