### PR TITLE
cohttp-eio: add Client.make_generic and HTTPS support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - cohttp-eio: Complete rewrite to follow common interfaces and behaviors. (mefyl #984)
+- cohttp-eio: Add Client.make_generic and HTTPS support. (talex5 #1002)
 
 ## v6.0.0~alpha2 (2023-08-08)
 - cohttp-lwt: Do not leak exceptions to `Lwt.async_exception_hook`. (mefyl #992, #995)

--- a/cohttp-eio.opam
+++ b/cohttp-eio.opam
@@ -27,6 +27,8 @@ depends: [
   "eio_main" {with-test}
   "mdx" {with-test}
   "uri" {with-test}
+  "tls-eio" {with-test & >= "0.17.2"}
+  "mirage-crypto-rng-eio" {with-test & >= "0.11.2"}
   "fmt"
   "ptime"
   "http" {= version}

--- a/cohttp-eio/examples/client1.ml
+++ b/cohttp-eio/examples/client1.ml
@@ -10,7 +10,7 @@ and () = Logs.Src.set_level Cohttp_eio.src (Some Debug)
 
 let () =
   Eio_main.run @@ fun env ->
-  let client = Client.make env#net in
+  let client = Client.make ~https:None env#net in
   Eio.Switch.run @@ fun sw ->
   let resp, body = Client.get ~sw client (Uri.of_string "http://example.com") in
   if Http.Status.compare resp.status `OK = 0 then

--- a/cohttp-eio/examples/client_timeout.ml
+++ b/cohttp-eio/examples/client_timeout.ml
@@ -2,7 +2,7 @@ open Cohttp_eio
 
 let () =
   Eio_main.run @@ fun env ->
-  let client = Client.make env#net in
+  let client = Client.make ~https:None env#net in
   (* Increment/decrement this value to see success/failure. *)
   let timeout_s = 0.01 in
   Eio.Time.with_timeout env#clock timeout_s (fun () ->

--- a/cohttp-eio/examples/client_tls.ml
+++ b/cohttp-eio/examples/client_tls.ml
@@ -5,18 +5,24 @@ let () =
   Logs_threaded.enable ();
   Logs.Src.set_level Cohttp_eio.src (Some Debug)
 
-let null_auth ?ip:_ ~host:_ _ = Ok None     (* Warning: use a real authenticator in your code! *)
+let null_auth ?ip:_ ~host:_ _ =
+  Ok None (* Warning: use a real authenticator in your code! *)
 
 let https ~authenticator =
   let tls_config = Tls.Config.client ~authenticator () in
   fun uri raw ->
-    let host = Uri.host uri |> Option.map (fun x -> Domain_name.(host_exn (of_string_exn x))) in
+    let host =
+      Uri.host uri
+      |> Option.map (fun x -> Domain_name.(host_exn (of_string_exn x)))
+    in
     Tls_eio.client_of_flow ?host tls_config raw
 
 let () =
   Eio_main.run @@ fun env ->
   Mirage_crypto_rng_eio.run (module Mirage_crypto_rng.Fortuna) env @@ fun () ->
-  let client = Client.make ~https:(Some (https ~authenticator:null_auth)) env#net in
+  let client =
+    Client.make ~https:(Some (https ~authenticator:null_auth)) env#net
+  in
   Eio.Switch.run @@ fun sw ->
   let resp, body =
     Client.get ~sw client (Uri.of_string "https://example.com")

--- a/cohttp-eio/examples/client_tls.ml
+++ b/cohttp-eio/examples/client_tls.ml
@@ -1,0 +1,26 @@
+open Cohttp_eio
+
+let () =
+  Logs.set_reporter (Logs_fmt.reporter ());
+  Logs_threaded.enable ();
+  Logs.Src.set_level Cohttp_eio.src (Some Debug)
+
+let null_auth ?ip:_ ~host:_ _ = Ok None     (* Warning: use a real authenticator in your code! *)
+
+let https ~authenticator =
+  let tls_config = Tls.Config.client ~authenticator () in
+  fun uri raw ->
+    let host = Uri.host uri |> Option.map (fun x -> Domain_name.(host_exn (of_string_exn x))) in
+    Tls_eio.client_of_flow ?host tls_config raw
+
+let () =
+  Eio_main.run @@ fun env ->
+  Mirage_crypto_rng_eio.run (module Mirage_crypto_rng.Fortuna) env @@ fun () ->
+  let client = Client.make ~https:(Some (https ~authenticator:null_auth)) env#net in
+  Eio.Switch.run @@ fun sw ->
+  let resp, body =
+    Client.get ~sw client (Uri.of_string "https://example.com")
+  in
+  if Http.Status.compare resp.status `OK = 0 then
+    print_string @@ Eio.Buf_read.(parse_exn take_all) body ~max_size:max_int
+  else Fmt.epr "Unexpected HTTP status: %a" Http.Status.pp resp.status

--- a/cohttp-eio/examples/docker_client.ml
+++ b/cohttp-eio/examples/docker_client.ml
@@ -10,7 +10,7 @@ and () = Logs.Src.set_level Cohttp_eio.src (Some Debug)
 
 let () =
   Eio_main.run @@ fun env ->
-  let client = Client.make env#net in
+  let client = Client.make ~https:None env#net in
   Eio.Switch.run @@ fun sw ->
   let response, body =
     Client.get client ~sw

--- a/cohttp-eio/examples/dune
+++ b/cohttp-eio/examples/dune
@@ -1,6 +1,6 @@
 (executables
- (names server1 client1 docker_client client_timeout)
- (libraries cohttp-eio eio_main eio.unix fmt unix logs.fmt logs.threaded))
+ (names server1 client1 docker_client client_timeout client_tls)
+ (libraries cohttp-eio eio_main eio.unix fmt unix logs.fmt logs.threaded tls-eio mirage-crypto-rng-eio))
 
 (alias
  (name runtest)

--- a/cohttp-eio/examples/dune
+++ b/cohttp-eio/examples/dune
@@ -1,6 +1,15 @@
 (executables
  (names server1 client1 docker_client client_timeout client_tls)
- (libraries cohttp-eio eio_main eio.unix fmt unix logs.fmt logs.threaded tls-eio mirage-crypto-rng-eio))
+ (libraries
+  cohttp-eio
+  eio_main
+  eio.unix
+  fmt
+  unix
+  logs.fmt
+  logs.threaded
+  tls-eio
+  mirage-crypto-rng-eio))
 
 (alias
  (name runtest)

--- a/cohttp-eio/src/client.mli
+++ b/cohttp-eio/src/client.mli
@@ -9,16 +9,20 @@ include
      and type body = Body.t
 
 val make :
-  https:(Uri.t -> [`Generic] Eio.Net.stream_socket_ty r -> _ Eio.Flow.two_way) option ->
-  _ Eio.Net.t -> t
-(** [make ~https net] is a convenience wrapper around {!make_generic} that
-    uses [net] to make connections.
+  https:
+    (Uri.t -> [ `Generic ] Eio.Net.stream_socket_ty r -> _ Eio.Flow.two_way)
+    option ->
+  _ Eio.Net.t ->
+  t
+(** [make ~https net] is a convenience wrapper around {!make_generic} that uses
+    [net] to make connections.
 
-    - URIs of the form "http://host:port/..." connect to the given TCP host and port.
-    - URIs of the form "https://host:port/..." connect to the given TCP host and port,
-      and are then wrapped by [https] (or rejected if that is [None]).
-    - URIs of the form "httpunix://unix-path/http-path" connect to the given Unix path.
-*)
+    - URIs of the form "http://host:port/..." connect to the given TCP host and
+      port.
+    - URIs of the form "https://host:port/..." connect to the given TCP host and
+      port, and are then wrapped by [https] (or rejected if that is [None]).
+    - URIs of the form "httpunix://unix-path/http-path" connect to the given
+      Unix path. *)
 
 val make_generic : (sw:Switch.t -> Uri.t -> _ Eio.Net.stream_socket) -> t
 (** [make_generic connect] is an HTTP client that uses [connect] to get the

--- a/cohttp-eio/src/client.mli
+++ b/cohttp-eio/src/client.mli
@@ -1,9 +1,25 @@
+open Eio.Std
+
 type t
 
 include
   Cohttp.Client.S
-    with type 'a with_context = t -> sw:Eio.Switch.t -> 'a
+    with type 'a with_context = t -> sw:Switch.t -> 'a
      and type 'a io = 'a
      and type body = Body.t
 
-val make : _ Eio.Net.t -> t
+val make :
+  https:(Uri.t -> [`Generic] Eio.Net.stream_socket_ty r -> _ Eio.Flow.two_way) option ->
+  _ Eio.Net.t -> t
+(** [make ~https net] is a convenience wrapper around {!make_generic} that
+    uses [net] to make connections.
+
+    - URIs of the form "http://host:port/..." connect to the given TCP host and port.
+    - URIs of the form "https://host:port/..." connect to the given TCP host and port,
+      and are then wrapped by [https] (or rejected if that is [None]).
+    - URIs of the form "httpunix://unix-path/http-path" connect to the given Unix path.
+*)
+
+val make_generic : (sw:Switch.t -> Uri.t -> _ Eio.Net.stream_socket) -> t
+(** [make_generic connect] is an HTTP client that uses [connect] to get the
+    connection to use for a given URI. *)

--- a/dune-project
+++ b/dune-project
@@ -371,6 +371,8 @@
   (eio_main :with-test)
   (mdx :with-test)
   (uri :with-test)
+  (tls-eio (and :with-test (>= 0.17.2)))
+  (mirage-crypto-rng-eio (and :with-test (>= 0.11.2)))
   fmt
   ptime
   (http


### PR DESCRIPTION
https://github.com/mirage/ocaml-cohttp/pull/984#issuecomment-1737065489 said:

> I aim at merging this and https://github.com/mefyl/ocaml-cohttp/compare/eio...talex5:ocaml-cohttp:eio-tls as they are now though (perhaps with some more explanations on how to do tls properly), release a new beta release and see if there are comments

However, the TLS support wasn't included in the end, so I'm opening a separate PR for it here.

/cc @SGrondin 