### PR TITLE
Add Eio server benchmark

### DIFF
--- a/cohttp-bench.opam
+++ b/cohttp-bench.opam
@@ -26,8 +26,10 @@ depends: [
   "dune" {>= "3.0"}
   "core" {>= "v0.13.0"}
   "core_bench"
+  "eio" {>= "0.12"}
   "http" {= version}
   "cohttp" {= version}
+  "cohttp-eio" {= version}
   "cohttp-lwt-unix" {= version}
   "cohttp-server-lwt-unix" {= version}
   "cohttp-async" {= version}

--- a/cohttp-bench/dune
+++ b/cohttp-bench/dune
@@ -13,6 +13,11 @@
  (modules async_server)
  (libraries cohttp-async core_unix.command_unix logs.fmt fmt.tty))
 
+(executable
+ (name eio_server)
+ (modules eio_server)
+ (libraries cohttp-eio eio_main))
+
 (rule
  (alias bench)
  (package cohttp-bench)

--- a/cohttp-bench/eio_server.ml
+++ b/cohttp-bench/eio_server.ml
@@ -1,0 +1,22 @@
+open Cohttp_eio
+
+let length = 2053
+let text = String.make length 'a'
+let headers = Cohttp.Header.of_list [ ("content-length", Int.to_string length) ]
+
+let server_callback _conn _req _body =
+  Server.respond_string ~headers ~status:`OK ~body:text ()
+
+
+let () =
+  let port = ref 8080 in
+  Arg.parse
+    [ ("-p", Arg.Set_int port, " Listening port number(8080 by default)") ]
+    ignore "An HTTP/1.1 server";
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let socket =
+    Eio.Net.listen env#net ~sw ~backlog:11_000 ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, !port))
+  and server = Cohttp_eio.Server.make ~callback:server_callback () in
+  Cohttp_eio.Server.run socket server ~on_error:raise

--- a/cohttp-bench/latency.sh
+++ b/cohttp-bench/latency.sh
@@ -4,7 +4,7 @@ set -xe
 rm -rf output/*
 mkdir -p output
 
-for cmd in "lwt_unix_server" "async_server" "lwt_unix_server_new"; do
+for cmd in "lwt_unix_server" "async_server" "lwt_unix_server_new" "eio_server"; do
   ./$cmd.exe &
   running_pid=$!
   echo "Measuring latency of $cmd"

--- a/dune-project
+++ b/dune-project
@@ -346,9 +346,13 @@
   (core
    (>= v0.13.0))
   core_bench
+  (eio
+   (>= 0.12))
   (http
    (= :version))
   (cohttp
+   (= :version))
+  (cohttp-eio
    (= :version))
   (cohttp-lwt-unix
    (= :version))


### PR DESCRIPTION
Adds a eio_server benchmark that I wrote for measuring the performance of cohttp-eio, similar to the `async_server` and `lwt_unix_server_new` benchmarks. Results obtained on a server machine (Intel Xeon Gold 5120) are below:

**eio_server**

```
141829 requests in 5.00s, 283.23MB read
Requests/sec:  28361.57
Transfer/sec:     56.64MB
```

**async_server**

```
105063 requests in 5.00s, 212.22MB read
Requests/sec:  21011.74
Transfer/sec:     42.44MB
```

**lwt_unix_server_new**

```
166961 requests in 5.00s, 333.42MB read
Requests/sec:  33393.19
Transfer/sec:     66.69MB
```