### PR TITLE
Cohttp_eio: Relax requirement on `Server.connection_handler`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - cohttp-lwt server: call conn_closed before drainig the body of response on error (pirbo)
+- cohttp-eio: Relax socket interface requirement on `Server.connection_handler`.
 
 ## v6.0.0~alpha1 (2023-04-28)
 

--- a/cohttp-eio.opam
+++ b/cohttp-eio.opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "dune" {>= "3.0"}
   "base-domains"
-  "eio" {>= "0.7"}
+  "eio" {>= "0.10"}
   "eio_main" {with-test}
   "mdx" {with-test}
   "uri" {with-test}

--- a/cohttp-eio/examples/client_timeout.ml
+++ b/cohttp-eio/examples/client_timeout.ml
@@ -9,7 +9,7 @@ let () =
   Eio.Time.with_timeout env#clock timeout_s (fun () ->
       let host, port = ("www.example.org", 80) in
       let he = Unix.gethostbyname host in
-      let addr = `Tcp (Eio_unix.Ipaddr.of_unix he.h_addr_list.(0), port) in
+      let addr = `Tcp (Eio_unix.Net.Ipaddr.of_unix he.h_addr_list.(0), port) in
       let conn = Net.connect ~sw env#net addr in
       let res = Client.get ~conn ~port env ~host "/" in
       Client.read_fixed res |> Result.ok)

--- a/cohttp-eio/src/cohttp_eio.mli
+++ b/cohttp-eio/src/cohttp_eio.mli
@@ -107,7 +107,7 @@ module Server : sig
   val connection_handler :
     handler ->
     #Eio.Time.clock ->
-    #Eio.Net.stream_socket ->
+    #Eio.Flow.two_way ->
     Eio.Net.Sockaddr.stream ->
     unit
   (** [connection_handler request_handler] is a connection handler, suitable for

--- a/dune-project
+++ b/dune-project
@@ -361,7 +361,8 @@ should also be fine under Windows too.
   "A CoHTTP server and client implementation based on `eio` library. `cohttp-eio`features a multicore capable HTTP 1.1 server. The library promotes and is built with direct style of coding as opposed to a monadic.")
  (depends
   base-domains
-  (eio (>= 0.7))
+  (eio
+   (>= 0.10))
   (eio_main :with-test)
   (mdx :with-test)
   (uri :with-test)


### PR DESCRIPTION
`Server.connection_handler` does not rely on its argument being a socket, a two way flow is sufficient. Relaxing the type constraint enables eg. unit testing with in-memory buffers.