### PR TITLE
cohttp-eio: remove unused code from tests to work with Eio 0.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- cohttp-eio: remove unused code from tests to work with Eio 0.8 (talex5 #967)
 - Upgrade dune to v3.0 (bikallem #947)
 - cohttp-eio: allow client to optionally configure request pipelining (bikallem #949)
 - cohttp-eio: update to Eio 0.7 (talex5 #952)

--- a/cohttp-eio/tests/server.md
+++ b/cohttp-eio/tests/server.md
@@ -107,22 +107,10 @@ let app (req, body, _client_addr) =
   | "/handle_chunk" -> handle_chunk_request req body
   | _ -> Server.not_found_response
 
-let mock_env =
-  let mock_clock = Eio_mock.Clock.make () in
-  Eio_mock.Clock.set_time mock_clock 1666627935.85052109 ;
-  let fake_domain_mgr = 
-    object (_ : #Eio.Domain_manager.t)
-      method run fn = fn ()
-      method run_raw fn = fn ()
-    end 
-  in
-  object 
-    method net        = (Eio_mock.Net.make "mock net" :> Eio.Net.t)
-    method clock      = (mock_clock :> Eio.Time.clock)
-    method domain_mgr = fake_domain_mgr
-  end
+let mock_clock = Eio_mock.Clock.make ()
+let () = Eio_mock.Clock.set_time mock_clock 1666627935.85052109
 
-let connection_handler = Server.connection_handler app mock_env#clock
+let connection_handler = Server.connection_handler app mock_clock
 ```
 
 To test it, we run the connection handler with our mock socket:


### PR DESCRIPTION
The domain_mgr API changed in Eio 0.8, breaking the tests. But the code that broke isn't used for anything anyway, so remove it.

/cc @bikallem