### PR TITLE
cohttp-eio: generate Date header in Server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 - Upgrade dune to v3.0 (bikallem #947)
 - cohttp-eio: allow client to optionally configure request pipelining (bikallem #949)
 - cohttp-eio: update to Eio 0.7 (talex5 #952)
+- cohttp-eio: generate Date header in responses (bikallem #955)
 
 ## v6.0.0~alpha0 (2022-10-24)
 - cohttp-eio: ensure "Host" header is the first header in http client requests (bikallem #939)

--- a/cohttp-eio.opam
+++ b/cohttp-eio.opam
@@ -26,6 +26,7 @@ depends: [
   "mdx" {with-test}
   "uri" {with-test}
   "fmt"
+  "ptime"
   "http" {= version}
   "odoc" {with-doc}
 ]

--- a/cohttp-eio/src/cohttp_eio.mli
+++ b/cohttp-eio/src/cohttp_eio.mli
@@ -35,6 +35,14 @@ module Server : sig
   type response = Http.Response.t * Body.t
   type handler = request -> response
 
+  type 'a env =
+    < domain_mgr : Eio.Domain_manager.t
+    ; net : Eio.Net.t
+    ; clock : Eio.Time.clock
+    ; .. >
+    as
+    'a
+
   (** {1 Request Body} *)
 
   val read_fixed : Http.Request.t -> Eio.Buf_read.t -> string option
@@ -84,15 +92,14 @@ module Server : sig
   (** {1 Run Server} *)
 
   val run :
-    ?socket_backlog:int ->
-    ?domains:int ->
-    port:int ->
-    < domain_mgr : Eio.Domain_manager.t ; net : Eio.Net.t ; .. > ->
-    handler ->
-    'a
+    ?socket_backlog:int -> ?domains:int -> port:int -> 'b env -> handler -> 'a
 
   val connection_handler :
-    handler -> #Eio.Net.stream_socket -> Eio.Net.Sockaddr.stream -> unit
+    handler ->
+    'a env ->
+    #Eio.Net.stream_socket ->
+    Eio.Net.Sockaddr.stream ->
+    unit
   (** [connection_handler request_handler] is a connection handler, suitable for
       passing to {!Eio.Net.accept_fork}. *)
 

--- a/cohttp-eio/src/cohttp_eio.mli
+++ b/cohttp-eio/src/cohttp_eio.mli
@@ -92,7 +92,7 @@ module Server : sig
   (** {1 Run Server} *)
 
   val run :
-    ?socket_backlog:int -> ?domains:int -> port:int -> 'b env -> handler -> 'a
+    ?socket_backlog:int -> ?domains:int -> port:int -> 'a env -> handler -> 'b
 
   val connection_handler :
     handler ->

--- a/cohttp-eio/src/dune
+++ b/cohttp-eio/src/dune
@@ -1,4 +1,4 @@
 (library
  (name cohttp_eio)
  (public_name cohttp-eio)
- (libraries eio http fmt))
+ (libraries eio http fmt ptime))

--- a/cohttp-eio/src/server.ml
+++ b/cohttp-eio/src/server.ml
@@ -114,7 +114,12 @@ let write_response ?request env writer (response, body) =
       (Http.Response.headers response)
       body
   in
-  let headers = Http.Header.add headers "Date" (http_date env) in
+  let headers =
+    (* https://www.rfc-editor.org/rfc/rfc9110#section-6.6.1 *)
+    match Http.Response.status response with
+    | #Http.Status.informational | #Http.Status.server_error -> headers
+    | _ -> Http.Header.add headers "Date" (http_date env)
+  in
   let version = Http.Version.to_string response.version in
   let status = Http.Status.to_string response.status in
   Buf_write.string writer version;

--- a/cohttp-eio/src/server.ml
+++ b/cohttp-eio/src/server.ml
@@ -7,6 +7,14 @@ and handler = request -> response
 and request = Http.Request.t * Eio.Buf_read.t * Eio.Net.Sockaddr.stream
 and response = Http.Response.t * Body.t
 
+type 'a env =
+  < domain_mgr : Eio.Domain_manager.t
+  ; net : Eio.Net.t
+  ; clock : Eio.Time.clock
+  ; .. >
+  as
+  'a
+
 let domain_count =
   match Sys.getenv_opt "COHTTP_DOMAINS" with
   | Some d -> int_of_string d
@@ -65,7 +73,40 @@ let internal_server_error_response =
 let bad_request_response =
   (Http.Response.make ~status:`Bad_request (), Body.Empty)
 
-let write_response ?request writer (response, body) =
+let http_date env =
+  let now = Eio.Time.now env#clock |> Ptime.of_float_s |> Option.get in
+  let (year, mm, dd), ((hh, min, ss), _) = Ptime.to_date_time now in
+  let weekday = Ptime.weekday now in
+  let weekday =
+    match weekday with
+    | `Mon -> "Mon"
+    | `Tue -> "Tue"
+    | `Wed -> "Wed"
+    | `Thu -> "Thu"
+    | `Fri -> "Fri"
+    | `Sat -> "Sat"
+    | `Sun -> "Sun"
+  in
+  let month =
+    match mm with
+    | 1 -> "Jan"
+    | 2 -> "Feb"
+    | 3 -> "Mar"
+    | 4 -> "Apr"
+    | 5 -> "May"
+    | 6 -> "Jun"
+    | 7 -> "Jul"
+    | 8 -> "Aug"
+    | 9 -> "Sep"
+    | 10 -> "Oct"
+    | 11 -> "Nov"
+    | 12 -> "Dec"
+    | _ -> failwith "Invalid HTTP datetime value"
+  in
+  Format.sprintf "%s, %02d %s %04d %02d:%02d:%02d GMT" weekday dd month year hh
+    min ss
+
+let write_response ?request env writer (response, body) =
   let headers =
     let request_meth = Option.map Http.Request.meth request in
     Body.add_content_length
@@ -73,6 +114,7 @@ let write_response ?request writer (response, body) =
       (Http.Response.headers response)
       body
   in
+  let headers = Http.Header.add headers "Date" (http_date env) in
   let version = Http.Version.to_string response.version in
   let status = Http.Status.to_string response.status in
   Buf_write.string writer version;
@@ -108,32 +150,34 @@ let[@warning "-3"] http_request t =
 
 (* main *)
 
-let rec handle_request client_addr reader writer flow handler =
+let rec handle_request env client_addr reader writer flow handler =
   match http_request reader with
   | request ->
       let response, body = handler (request, reader, client_addr) in
-      write_response ~request writer (response, body);
+      write_response ~request env writer (response, body);
       if Http.Request.is_keep_alive request then
-        handle_request client_addr reader writer flow handler
-  | exception End_of_file | exception Eio.Io (Eio.Net.E Connection_reset _, _) -> ()
+        handle_request env client_addr reader writer flow handler
+  | (exception End_of_file)
+  | (exception Eio.Io (Eio.Net.E (Connection_reset _), _)) ->
+      ()
   | exception (Failure _ as ex) ->
-      write_response writer bad_request_response;
+      write_response env writer bad_request_response;
       raise ex
   | exception ex ->
-      write_response writer internal_server_error_response;
+      write_response env writer internal_server_error_response;
       raise ex
 
-let connection_handler (handler : handler) flow client_addr =
+let connection_handler (handler : handler) env flow client_addr =
   let reader = Buf_read.of_flow ~initial_size:0x1000 ~max_size:max_int flow in
   Buf_write.with_flow flow (fun writer ->
-      handle_request client_addr reader writer flow handler)
+      handle_request env client_addr reader writer flow handler)
 
-let run_domain ssock handler =
+let run_domain env ssock handler =
   let on_error exn =
     Printf.fprintf stderr "Error handling connection: %s\n%!"
       (Printexc.to_string exn)
   in
-  let handler = connection_handler handler in
+  let handler = connection_handler handler env in
   Switch.run (fun sw ->
       let rec loop () =
         Eio.Net.accept_fork ~sw ssock ~on_error handler;
@@ -151,9 +195,10 @@ let run ?(socket_backlog = 128) ?(domains = domain_count) ~port env handler =
   in
   for _ = 2 to domains do
     Eio.Std.Fiber.fork ~sw (fun () ->
-        Eio.Domain_manager.run domain_mgr (fun () -> run_domain ssock handler))
+        Eio.Domain_manager.run domain_mgr (fun () ->
+            run_domain env ssock handler))
   done;
-  run_domain ssock handler
+  run_domain env ssock handler
 
 (* Basic handlers *)
 

--- a/dune-project
+++ b/dune-project
@@ -366,5 +366,6 @@ should also be fine under Windows too.
   (mdx :with-test)
   (uri :with-test)
   fmt
+  ptime
   (http
    (= :version))))


### PR DESCRIPTION
Generates Date header in responses from `Cohttp_eio.Server`. 

Fixes https://github.com/mirage/ocaml-cohttp/issues/932

/cc @mseri @talex5 