### PR TITLE
Cohttp_lwt_unix.Server: Do not leak fd serving potentially never ending bodies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- cohttp-lwt server: call conn_closed before drainig the body of response on error (pirbo)
+
 ## v6.0.0~alpha1 (2023-04-28)
 
 - cohttp,cohttp-async server: correctly close broken streams (reported by Stéphane Glondu, fix by samhot and anuragsoni)

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -111,51 +111,60 @@ module Make (IO : S.IO) = struct
                 `Response rsp))
       (fun () -> Body.drain_body body)
 
-  let handle_response ~keep_alive oc res body handle_client =
+  let handle_response ~keep_alive oc res body conn_closed handle_client =
     IO.catch (fun () ->
         let flush = Response.flush res in
         Response.write ~flush
           (fun writer -> Body.write_body (Response.write_body writer) body)
           res oc)
     >>= function
-    | Ok () -> if keep_alive then handle_client oc else Lwt.return_unit
+    | Ok () ->
+        if keep_alive then handle_client oc
+        else
+          let () = conn_closed () in
+          Lwt.return_unit
     | Error e ->
         Log.info (fun m -> m "IO error while writing body: %a" IO.pp_error e);
+        conn_closed ();
         Body.drain_body body
 
-  let rec handle_client ic oc conn callback =
+  let rec handle_client ic oc conn spec =
     Request.read ic >>= function
-    | `Eof -> Lwt.return_unit
+    | `Eof ->
+        spec.conn_closed conn;
+        Lwt.return_unit
     | `Invalid data ->
         Log.err (fun m -> m "invalid input %s while handling client" data);
+        spec.conn_closed conn;
         Lwt.return_unit
     | `Ok req -> (
         let body = read_body ic req in
-        handle_request callback conn req body >>= function
+        handle_request spec.callback conn req body >>= function
         | `Response (res, body) ->
             let keep_alive =
               Http.Request.is_keep_alive req && Http.Response.is_keep_alive res
             in
-            handle_response ~keep_alive oc res body (fun oc ->
-                handle_client ic oc conn callback)
+            handle_response ~keep_alive oc res body
+              (fun () -> spec.conn_closed conn)
+              (fun oc -> handle_client ic oc conn spec)
         | `Expert (res, io_handler) ->
             Response.write_header res oc >>= fun () ->
-            io_handler ic oc >>= fun () -> handle_client ic oc conn callback)
+            io_handler ic oc >>= fun () -> handle_client ic oc conn spec)
 
   let callback spec io_id ic oc =
     let conn_id = Connection.create () in
     let conn_closed () = spec.conn_closed (io_id, conn_id) in
-    Lwt.finalize
+    Lwt.catch
       (fun () ->
-        IO.catch (fun () -> handle_client ic oc (io_id, conn_id) spec.callback)
+        IO.catch (fun () -> handle_client ic oc (io_id, conn_id) spec)
         >>= function
         | Ok () -> Lwt.return_unit
         | Error e ->
             Log.info (fun m ->
                 m "IO error while handling client: %a" IO.pp_error e);
+            conn_closed ();
             Lwt.return_unit)
-      (fun () ->
-        (* Clean up resources when the response stream terminates and call
-         * the user callback *)
-        conn_closed () |> Lwt.return)
+      (fun e ->
+        conn_closed ();
+        Lwt.fail e)
 end

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -116,10 +116,9 @@ module Make (IO : S.IO) = struct
         let flush = Response.flush res in
         Response.write ~flush
           (fun writer -> Body.write_body (Response.write_body writer) body)
-          res oc
-        >>= fun () -> if keep_alive then handle_client oc else Lwt.return_unit)
+          res oc)
     >>= function
-    | Ok () -> Lwt.return_unit
+    | Ok () -> if keep_alive then handle_client oc else Lwt.return_unit
     | Error e ->
         Log.info (fun m -> m "IO error while writing body: %a" IO.pp_error e);
         Body.drain_body body


### PR DESCRIPTION
Please tell me if I should be doing what I do in a complete different way (and c70ad81544eca744b9e8d7d3c7d08d90622c9f10 makes me think I do because Cohttp.Connection **are** useful in my case)

I want to use Cohttp to serve Server Sent Events (aka stream of things living as long as there is a client to receive them) and the way I implement them follows the sketch of 3226fdd33d165260400525cb16204e6d96da4ac8 but I realize that without this patch "Cohttp" never close the connections:
- I `dune exec cohttp-lwt-unix/examples/server_sent_event_lwt.exe` in one terminal and in an other I can see
```
$ lsof -p PID | wc -l
15
$ curl http://localhost:8800
Not found: //localhost:8800/
$ lsof -p PID | wc -l
15
$ curl http://localhost:8800/lol
Not found: //localhost:8800/lol
$ lsof -p PID | wc -l
15
```
but
```
$ curl http://localhost:8800/tic
Tic
Tic
^C
$ lsof -p PID | wc -l
16
$ curl http://localhost:8800/tic
Tic
^C
$ lsof -p PID | wc -l
17
```
And obviously, if you wait to drain the infinite body of the reply before calling `conn_closed` that would terminates it, it would take a while...

So, here I'm (maybe naively) swapping the 2.