### PR TITLE
cohttp-eio: Improve error handling in example server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- cohttp-eio: Improve error handling in example server (talex5 #1023)
 - cohttp-eio: Don't blow up `Server.callback` on client disconnections. (mefyl #1015)
 - http: Fix assertion in `Source.to_string_trim` when `pos <> 0` (mefyl #1017)
 

--- a/cohttp-bench/eio_server.ml
+++ b/cohttp-bench/eio_server.ml
@@ -7,7 +7,6 @@ let headers = Cohttp.Header.of_list [ ("content-length", Int.to_string length) ]
 let server_callback _conn _req _body =
   Server.respond_string ~headers ~status:`OK ~body:text ()
 
-
 let () =
   let port = ref 8080 in
   Arg.parse

--- a/cohttp-eio.opam
+++ b/cohttp-eio.opam
@@ -26,7 +26,8 @@ depends: [
   "eio" {>= "0.12"}
   "eio_main" {with-test}
   "mdx" {with-test}
-  "uri" {with-test}
+  "logs"
+  "uri"
   "tls-eio" {with-test & >= "0.17.2"}
   "mirage-crypto-rng-eio" {with-test & >= "0.11.2"}
   "fmt"

--- a/cohttp-eio/examples/server1.ml
+++ b/cohttp-eio/examples/server1.ml
@@ -42,6 +42,8 @@ let handler _socket request _body =
         Eio.Flow.string_source text )
   | _ -> (Http.Response.make ~status:`Not_found (), Cohttp_eio.Body.of_string "")
 
+let log_warning ex = Logs.warn (fun f -> f "%a" Eio.Exn.pp ex)
+
 let () =
   let port = ref 8080 in
   Arg.parse
@@ -53,4 +55,4 @@ let () =
     Eio.Net.listen env#net ~sw ~backlog:128 ~reuse_addr:true
       (`Tcp (Eio.Net.Ipaddr.V4.loopback, !port))
   and server = Cohttp_eio.Server.make ~callback:handler () in
-  Cohttp_eio.Server.run socket server ~on_error:raise
+  Cohttp_eio.Server.run socket server ~on_error:log_warning

--- a/dune-project
+++ b/dune-project
@@ -375,7 +375,8 @@
    (>= 0.12))
   (eio_main :with-test)
   (mdx :with-test)
-  (uri :with-test)
+  logs
+  uri
   (tls-eio (and :with-test (>= 0.17.2)))
   (mirage-crypto-rng-eio (and :with-test (>= 0.11.2)))
   fmt


### PR DESCRIPTION
The example was using `~on_error:raise`, which causes the server to crash if any error occurs handling a connection. This is unlikely to be what you want. Instead, log the error and continue.

This also now matches the behaviour of the Lwt example, which just logs errors and continues.

(from https://github.com/mirage/ocaml-cohttp/pull/1021#issuecomment-1934203471)