### PR TITLE
cohttp: move new client and server modules into a generic module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## v6.0.0~beta1 (2023-10-27)
+- cohttp-eio: move new Cohttp.{Client,Server} modules under Cohttp.Generic (mseri #1003)
 - cohttp-eio: Add Client.make_generic and HTTPS support. (talex5 #1002)
 - cohttp: move generic client and server signatures to cohttp and use them across all packges. (mefyl #984)
 - cohttp-eio: Complete rewrite to follow common interfaces and behaviors. (mefyl #984)

--- a/cohttp-eio/src/client.ml
+++ b/cohttp-eio/src/client.ml
@@ -6,7 +6,7 @@ type connection = Eio.Flow.two_way_ty r
 type t = sw:Switch.t -> Uri.t -> connection
 
 include
-  Cohttp.Client.Make
+  Cohttp.Generic.Client.Make
     (struct
       type 'a io = 'a
       type body = Body.t

--- a/cohttp-eio/src/client.mli
+++ b/cohttp-eio/src/client.mli
@@ -3,7 +3,7 @@ open Eio.Std
 type t
 
 include
-  Cohttp.Client.S
+  Cohttp.Generic.Client.S
     with type 'a with_context = t -> sw:Switch.t -> 'a
      and type 'a io = 'a
      and type body = Body.t

--- a/cohttp-eio/src/server.mli
+++ b/cohttp-eio/src/server.mli
@@ -1,4 +1,4 @@
-include Cohttp.Server.S with module IO = Io.IO and type body = Body.t
+include Cohttp.Generic.Server.S with module IO = Io.IO and type body = Body.t
 
 val run :
   ?max_connections:int ->

--- a/cohttp-lwt.opam
+++ b/cohttp-lwt.opam
@@ -29,7 +29,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "http" {= version}
   "cohttp" {= version}
-  "lwt" {>= "2.5.0"}
+  "lwt" {>= "5.4.0"}
   "sexplib0"
   "ppx_sexp_conv" {>= "v0.13.0"}
   "logs"

--- a/cohttp-lwt/src/client.ml
+++ b/cohttp-lwt/src/client.ml
@@ -17,7 +17,7 @@ module Make (Connection : S.Connection) = struct
     | Some ctx -> No_cache.(call (create ~ctx ()))
 
   include
-    Cohttp.Client.Make
+    Cohttp.Generic.Client.Make
       (struct
         type 'a io = 'a Lwt.t
         type body = Body.t

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -196,7 +196,7 @@ module type Client = sig
         interface rather than invoke this function directly. See {!head}, {!get}
         and {!post} for some examples. *)
   include
-    Cohttp.Client.S
+    Cohttp.Generic.Client.S
       with type 'a io = 'a Lwt.t
        and type body = Body.t
        and type 'a with_context = ?ctx:ctx -> 'a
@@ -223,7 +223,7 @@ end
 
 (** The [Server] module implements a pipelined HTTP/1.1 server. *)
 module type Server = sig
-  include Cohttp.Server.S with type body = Body.t and type 'a IO.t = 'a Lwt.t
+  include Cohttp.Generic.Server.S with type body = Body.t and type 'a IO.t = 'a Lwt.t
 
   val resolve_local_file : docroot:string -> uri:Uri.t -> string
     [@@deprecated "Please use Cohttp.Path.resolve_local_file. "]

--- a/cohttp/src/cohttp.ml
+++ b/cohttp/src/cohttp.ml
@@ -1,7 +1,6 @@
 module Accept = Accept
 module Auth = Auth
 module Body = Body
-module Client = Client
 module Conf = Conf
 module Connection = Connection [@@deprecated "Connection.t values are useless."]
 module Code = Code
@@ -11,9 +10,13 @@ module Link = Link
 module Request = Request
 module Response = Response
 module S = S
-module Server = Server
 module Path = Path
 module Transfer = Transfer
+
+module Generic = struct
+  module Client = Client
+  module Server = Server
+end
 
 module Private = struct
   module Transfer_io = Transfer_io

--- a/dune-project
+++ b/dune-project
@@ -76,7 +76,7 @@
   (cohttp
    (= :version))
   (lwt
-   (>= 2.5.0))
+   (>= 5.4.0))
   sexplib0
   (ppx_sexp_conv
    (>= v0.13.0))


### PR DESCRIPTION
to avoid shadowing Client and Server modules when opening Cohttp.

This preserves backward compatibility for a very small price and improves library ergonomics since right now many project tend to open Cohttp to have the Headers and Response modules directly accessible.