### PR TITLE
We should not link against bytes

### DIFF
--- a/cohttp/src/dune
+++ b/cohttp/src/dune
@@ -16,7 +16,6 @@
   uri
   uri-sexp
   sexplib0
-  bytes
   base64))
 
 (ocamllex accept_lexer)


### PR DESCRIPTION
The failure was seen in the opam-repository CI, see https://github.com/ocaml/opam-repository/pull/23262#issuecomment-1423795120

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>