### PR TITLE
cohttp-eio(examples): update client and server examples

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 - Upgrade dune to v3.0 (bikallem #947)
 - cohttp-eio: allow client to optionally configure request pipelining (bikallem #949)
 - cohttp-eio: update to Eio 0.7 (talex5 #952)
+- cohttp-eio: update examples to use eio 0.7 primitives (bikallem #?)
 
 ## v6.0.0~alpha0 (2022-10-24)
 - cohttp-eio: ensure "Host" header is the first header in http client requests (bikallem #939)

--- a/cohttp-eio/examples/client1.ml
+++ b/cohttp-eio/examples/client1.ml
@@ -1,13 +1,10 @@
-open Eio
 open Cohttp_eio
 
 let () =
+  let host, port = ("www.example.org", 80) in
   Eio_main.run @@ fun env ->
-  Switch.run @@ fun sw ->
-  let hostname, port = ("www.example.org", 80) in
-  let he = Unix.gethostbyname hostname in
-  let addr = `Tcp (Eio_unix.Ipaddr.of_unix he.h_addr_list.(0), port) in
-  let conn = Net.connect ~sw env#net addr in
-  let host = (hostname, Some port) in
-  let res = Client.get ~conn host "/" in
-  print_string @@ Client.read_fixed res
+  Eio.Net.with_tcp_connect ~host ~service:(string_of_int port) env#net
+    (fun conn ->
+      let host = (host, Some port) in
+      let res = Client.get ~conn host "/" in
+      print_string @@ Client.read_fixed res)

--- a/cohttp-eio/examples/server1.ml
+++ b/cohttp-eio/examples/server1.ml
@@ -30,7 +30,8 @@ let text =
 
 open Cohttp_eio
 
-let app (req, _reader, _client_addr) =
+let app : Server.request -> Server.response =
+ fun ((req, _, _) : Server.request) ->
   match Http.Request.resource req with
   | "/" -> Server.text_response text
   | "/html" -> Server.html_response text


### PR DESCRIPTION
Uses eio 0.6/0.7 convenience primitives. 