### PR TITLE
cohttp-eio : server api improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - cohttp-eio: update examples to use eio 0.7 primitives (bikallem #957)
 - cohttp-eio: generate Date header in responses (bikallem #955)
 - cohttp-eio: further improve Cohttp_eio.Client ergonomics (bikallem #?)
+- cohttp-eio: server api improvements (bikallem #962)
 
 ## v6.0.0~alpha0 (2022-10-24)
 - cohttp-eio: ensure "Host" header is the first header in http client requests (bikallem #939)

--- a/cohttp-eio/src/cohttp_eio.mli
+++ b/cohttp-eio/src/cohttp_eio.mli
@@ -93,6 +93,16 @@ module Server : sig
 
   val run :
     ?socket_backlog:int -> ?domains:int -> port:int -> 'a env -> handler -> 'b
+  (** [run ~socket_backlog ~domains ~port env handler] runs a HTTP/1.1 server
+      executing [handler] and listening on [port]. [env] corresponds to
+      {!val:Eio.Stdenv.t}.
+
+      [socket_backlog] is the number of pending connections for tcp server
+      socket. The default is [128].
+
+      [domains] is the number of OCaml 5.0 domains the server will use. The
+      default is [1]. You may use {!val:Domain.recommended_domain_count} to
+      configure a multicore capable server. *)
 
   val connection_handler :
     handler ->
@@ -106,6 +116,7 @@ module Server : sig
   (** {1 Basic Handlers} *)
 
   val not_found_handler : handler
+  (** [not_found_handler] return HTTP 404 response. *)
 end
 
 (** [Client] is a HTTP/1.1 client. *)

--- a/cohttp-eio/src/cohttp_eio.mli
+++ b/cohttp-eio/src/cohttp_eio.mli
@@ -96,7 +96,7 @@ module Server : sig
 
   val connection_handler :
     handler ->
-    'a env ->
+    #Eio.Time.clock ->
     #Eio.Net.stream_socket ->
     Eio.Net.Sockaddr.stream ->
     unit

--- a/cohttp-eio/src/server.ml
+++ b/cohttp-eio/src/server.ml
@@ -15,11 +15,6 @@ type 'a env =
   as
   'a
 
-let domain_count =
-  match Sys.getenv_opt "COHTTP_DOMAINS" with
-  | Some d -> int_of_string d
-  | None -> 1
-
 (* Request *)
 
 let read_fixed request reader =
@@ -190,7 +185,7 @@ let run_domain env ssock handler =
       in
       loop ())
 
-let run ?(socket_backlog = 128) ?(domains = domain_count) ~port env handler =
+let run ?(socket_backlog = 128) ?(domains = 1) ~port env handler =
   Switch.run @@ fun sw ->
   let domain_mgr = Eio.Stdenv.domain_mgr env in
   let ssock =

--- a/cohttp-eio/tests/server.md
+++ b/cohttp-eio/tests/server.md
@@ -122,7 +122,7 @@ let mock_env =
     method domain_mgr = fake_domain_mgr
   end
 
-let connection_handler = Server.connection_handler app mock_env
+let connection_handler = Server.connection_handler app mock_env#clock
 ```
 
 To test it, we run the connection handler with our mock socket:


### PR DESCRIPTION
Addresses some points raised in #961, Specifically,

1. Make `Server.connection_handler` accept `env#clock` only.
2. Remove COHTTP_DOMAINS env variable usage.
3. Document `Server.run` and `Server.not_found_handler`.

/cc @patricoferris
