### PR TITLE
Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,8 +463,8 @@ $ cohttp-curl-lwt 'http://0.0.0.0:8080/README.md'
 ```
 
 Other examples using the async api are avaliable in the
-[examples/async](https://github.com/mirage/ocaml-cohttp/tree/master/examples)
-folder in the sources
+[cohttp-async/examples](https://github.com/mirage/ocaml-cohttp/tree/master/cohttp-async/examples)
+folder in the sources.
 
 ## Debugging
 


### PR DESCRIPTION
Fix broken link in readme (cohttp-async/examples).