### PR TITLE
Further improve Cohttp_eio.Client ergonomics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 - Upgrade dune to v3.0 (bikallem #947)
 - cohttp-eio: allow client to optionally configure request pipelining (bikallem #949)
 - cohttp-eio: update to Eio 0.7 (talex5 #952)
-- cohttp-eio: update examples to use eio 0.7 primitives (bikallem #?)
+- cohttp-eio: update examples to use eio 0.7 primitives (bikallem #957)
 - cohttp-eio: generate Date header in responses (bikallem #955)
+- cohttp-eio: further improve Cohttp_eio.Client ergonomics (bikallem #?)
 
 ## v6.0.0~alpha0 (2022-10-24)
 - cohttp-eio: ensure "Host" header is the first header in http client requests (bikallem #939)

--- a/cohttp-eio/examples/client1.ml
+++ b/cohttp-eio/examples/client1.ml
@@ -1,10 +1,6 @@
 open Cohttp_eio
 
 let () =
-  let host, port = ("www.example.org", 80) in
   Eio_main.run @@ fun env ->
-  Eio.Net.with_tcp_connect ~host ~service:(string_of_int port) env#net
-    (fun conn ->
-      let host = (host, Some port) in
-      let res = Client.get ~conn host "/" in
-      print_string @@ Client.read_fixed res)
+  let res = Client.get env ~host:"www.example.org" "/" in
+  print_string @@ Client.read_fixed res

--- a/cohttp-eio/examples/client_timeout.ml
+++ b/cohttp-eio/examples/client_timeout.ml
@@ -7,12 +7,11 @@ let () =
   (* Increment/decrement this value to see success/failure. *)
   let timeout_s = 0.01 in
   Eio.Time.with_timeout env#clock timeout_s (fun () ->
-      let hostname, port = ("www.example.org", 80) in
-      let he = Unix.gethostbyname hostname in
+      let host, port = ("www.example.org", 80) in
+      let he = Unix.gethostbyname host in
       let addr = `Tcp (Eio_unix.Ipaddr.of_unix he.h_addr_list.(0), port) in
       let conn = Net.connect ~sw env#net addr in
-      let host = (hostname, Some port) in
-      let res = Client.get ~conn host "/" in
+      let res = Client.get ~conn ~port env ~host "/" in
       Client.read_fixed res |> Result.ok)
   |> function
   | Ok s -> print_string s

--- a/cohttp-eio/examples/docker_client.ml
+++ b/cohttp-eio/examples/docker_client.ml
@@ -10,7 +10,7 @@ let () =
   Switch.run @@ fun sw ->
   let addr = `Unix "/var/run/docker.sock" in
   let conn = Net.connect ~sw env#net addr in
-  let res = Client.get ~conn ("docker", None) "/version" in
+  let res = Client.get ~conn ~host:"docker" env "/version" in
   let code = fst res |> Response.status |> Status.to_int in
   Printf.printf "Response code: %d\n" code;
   Printf.printf "Headers: %s\n"


### PR DESCRIPTION
While working on documentation for cohttp-eio and https://github.com/mirage/ocaml-cohttp/pull/957, it dawned on me that the `Cohttp_eio.Client` ergonomics could be further improved. Such that users of `Cohttp_eio.Client` don't even need to use `Eio.Net.with_tcp_connect` for most use cases. This PR aims to do just that. Now we do,

```
open Cohttp_eio

let () =
  Eio_main.run @@ fun env ->
  let res = Client.get env ~host:"www.example.org" "/" in
  print_string @@ Client.read_fixed res
```
rather than a bit verbose below: 

```
open Cohttp_eio

let () =
  let host, port = ("www.example.org", 80) in
  Eio_main.run @@ fun env ->
  Eio.Net.with_tcp_connect ~host ~service:(string_of_int port) env#net
    (fun conn ->
      let host = (host, Some port) in
      let res = Client.get ~conn host "/" in
      print_string @@ Client.read_fixed res)
```
Note, however, we still retain the ability to pass in the `flow/connection` parameter like before. It is however now an optional parameter rather than a required one.