### PR TITLE
ci: test cohttp-eio using OCaml 5.0.0

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -70,7 +70,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ocaml-compiler:
-          - ocaml-variants.5.0.0
+          - 5.0.x
         local-packages:
           - |
             http.opam

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -70,7 +70,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ocaml-compiler:
-          - ocaml-variants.5.0.0~beta1+options
+          - ocaml-variants.5.0.0
         local-packages:
           - |
             http.opam


### PR DESCRIPTION
Updates `cohttp-eio` ci to use new release OCaml 5.0.0