### PR TITLE
cohttp-eio.Server: Don't blow up in `callback` on client read timeout.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- cohttp-eio: Don't blow up `Server.callback` on connection timeout. (mefyl #1021)
 - cohttp-eio: Don't blow up `Server.callback` on client disconnections. (mefyl #1015)
 - http: Fix assertion in `Source.to_string_trim` when `pos <> 0` (mefyl #1017)
 


### PR DESCRIPTION
Yet another escaping exception. We can't catch the specific `Eio_unix.Unix_error (ETIMEDOUT, _, _)` since this is backend agnostic, so I'm stopping all backend exceptions. Which I dislike, suggestions welcome.

<details>
  <summary>Backtrace</summary>

```
routine-push-notifications: internal error, uncaught exception:
                            Eio.Io Unix_error (Operation timed out, "readv", "")
                            Raised at Eio_posix__Flow.Impl.single_read in file "lib_eio_posix/flow.ml", line 88, characters 55-85
                            Called from Eio__Flow.single_read in file "lib_eio/flow.ml", line 85, characters 12-31
                            Called from Eio__Buf_read.ensure_slow_path in file "lib_eio/buf_read.ml", line 122, characters 18-50
                            Called from Eio__Buf_read.ensure in file "lib_eio/buf_read.ml" (inlined), line 131, characters 20-40
                            Called from Cohttp_eio__Io.IO.refill in file "cohttp-eio/src/io.ml", line 17, characters 29-62
                            Called from Cohttp__Request.Make.read in file "cohttp/src/request.ml", line 183, characters 8-20
                            Called from Cohttp_eio__Server.read in file "cohttp-eio/src/server.ml", line 46, characters 8-29
                            Called from Cohttp_eio__Server.callback.handle in file "cohttp-eio/src/server.ml", line 98, characters 10-20
```
</detail>