### PR TITLE
v2.5 base v0.16 compat

### DIFF
--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -30,7 +30,7 @@ depends: [
   "async" {>= "v0.14.0"}
   "base" {>= "v0.11.0"}
   "core" {with-test}
-  "cohttp" {=version}
+  "cohttp" {>= "2.5.6" & "3.0.0"}
   "conduit-async" {>="1.2.0" & < "3.0.0"}
   "core_unix" {>= "v0.14.0"}
   "magic-mime"

--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -30,7 +30,7 @@ depends: [
   "async" {>= "v0.14.0"}
   "base" {>= "v0.11.0"}
   "core" {with-test}
-  "cohttp" {>= "2.5.6" & "3.0.0"}
+  "cohttp" {=version}
   "conduit-async" {>="1.2.0" & < "3.0.0"}
   "core_unix" {>= "v0.14.0"}
   "magic-mime"

--- a/cohttp-async/bin/cohttp_server_async.ml
+++ b/cohttp-async/bin/cohttp_server_async.ml
@@ -50,7 +50,7 @@ let serve ~info ~docroot ~index uri path =
         serve_file ~docroot ~uri
       | `No | `Unknown -> (* Do a directory listing *)
         Sys.ls_dir file_name
-        >>= Deferred.List.map ~f:(fun f ->
+        >>= Deferred.List.map ~how:Sequential ~f:(fun f ->
           let file_name = file_name / f in
           try_with (fun () ->
             Unix.stat file_name

--- a/cohttp-async/bin/cohttp_server_async.ml
+++ b/cohttp-async/bin/cohttp_server_async.ml
@@ -50,7 +50,7 @@ let serve ~info ~docroot ~index uri path =
         serve_file ~docroot ~uri
       | `No | `Unknown -> (* Do a directory listing *)
         Sys.ls_dir file_name
-        >>= Deferred.List.map ~how:`Sequential ~f:(fun f ->
+        >>= Deferred.List.map ~how:`Parallel ~f:(fun f ->
           let file_name = file_name / f in
           try_with (fun () ->
             Unix.stat file_name

--- a/cohttp-async/bin/cohttp_server_async.ml
+++ b/cohttp-async/bin/cohttp_server_async.ml
@@ -50,7 +50,7 @@ let serve ~info ~docroot ~index uri path =
         serve_file ~docroot ~uri
       | `No | `Unknown -> (* Do a directory listing *)
         Sys.ls_dir file_name
-        >>= Deferred.List.map ~how:Sequential ~f:(fun f ->
+        >>= Deferred.List.map ~how:`Sequential ~f:(fun f ->
           let file_name = file_name / f in
           try_with (fun () ->
             Unix.stat file_name

--- a/cohttp-async/src/body_raw.ml
+++ b/cohttp-async/src/body_raw.ml
@@ -66,7 +66,7 @@ let write_body write_body (body : t) writer =
   match body with
   | `Empty -> return ()
   | `String s -> write_body writer s
-  | `Strings sl -> Deferred.List.iter sl ~f:(write_body writer)
+  | `Strings sl -> Deferred.List.iter ~how:`Sequential sl ~f:(write_body writer)
   | `Pipe p -> Pipe.iter p ~f:(write_body writer)
 
 let pipe_of_body read_chunk ic =

--- a/cohttp-async/src/io.ml
+++ b/cohttp-async/src/io.ml
@@ -19,7 +19,7 @@ open Async_kernel
 
 module Writer = Async_unix.Writer
 module Reader = Async_unix.Reader
-module Format = Caml.Format
+module Format = Stdlib.Format
 
 let log_src_name = "cohttp.async.io"
 let src = Logs.Src.create log_src_name ~doc:"Cohttp Async IO module"
@@ -41,7 +41,7 @@ let default_reporter () =
       over ();
       k () in
     msgf @@ fun ?header:_ ?tags:_ fmt ->
-    Format.kfprintf k fmtr Caml.("@[" ^^ fmt ^^ "@]@.")
+    Format.kfprintf k fmtr Stdlib.("@[" ^^ fmt ^^ "@]@.")
   in
   { Logs.report }
 
@@ -56,10 +56,10 @@ let set_log = lazy (
 )
 
 let check_debug norm_fn debug_fn =
-  match Caml.Sys.getenv "COHTTP_DEBUG" with
+  match Stdlib.Sys.getenv "COHTTP_DEBUG" with
   | _ ->
     Lazy.force set_log; debug_fn
-  | exception Caml.Not_found -> norm_fn
+  | exception Stdlib.Not_found -> norm_fn
 
 type 'a t = 'a Deferred.t
 let (>>=) = Deferred.(>>=)


### PR DESCRIPTION
Hi! We are nearing the v0.16 release of Jane Street OCaml libraries. As discussed with @avsm, we'd like to backport the necessary fixes to cohttp-async v2.5 since we're still using this version internally. Let's coordinate around publishing everything to OPAM at the same time so there's no conflict.