### PR TITLE
Remove special treatment of "host" header

### DIFF
--- a/cohttp-eio/src/client.ml
+++ b/cohttp-eio/src/client.ml
@@ -41,7 +41,6 @@ let write_request pipeline_requests request writer body =
       body
   in
   let headers = Http.Header.clean_dup headers in
-  let headers = Http.Header.Private.move_to_front headers "Host" in
   let meth = Http.Method.to_string @@ Http.Request.meth request in
   let version = Http.Version.to_string @@ Http.Request.version request in
   Buf_write.string writer meth;

--- a/cohttp-eio/tests/client.md
+++ b/cohttp-eio/tests/client.md
@@ -44,8 +44,8 @@ GET method request:
       |> Client.read_fixed
       |> print_string);;
 +socket: wrote "GET / HTTP/1.1\r\n"
-+              "Host: localhost\r\n"
 +              "Accept: application/json\r\n"
++              "Host: localhost\r\n"
 +              "User-Agent: cohttp-eio\r\n"
 +              "TE: trailers\r\n"
 +              "Connection: TE\r\n"
@@ -82,9 +82,9 @@ POST request:
       |> Client.read_fixed
       |> print_string);;
 +socket: wrote "POST /post HTTP/1.1\r\n"
-+              "Host: localhost\r\n"
 +              "Accept: application/json\r\n"
 +              "Content-Length: 12\r\n"
++              "Host: localhost\r\n"
 +              "User-Agent: cohttp-eio\r\n"
 +              "TE: trailers\r\n"
 +              "Connection: TE\r\n"
@@ -158,10 +158,10 @@ Chunk request:
       |> Client.read_fixed
       |> print_string);;
 +socket: wrote "POST /handle_chunk HTTP/1.1\r\n"
-+              "Host: localhost\r\n"
 +              "Transfer-Encoding: chunked\r\n"
 +              "Content-Type: text/plain\r\n"
 +              "Trailer: Expires, Header1\r\n"
++              "Host: localhost\r\n"
 +              "User-Agent: cohttp-eio\r\n"
 +              "TE: trailers\r\n"
 +              "Connection: TE\r\n"

--- a/cohttp-lwt-unix/test/test_parser.ml
+++ b/cohttp-lwt-unix/test/test_parser.ml
@@ -270,7 +270,7 @@ let make_simple_req () =
   let open Cohttp in
   let open Cohttp_lwt_unix in
   let expected =
-    "POST /foo/bar HTTP/1.1\r\nhost: localhost\r\nFoo: bar\r\nuser-agent: "
+    "POST /foo/bar HTTP/1.1\r\nFoo: bar\r\nhost: localhost\r\nuser-agent: "
     ^ user_agent
     ^ "\r\ntransfer-encoding: chunked\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n"
   in
@@ -285,7 +285,7 @@ let mutate_simple_req () =
   let open Cohttp in
   let open Cohttp_lwt_unix in
   let expected =
-    "POST /foo/bar HTTP/1.1\r\nhost: localhost\r\nfoo: bar\r\nuser-agent: "
+    "POST /foo/bar HTTP/1.1\r\nfoo: bar\r\nhost: localhost\r\nuser-agent: "
     ^ user_agent
     ^ "\r\ntransfer-encoding: chunked\r\n\r\n6\r\nfoobar\r\n0\r\n\r\n"
   in

--- a/cohttp/src/request.ml
+++ b/cohttp/src/request.ml
@@ -61,7 +61,6 @@ let make ?(meth = `GET) ?(version = `HTTP_1_1) ?(encoding = Transfer.Unknown)
           ^
           match Uri.port uri with Some p -> ":" ^ string_of_int p | None -> ""))
   in
-  let headers = Header.Private.move_to_front headers "host" in
   let headers =
     Header.add_unless_exists headers "user-agent" Header.user_agent
   in
@@ -204,7 +203,6 @@ module Make (IO : S.IO) = struct
         Header.add_transfer_encoding headers req.encoding
       else headers
     in
-    let headers = Header.Private.move_to_front headers "host" in
     IO.write oc fst_line >>= fun _ -> Header_IO.write headers oc
 
   let make_body_writer ?flush req oc =

--- a/cohttp/test/test_request.ml
+++ b/cohttp/test/test_request.ml
@@ -321,8 +321,8 @@ let null_content_length_header () =
   Alcotest.(check string)
     "null content-length header are sent"
     "PUT / HTTP/1.1\r\n\
-     host: someuri.com\r\n\
      user-agent: ocaml-cohttp\r\n\
+     host: someuri.com\r\n\
      content-length: 0\r\n\
      \r\n"
     (Buffer.to_string output)

--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -309,11 +309,12 @@ module Header : sig
         [h] is returned unchanged. *)
 
   val iter_ord : (string -> string -> unit) -> t -> unit
-  (** [iter_ord f h] applies [f] to all the headers of [h] following the header order. *)
-  
+  (** [iter_ord f h] applies [f] to all the headers of [h] following the header
+      order. *)
+
   val iter : (string -> string -> unit) -> t -> unit
-  (** [iter f h] applies [f] to all the headers of [h] following an unspecified order. 
-      This function is faster than iter_ord. *)
+  (** [iter f h] applies [f] to all the headers of [h] following an unspecified
+      order. This function is faster than iter_ord. *)
 
   val map : (string -> string -> string) -> t -> t
   val fold : (string -> string -> 'a -> 'a) -> t -> 'a -> 'a
@@ -377,15 +378,6 @@ module Header : sig
     val caseless_equal : string -> string -> bool
     (** [caseless_equal a b] must be equivalent to
         [String.equal (String.lowercase_ascii a) (String.lowercase_ascii b)]. *)
-
-    val first : t -> (string * string) option
-    (** [first t] is [Some (hdr_name, hdr_value)], which represents the first
-        header in headers list [t]. It is [None] if [t] is empty. *)
-
-    val move_to_front : t -> string -> t
-    (** [move_to_front t hdr_name] is [t] with header name [hdr_name] moved to
-        the front of the headers list [t]. If the header doesn't exist in [t] or
-        the header is already at the front, then [t] is unchanged. *)
   end
 end
 

--- a/http/test/test_header.ml
+++ b/http/test/test_header.ml
@@ -167,24 +167,6 @@ let replace_tests () =
     ]
     H.(to_list (replace prebuilt "accept" "text/*"))
 
-let move_to_front_tests () =
-  let headers1 = [ ("accept", "text/*"); ("Host", "www.example.com") ] in
-  let headers2 =
-    [
-      ("content-length", "23"); ("Host", "www.example.com"); ("accept", "text/*");
-    ]
-  in
-  aeso {|move_to_front h "Host"|} (Some "Host")
-    (H.(Private.move_to_front (H.of_list headers1) "Host" |> Private.first)
-     |> function
-     | Some (k, _) -> Some k
-     | None -> Some "");
-  aeso {|move_to_front h "Host"|} (Some "Host")
-    (H.(Private.move_to_front (H.of_list headers2) "Host" |> Private.first)
-     |> function
-     | Some (k, _) -> Some k
-     | None -> Some "")
-
 let h =
   H.init () |> fun h ->
   H.add h "first" "1" |> fun h ->
@@ -398,7 +380,6 @@ let tests =
       ("Header.iter", `Quick, iter_tests);
       ("Header.update", `Quick, update_tests);
       ("Header.update_all", `Quick, update_all_tests);
-      ("Header.move_to_front", `Quick, move_to_front_tests);
       ("many headers", `Slow, many_headers);
       ("transfer encoding is in correct order", `Quick, transfer_encoding_tests);
     ]


### PR DESCRIPTION
As correctly pointed out by @anuragsoni, the RFC says that order of header fields isn't significant within a well-behaved server.https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2

> The order in which header fields with differing field names are
> received is not significant.  However, it is good practice to send
> header fields that contain control data first, such as Host on
> requests and Date on responses, so that implementations can decide
> when not to handle a message as early as possible.  A server MUST NOT
> apply a request to the target resource until the entire request

Since this introduces unnecessary complexity and unnecessary extra functions in the http package header module, I am removing the special treatment in this PR.

Users that want to enforce the ordering of the headers can do it with the same type of overhead directly in their code and can take 0d252ec as inspiration. Using `Header.to_list` and `of_list` in their code it is also safer than what we do here, in case the implementation details of the header module change.