### PR TITLE
Do not omit mandatory null content-length headers.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 ## Unreleased
+
+- do not omit mandatory null Content-Length headers (mefyl #985)
 - cohttp-async, cohttp-curl-async: compatibility with core/async v0.16.0 (mseri, dkalinichenko-js #976)
 - cohttp-lwt server: call conn_closed before drainig the body of response on error (pirbo #982)
 - cohttp-eio: Relax socket interface requirement on `Server.connection_handler`. (mefyl #983)

--- a/cohttp/src/request.ml
+++ b/cohttp/src/request.ml
@@ -199,9 +199,9 @@ module Make (IO : S.IO) = struct
     in
     let headers = req.headers in
     let headers =
-      match Http.Request.has_body req with
-      | `Yes | `Unknown -> Header.add_transfer_encoding headers req.encoding
-      | `No -> headers
+      if Http.Method.body_allowed req.meth then
+        Header.add_transfer_encoding headers req.encoding
+      else headers
     in
     IO.write oc fst_line >>= fun _ -> Header_IO.write headers oc
 

--- a/cohttp/test/dune
+++ b/cohttp/test/dune
@@ -26,7 +26,7 @@
  (name test_request)
  (modules test_request)
  (forbidden_libraries base)
- (libraries cohttp alcotest fmt))
+ (libraries alcotest cohttp fmt http_bytebuffer))
 
 (rule
  (alias runtest)

--- a/http/src/http.ml
+++ b/http/src/http.ml
@@ -702,6 +702,11 @@ module Method = struct
     | "CONNECT" -> `CONNECT
     | s -> `Other s
 
+  (* Defined for method types in RFC7231 *)
+  let body_allowed = function
+    | `GET | `HEAD | `CONNECT | `TRACE -> false
+    | `DELETE | `POST | `PUT | `PATCH | `OPTIONS | `Other _ -> true
+
   let compare (a : t) (b : t) = Stdlib.compare a b
   let pp fmt t = Format.fprintf fmt "%s" (to_string t)
 end
@@ -792,10 +797,7 @@ module Request = struct
 
   (* Defined for method types in RFC7231 *)
   let has_body req =
-    match req.meth with
-    | `GET | `HEAD | `CONNECT | `TRACE -> `No
-    | `DELETE | `POST | `PUT | `PATCH | `OPTIONS | `Other _ ->
-        Transfer.has_body req.encoding
+    if Method.body_allowed req.meth then Transfer.has_body req.encoding else `No
 
   let make ?(meth = `GET) ?(version = `HTTP_1_1) ?(headers = Header.empty)
       ?scheme resource =

--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -21,6 +21,11 @@ module Method : sig
     | `Other of string ]
 
   val compare : t -> t -> int
+
+  val body_allowed : t -> bool
+  (** [body_allowed meth] returns whether [meth] allows a payload body to be
+      present per RFC7231. *)
+
   val of_string : string -> t
   val to_string : t -> string
   val pp : Format.formatter -> t -> unit


### PR DESCRIPTION
The code currently reuses the code that determines whether a body should be read to determine whether a `Content-Length` header should be sent. However, for unchunked bodies of size 0, there is no body to read, but `Content-Length: 0` is still mandatory for methods which may allow a body.