### PR TITLE
cohttp-lwt: Preserve extended signature of `IO` in `Server.S`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - cohttp-eio: Don't blow up Server on client disconnections. (mefyl #1011)
 - cohttp-eio: Match body encoding with headers. (mefyl #1012)
+- cohttp-lwt: Preserve extended `Server.S.IO` signature. (mefyl #1013)
 
 ## v6.0.0~beta1 (2023-10-27)
 - cohttp-eio: move new Cohttp.{Client,Server} modules under Cohttp.Generic (mseri #1003)

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -223,7 +223,8 @@ end
 
 (** The [Server] module implements a pipelined HTTP/1.1 server. *)
 module type Server = sig
-  include Cohttp.Generic.Server.S with type body = Body.t and type 'a IO.t = 'a Lwt.t
+  module IO : IO
+  include Cohttp.Generic.Server.S with type body = Body.t and module IO := IO
 
   val resolve_local_file : docroot:string -> uri:Uri.t -> string
     [@@deprecated "Please use Cohttp.Path.resolve_local_file. "]


### PR DESCRIPTION
Fixes #1010 