### PR TITLE
cohttp-async: base/async v0.16 compatibility

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -60,9 +60,9 @@ jobs:
       - run: echo "PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig" >>"$GITHUB_ENV"
         if: ${{ matrix.os == 'macos-latest' }}
 
-      - run: opam install --with-test --deps-only http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
-      - run: opam exec -- dune build http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
-      - run: opam exec -- dune runtest http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
+      - run: opam install --with-test --deps-only http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top
+      - run: opam exec -- dune build http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top
+      - run: opam exec -- dune runtest http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top
 
   build-test-cohttp-async:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,18 +28,18 @@ jobs:
           - ocaml-variants.4.11.2+afl
           - ocaml-variants.4.12.1+options,ocaml-option-afl
           - ocaml-variants.4.13.1+options,ocaml-option-afl
-          - ocaml-variants.4.14.0+options,ocaml-option-afl
+          - ocaml-variants.4.14.1+options,ocaml-option-afl
         local-packages:
           - |
             *.opam
             !cohttp-eio.opam
+            !cohttp-async.opam
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
@@ -59,9 +59,55 @@ jobs:
       - run: echo "PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig" >>"$GITHUB_ENV"
         if: ${{ matrix.os == 'macos-latest' }}
 
-      - run: opam install --with-test --deps-only http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-mirage cohttp-async cohttp-curl-async cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
-      - run: opam exec -- dune build http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-mirage cohttp-async cohttp-curl-async cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
-      - run: opam exec -- dune runtest http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-mirage cohttp-async cohttp-curl-async cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
+      - run: opam install --with-test --deps-only http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
+      - run: opam exec -- dune build http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
+      - run: opam exec -- dune runtest http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
+
+  build-test-cohttp-async:
+    if: github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        ocaml-compiler:
+          - ocaml-variants.4.14.1+options,ocaml-option-afl
+        local-packages:
+          - |
+            http.opam
+            cohttp.opam
+            cohttp-async.opam
+            cohttp-curl.opam
+            cohttp-curl-async.opam
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: ${{ matrix.os == 'ubuntu-latest' }}
+          opam-depext: true
+          opam-depext-flags: --with-test
+          opam-local-packages: ${{ matrix.local-packages }}
+
+      - run: |
+          sudo apt update
+          sudo apt upgrade
+          opam depext conf-libcurl
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+
+      - run: echo "PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig" >>"$GITHUB_ENV"
+        if: ${{ matrix.os == 'macos-latest' }}
+
+      - run: opam install --with-test --deps-only cohttp-async cohttp-curl-async
+      - run: opam exec -- dune build cohttp-async cohttp-curl-async
+      - run: opam exec -- dune runtest cohttp-async cohttp-curl-async
 
   build-test-cohttp-eio:
     if: github.event.pull_request.draft == false
@@ -95,7 +141,5 @@ jobs:
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
 
       - run: opam install --with-test --deps-only cohttp-eio
-
       - run: opam exec -- dune build cohttp-eio
-
       - run: opam exec -- dune runtest cohttp-eio

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,6 +34,7 @@ jobs:
             !cohttp-eio.opam
             !cohttp-curl-async.opam
             !cohttp-async.opam
+            !cohttp-bench.opam
 
     runs-on: ${{ matrix.os }}
 
@@ -75,11 +76,8 @@ jobs:
           - ocaml-variants.4.14.1+options,ocaml-option-afl
         local-packages:
           - |
-            http.opam
-            cohttp.opam
-            cohttp-async.opam
-            cohttp-curl.opam
-            cohttp-curl-async.opam
+            *.opam
+            !cohttp-eio.opam
 
     runs-on: ${{ matrix.os }}
 
@@ -105,9 +103,9 @@ jobs:
       - run: echo "PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig" >>"$GITHUB_ENV"
         if: ${{ matrix.os == 'macos-latest' }}
 
-      - run: opam install --with-test --deps-only cohttp-async cohttp-curl-async
-      - run: opam exec -- dune build cohttp-async cohttp-curl-async
-      - run: opam exec -- dune runtest cohttp-async cohttp-curl-async
+      - run: opam install --with-test --deps-only http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-async cohttp-curl-async cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
+      - run: opam exec -- dune build http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-async cohttp-curl-async cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
+      - run: opam exec -- dune runtest http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-async cohttp-curl-async cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
 
   build-test-cohttp-eio:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,6 +33,7 @@ jobs:
           - |
             *.opam
             !cohttp-eio.opam
+            !cohttp-curl-async.opam
             !cohttp-async.opam
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,6 @@ jobs:
           - ocaml-variants.4.11.2+afl
           - ocaml-variants.4.12.1+options,ocaml-option-afl
           - ocaml-variants.4.13.1+options,ocaml-option-afl
-          - ocaml-variants.4.14.1+options,ocaml-option-afl
         local-packages:
           - |
             *.opam

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- cohttp-async, cohttp-curl-async: compatibility with core/async v0.16.0 (mseri, dkalinichenko-js #976)
 - cohttp-eio: remove unused code from tests to work with Eio 0.8 (talex5 #967)
 - Upgrade dune to v3.0 (bikallem #947)
 - cohttp-eio: allow client to optionally configure request pipelining (bikallem #949)

--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -31,7 +31,7 @@ depends: [
   "async_kernel" {>= "v0.14.0"}
   "async_unix" {>= "v0.14.0"}
   "async" {>= "v0.14.0"}
-  "base" {>= "v0.11.0"}
+  "base" {>= "v0.16~preview.128.10+111"}
   "core" {with-test}
   "core_unix" {>= "v0.14.0"}
   "conduit-async" {>= "1.2.0"}

--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -25,12 +25,12 @@ doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.14"}
   "http" {= version}
   "cohttp" {= version}
-  "async_kernel" {>= "v0.14.0"}
-  "async_unix" {>= "v0.14.0"}
-  "async" {>= "v0.14.0"}
+  "async_kernel" {>= "v0.16.0"}
+  "async_unix" {>= "v0.16.0"}
+  "async" {>= "v0.16.0"}
   "base" {>= "v0.16"}
   "core" {with-test}
   "core_unix" {>= "v0.14.0"}

--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -31,7 +31,7 @@ depends: [
   "async_kernel" {>= "v0.14.0"}
   "async_unix" {>= "v0.14.0"}
   "async" {>= "v0.14.0"}
-  "base" {>= "v0.16~preview.128.10+111"}
+  "base" {>= "v0.16"}
   "core" {with-test}
   "core_unix" {>= "v0.14.0"}
   "conduit-async" {>= "1.2.0"}

--- a/cohttp-async/bin/cohttp_server_async.ml
+++ b/cohttp-async/bin/cohttp_server_async.ml
@@ -50,7 +50,7 @@ let serve ~info ~docroot ~index uri path =
             | `No | `Unknown ->
                 (* Do a directory listing *)
                 Sys.ls_dir file_name
-                >>= Deferred.List.map ~f:(fun f ->
+                >>= Deferred.List.map ~how:`Parallel ~f:(fun f ->
                         let file_name = file_name / f in
                         try_with (fun () ->
                             Unix.stat file_name >>| fun stat ->

--- a/cohttp-async/examples/hello_world.ml
+++ b/cohttp-async/examples/hello_world.ml
@@ -18,8 +18,8 @@ let handler ~body:_ _sock req =
   | _ -> Server.respond_string ~status:`Not_found "Route not found"
 
 let start_server port () =
-  Caml.Printf.eprintf "Listening for HTTP on port %d\n" port;
-  Caml.Printf.eprintf "Try 'curl http://localhost:%d/test?hello=xyz'\n%!" port;
+  Stdlib.Printf.eprintf "Listening for HTTP on port %d\n" port;
+  Stdlib.Printf.eprintf "Try 'curl http://localhost:%d/test?hello=xyz'\n%!" port;
   Server.create ~on_handler_error:`Raise
     (Async.Tcp.Where_to_listen.of_port port)
     handler

--- a/cohttp-async/examples/receive_post.ml
+++ b/cohttp-async/examples/receive_post.ml
@@ -7,15 +7,15 @@ module Server = Cohttp_async.Server
 (* compile with: $ corebuild receive_post.native -pkg cohttp.async *)
 
 let start_server port () =
-  Caml.Printf.eprintf "Listening for HTTP on port %d\n" port;
-  Caml.Printf.eprintf "Try 'curl -X POST -d 'foo bar' http://localhost:%d\n"
+  Stdlib.Printf.eprintf "Listening for HTTP on port %d\n" port;
+  Stdlib.Printf.eprintf "Try 'curl -X POST -d 'foo bar' http://localhost:%d\n"
     port;
   Cohttp_async.Server.create ~on_handler_error:`Raise
     (Async.Tcp.Where_to_listen.of_port port) (fun ~body _ req ->
       match req |> Http.Request.meth with
       | `POST ->
           Body.to_string body >>= fun body ->
-          Caml.Printf.eprintf "Body: %s" body;
+          Stdlib.Printf.eprintf "Body: %s" body;
           Server.respond `OK
       | _ -> Server.respond `Method_not_allowed)
   >>= fun _ -> Deferred.never ()

--- a/cohttp-async/src/body.ml
+++ b/cohttp-async/src/body.ml
@@ -67,7 +67,7 @@ let write_body write_body (body : t) writer =
   match body with
   | `Empty -> return ()
   | `String s -> write_body writer s
-  | `Strings sl -> Deferred.List.iter sl ~f:(write_body writer)
+  | `Strings sl -> Deferred.List.iter ~how:`Sequential sl ~f:(write_body writer)
   | `Pipe p -> Pipe.iter p ~f:(write_body writer)
 
 let pipe_of_body read_chunk ic =

--- a/cohttp-async/src/client.ml
+++ b/cohttp-async/src/client.ml
@@ -120,7 +120,7 @@ let callv ?interrupt ?ssl_config uri reqs =
   Connection.connect ?interrupt ?ssl_config uri >>| fun connection ->
   let responses =
     Pipe.map' ~max_queue_length:1 reqs ~f:(fun reqs ->
-        Deferred.Queue.map reqs ~f:(fun (req, body) ->
+        Deferred.Queue.map ~how:`Sequential reqs ~f:(fun (req, body) ->
             Connection.request ~body connection req))
   in
   Pipe.closed responses

--- a/cohttp-async/src/io.ml
+++ b/cohttp-async/src/io.ml
@@ -20,7 +20,7 @@ open Async_kernel
 module IO = struct
   module Writer = Async_unix.Writer
   module Reader = Async_unix.Reader
-  module Format = Caml.Format
+  module Format = Stdlib.Format
 
   let log_src_name = "cohttp.async.io"
   let src = Logs.Src.create log_src_name ~doc:"Cohttp Async IO module"
@@ -44,7 +44,7 @@ module IO = struct
         k ()
       in
       msgf @@ fun ?header:_ ?tags:_ fmt ->
-      Format.kfprintf k fmtr Caml.("@[" ^^ fmt ^^ "@]@.")
+      Format.kfprintf k fmtr Stdlib.("@[" ^^ fmt ^^ "@]@.")
     in
     { Logs.report }
 
@@ -58,11 +58,11 @@ module IO = struct
        Logs.set_reporter (default_reporter ()))
 
   let check_debug norm_fn debug_fn =
-    match Caml.Sys.getenv "COHTTP_DEBUG" with
+    match Stdlib.Sys.getenv "COHTTP_DEBUG" with
     | _ ->
         Lazy.force set_log;
         debug_fn
-    | exception Caml.Not_found -> norm_fn
+    | exception Stdlib.Not_found -> norm_fn
 
   type 'a t = 'a Deferred.t
 

--- a/cohttp-async/test/test_async_integration.ml
+++ b/cohttp-async/test/test_async_integration.ml
@@ -81,7 +81,7 @@ let ts =
         reqs |> Pipe.of_list |> Client.callv uri >>= fun responses ->
         responses |> Pipe.to_list >>= fun resps ->
         resps
-        |> Deferred.List.iter ~f:(fun (_resp, body) ->
+        |> Deferred.List.iter ~how:`Sequential ~f:(fun (_resp, body) ->
                let expected_body = body_q |> Queue.dequeue_exn in
                body |> Body.to_string >>| fun body ->
                assert_equal ~printer expected_body body)
@@ -113,7 +113,7 @@ let ts =
             ("Pipe with empty strings", Pipe.of_list [ ""; ""; "" ], true);
           ]
         in
-        Deferred.List.iter tests ~f:(fun (msg, pipe, expected) ->
+        Deferred.List.iter ~how:`Sequential tests ~f:(fun (msg, pipe, expected) ->
             is_empty (`Pipe pipe) >>| fun real ->
             assert_equal ~msg expected real)
         >>= fun () ->

--- a/cohttp-bench/async_server.ml
+++ b/cohttp-bench/async_server.ml
@@ -13,7 +13,7 @@ let start_server port () =
     handler
   >>= fun server ->
   Deferred.forever () (fun () ->
-      after Time.Span.(of_sec 0.5) >>| fun () ->
+      after Time_float.Span.(of_sec 0.5) >>| fun () ->
       Log.Global.printf "Active connections: %d" (Server.num_connections server));
   Deferred.never ()
 

--- a/cohttp-curl-async.opam
+++ b/cohttp-curl-async.opam
@@ -25,7 +25,7 @@ depends: [
   "http" {= version}
   "stringext"
   "cohttp-curl" {= version}
-  "core"
+  "core" {>= "v0.16.0""}
   "core_unix" {>= "v0.14.0"}
   "async_kernel"
   "async_unix"

--- a/cohttp-curl-async.opam
+++ b/cohttp-curl-async.opam
@@ -25,7 +25,7 @@ depends: [
   "http" {= version}
   "stringext"
   "cohttp-curl" {= version}
-  "core" {>= "v0.16.0""}
+  "core" {>= "v0.16.0"}
   "core_unix" {>= "v0.14.0"}
   "async_kernel"
   "async_unix"

--- a/cohttp-curl-async/bin/curl.ml
+++ b/cohttp-curl-async/bin/curl.ml
@@ -12,7 +12,7 @@ let client uri meth' () =
   let reply =
     let context = Curl.Context.create () in
     let request =
-      Curl.Request.create ~timeout:(Time_float.Span.of_ms 5000.) meth ~uri
+      Curl.Request.create ~timeout:(Time.Span.of_ms 5000.) meth ~uri
         ~input:Curl.Source.empty ~output:Curl.Sink.string
     in
     Curl.submit context request

--- a/cohttp-curl-async/bin/curl.ml
+++ b/cohttp-curl-async/bin/curl.ml
@@ -3,7 +3,7 @@ module Curl = Cohttp_curl_async
 module Sexp = Sexplib0.Sexp
 open Async_kernel
 module Writer = Async_unix.Writer
-module Time = Core.Time
+module Time = Core.Time_float
 
 let ( let* ) x f = Deferred.bind x ~f
 
@@ -12,7 +12,7 @@ let client uri meth' () =
   let reply =
     let context = Curl.Context.create () in
     let request =
-      Curl.Request.create ~timeout:(Time.Span.of_ms 5000.) meth ~uri
+      Curl.Request.create ~timeout:(Time_float.Span.of_ms 5000.) meth ~uri
         ~input:Curl.Source.empty ~output:Curl.Sink.string
     in
     Curl.submit context request

--- a/cohttp-curl-async/src/cohttp_curl_async.ml
+++ b/cohttp-curl-async/src/cohttp_curl_async.ml
@@ -1,5 +1,5 @@
 open Async_kernel
-module Time = Core.Time
+module Time = Core.Time_float
 module Fd = Async_unix.Fd
 module Clock = Async_unix.Clock
 
@@ -59,7 +59,7 @@ module Context = struct
         (match t.timeout with
         | None -> ()
         | Some event -> Clock.Event.abort_if_possible event ());
-        let duration = Time.Span.of_ms (float_of_int timeout) in
+        let duration = Time_float.Span.of_ms (float_of_int timeout) in
         t.timeout <- Some (Clock.Event.run_after duration on_timer ()));
     let socket_function fd (what : Curl.Multi.poll) =
       let create_event fd what =

--- a/cohttp-curl-async/src/cohttp_curl_async.ml
+++ b/cohttp-curl-async/src/cohttp_curl_async.ml
@@ -164,7 +164,7 @@ module Request = struct
     let base =
       let timeout_ms =
         Option.map
-          (fun timeout -> Core.Time.Span.to_ms timeout |> int_of_float)
+          (fun timeout -> Time.Span.to_ms timeout |> int_of_float)
           timeout
       in
       Cohttp_curl.Request.create ?timeout_ms ?headers method_ ~uri ~input

--- a/cohttp-curl-async/src/cohttp_curl_async.ml
+++ b/cohttp-curl-async/src/cohttp_curl_async.ml
@@ -59,7 +59,7 @@ module Context = struct
         (match t.timeout with
         | None -> ()
         | Some event -> Clock.Event.abort_if_possible event ());
-        let duration = Time_float.Span.of_ms (float_of_int timeout) in
+        let duration = Time.Span.of_ms (float_of_int timeout) in
         t.timeout <- Some (Clock.Event.run_after duration on_timer ()));
     let socket_function fd (what : Curl.Multi.poll) =
       let create_event fd what =

--- a/cohttp-curl-async/src/cohttp_curl_async.mli
+++ b/cohttp-curl-async/src/cohttp_curl_async.mli
@@ -51,7 +51,7 @@ module Request : sig
       handled. *)
 
   val create :
-    ?timeout:Core.Time.Span.t (** timeout for the request *) ->
+    ?timeout:Core.Time_float.Span.t (** timeout for the request *) ->
     ?headers:Http.Header.t (** http headers *) ->
     Http.Method.t (** http method *) ->
     uri:string (** uri *) ->

--- a/dune-project
+++ b/dune-project
@@ -180,7 +180,7 @@ should also be fine under Windows too.
   (async
    (>= v0.14.0))
   (base
-   (>= "v0.16~preview.128.10+111"))
+   (>= "v0.16"))
   (core :with-test)
   (core_unix
    (>= v0.14.0))

--- a/dune-project
+++ b/dune-project
@@ -180,7 +180,7 @@ should also be fine under Windows too.
   (async
    (>= v0.16.0))
   (base
-   (>= "v0.16"))
+   (>= v0.16.0))
   (core :with-test)
   (core_unix
    (>= v0.14.0))

--- a/dune-project
+++ b/dune-project
@@ -174,11 +174,11 @@ should also be fine under Windows too.
   (cohttp
    (= :version))
   (async_kernel
-   (>= v0.14.0))
+   (>= v0.16.0))
   (async_unix
-   (>= v0.14.0))
+   (>= v0.16.0))
   (async
-   (>= v0.14.0))
+   (>= v0.16.0))
   (base
    (>= "v0.16"))
   (core :with-test)

--- a/dune-project
+++ b/dune-project
@@ -180,7 +180,7 @@ should also be fine under Windows too.
   (async
    (>= v0.14.0))
   (base
-   (>= v0.11.0))
+   (>= "v0.16~preview.128.10+111"))
   (core :with-test)
   (core_unix
    (>= v0.14.0))

--- a/dune-project
+++ b/dune-project
@@ -317,7 +317,7 @@ should also be fine under Windows too.
   stringext
   (cohttp-curl
    (= :version))
-  core
+  (core (>= v0.16.0))
   (core_unix (>= v0.14.0))
   async_kernel
   async_unix


### PR DESCRIPTION
The next major release of Base will rename the `Caml` module to `Stdlib`. The next major release of `Async` will make the `how` argument mandatory for certain `Deferred` operations. This PR updates cohttp-async before releasing these changes, since some Jane Street packages depend on it.

I'm not sure about the testing story for this change. The preview versions of our libraries are accessible at our bleeding edge repo (https://github.com/janestreet/opam-repository), and currently only work with OCaml 4.14.1. We are working towards 5.0.0 compatibility, but do not want it to delay the renaming and API tweaks.