### PR TITLE
Fix assertion in `Parser.Source.to_string_trim`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- http: Fix assertion in `Source.to_string_trim` when `pos <> 0` (mefyl #1017)
+
 ## v6.0.0~beta2 (2024-01-05)
 
 - cohttp-eio: Don't blow up Server on client disconnections. (mefyl #1011)

--- a/http/src/http.ml
+++ b/http/src/http.ml
@@ -944,7 +944,7 @@ module Parser = struct
              "Http_parser.Source.substring: Index out of bounds., Requested \
               off: %d, len: %d"
              pos len);
-      let last = ref (t.pos + len - 1) in
+      let last = ref (t.pos + pos + len - 1) in
       let pos = ref (t.pos + pos) in
       while is_space (String.unsafe_get t.buffer !pos) do
         incr pos

--- a/http/src/http.ml
+++ b/http/src/http.ml
@@ -953,7 +953,7 @@ module Parser = struct
         decr last
       done;
       let len = !last - !pos + 1 in
-      String.sub t.buffer !pos len
+      if len < 0 then "" else String.sub t.buffer !pos len
 
     let rec index_rec t ch idx len =
       if idx = len then -1

--- a/http/test/test_parser.ml
+++ b/http/test/test_parser.ml
@@ -15,6 +15,7 @@ let req =
    Cookie: wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; \
    __utma=xxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.x; \
    __utmz=xxxxxxxxx.xxxxxxxxxx.x.x.utmccn=(referral)|utmcsr=reader.livedoor.com|utmcct=/reader/|utmcmd=referral\r\n\
+   Empty:    \r\n\
    \r\n"
 
 let assert_req_success ~here ~expected_req ~expected_consumed ?pos ?len buf =
@@ -69,13 +70,14 @@ let req_expected =
               __utma=xxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.x; \
               __utmz=xxxxxxxxx.xxxxxxxxxx.x.x.utmccn=(referral)|utmcsr=reader.livedoor.com|utmcct=/reader/|utmcmd=referral"
            );
+           ("Empty", "");
          ])
     `GET "/wp-content/uploads/2010/03/hello-kitty-darth-vader-pink.jpg"
 
 let parse_single_request () =
   assert_req_success
     ~here:[ [%here] ]
-    ~expected_req:req_expected ~expected_consumed:706 req
+    ~expected_req:req_expected ~expected_consumed:718 req
 
 let reject_headers_with_space_before_colon () =
   let req =


### PR DESCRIPTION
I'm occasionally getting the assertion below. I didn't try reproducing, but an indexing error in `to_string_trim` is probably the culprit.

```
routine-push-notifications: internal error, uncaught exception:
                            Invalid_argument("String.sub / Bytes.sub")
                            Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
                            Called from Stdlib__String.sub in file "string.ml" (inlined), line 43, characters 2-23
                            Called from Http.Parser.Source.to_string_trim in file "http/src/http.ml" (inlined), line 956, characters 6-34
                            Called from Http.Parser.header in file "http/src/http.ml", line 1053, characters 16-60
                            Called from Http.Parser.headers.loop in file "http/src/http.ml", line 1065, characters 16-29
                            Called from Http.Parser.headers.(fun) in file "http/src/http.ml" (inlined), line 1069, characters 18-32
                            Called from Http.Parser.request in file "http/src/http.ml", line 1149, characters 18-32
                            Called from Http.Parser.run_parser in file "http/src/http.ml", line 1164, characters 10-18
                            Called from Http.Parser.parse_request in file "http/src/http.ml" (inlined), line 1171, characters 36-68
                            Called from Cohttp__Request.Make.read.(fun) in file "cohttp/src/request.ml", line 176, characters 16-63
                            Called from Cohttp_eio__Io.IO.with_input_buffer in file "cohttp-eio/src/io.ml", line 20, characters 6-74
                            Called from Cohttp__Request.Make.read in file "cohttp/src/request.ml", line 175, characters 6-270
```