### PR TITLE
Curl no longer prepends the first HTTP request header to the output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- cohttp-curl: Curl no longer prepends the first HTTP request header to the output. (jonahbeckford #1030, #987)
 - cohttp-eio: client: use permissive argument type for make_generic
 - cohttp-eio: Improve error handling in example server (talex5 #1023)
 - cohttp-eio: Don't blow up `Server.callback` on client disconnections. (mefyl #1015)

--- a/cohttp-curl/src/cohttp_curl.ml
+++ b/cohttp-curl/src/cohttp_curl.ml
@@ -53,13 +53,13 @@ module Request = struct
     let response_header_acc = ref [] in
     let response_body = ref None in
     let h = Curl.init () in
-    let buf = Buffer.create 128 in
     Curl.setopt h (CURLOPT_URL uri);
     Curl.setopt h (CURLOPT_CUSTOMREQUEST (Http.Method.to_string method_));
     let () =
       match headers with
       | None -> ()
       | Some headers ->
+          let buf = Buffer.create 128 in
           let headers =
             Http.Header.fold
               (fun key value acc ->
@@ -120,6 +120,7 @@ module Request = struct
          (match output with
          | Discard -> fun s -> String.length s
          | String ->
+             let buf = Buffer.create 128 in
              response_body := Some buf;
              fun s ->
                Buffer.add_string buf s;


### PR DESCRIPTION
fix for #987