### PR TITLE
README: fix typo in server_example invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ EOF
 ```
 then build and execute the example with
 ```
-$ dune exec ./client_example.exe
+$ dune exec ./server_example.exe
 ```
 
 As in the previous example, here we are explicitly mentioning conduit-lwt to


### PR DESCRIPTION
This PR fixes a typo in the dune command for the server example.