### PR TITLE
cohttp-{lwt,eio}: server: return connection header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- cohttp-{lwt,eio}: server: return connection header (ushitora-anqou #1025)
 - cohttp-eio: Improve error handling in example server (talex5 #1023)
 - cohttp-eio: Don't blow up `Server.callback` on client disconnections. (mefyl #1015)
 - http: Fix assertion in `Source.to_string_trim` when `pos <> 0` (mefyl #1017)

--- a/cohttp-eio/tests/test.ml
+++ b/cohttp-eio/tests/test.ml
@@ -44,7 +44,8 @@ let () =
         [ Cstruct.of_string "GET / HTTP/1.1\r\nconnection: close\r\n\r\n" ]
     in
     Alcotest.(check ~here:[%here] string)
-      "response" "HTTP/1.1 200 OK\r\ncontent-length: 4\r\n\r\nroot"
+      "response"
+      "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 4\r\n\r\nroot"
       Eio.Buf_read.(of_flow ~max_size:max_int socket |> take_all)
   and missing socket =
     let () =
@@ -54,7 +55,8 @@ let () =
         ]
     in
     Alcotest.(check ~here:[%here] string)
-      "response" "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\n\r\n"
+      "response"
+      "HTTP/1.1 404 Not Found\r\nconnection: close\r\ncontent-length: 0\r\n\r\n"
       Eio.Buf_read.(of_flow ~max_size:max_int socket |> take_all)
   and streaming_response socket =
     let () =
@@ -66,6 +68,7 @@ let () =
     Alcotest.(check ~here:[%here] string)
       "response"
       "HTTP/1.1 200 OK\r\n\
+       connection: close\r\n\
        transfer-encoding: chunked\r\n\
        \r\n\
        5\r\n\
@@ -90,6 +93,7 @@ let () =
     Alcotest.(check ~here:[%here] string)
       "response"
       "HTTP/1.1 200 OK\r\n\
+       connection: close\r\n\
        transfer-encoding: chunked\r\n\
        \r\n\
        c\r\n\

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -146,6 +146,15 @@ module Make (IO : S.IO) = struct
             let keep_alive =
               Http.Request.is_keep_alive req && Http.Response.is_keep_alive res
             in
+            let res =
+              let headers =
+                Http.Header.add_unless_exists
+                  (Http.Response.headers res)
+                  "connection"
+                  (if keep_alive then "keep-alive" else "close")
+              in
+              { res with Http.Response.headers }
+            in
             handle_response ~keep_alive oc res body
               (fun () -> spec.conn_closed conn)
               (fun oc -> handle_client ic oc conn spec)


### PR DESCRIPTION
ocaml-async returns a `connection` HTTP header if one doesn't exist in the response ([here](https://github.com/mirage/ocaml-cohttp/blob/cf2ae3344ed9211230a5680f251613326eacb296/cohttp-async/src/server.ml#L90-L95)), but cohttp-lwt and cohttp-eio do not.

This PR solves the above issue.