### PR TITLE
Fix cohttp EOF read

### DIFF
--- a/cohttp-lwt-unix/test/dune
+++ b/cohttp-lwt-unix/test/dune
@@ -36,6 +36,11 @@
  (name test_body)
  (libraries cohttp_lwt_unix_test cohttp-lwt-unix))
 
+(executable
+ (modules test_leak)
+ (name test_leak)
+ (libraries cohttp-lwt-unix))
+
 (rule
  (alias runtest)
  (package cohttp-lwt-unix)

--- a/cohttp-lwt-unix/test/test_leak.ml
+++ b/cohttp-lwt-unix/test/test_leak.ml
@@ -39,6 +39,7 @@ let start_server () =
       ~mode:(`TCP (`Port port))
       (Server.make
          ~conn_closed:(fun _ -> Format.printf "Cohttp connection closed\n%!")
+         ~sleep_fn:(fun () -> Lwt_unix.sleep 1.0)
          ~callback ())
   in
   Printf.printf "Server running on port %d\n%!" port;

--- a/cohttp-lwt-unix/test/test_leak.ml
+++ b/cohttp-lwt-unix/test/test_leak.ml
@@ -1,0 +1,47 @@
+(*
+  This test is meant to be used in the following way:
+  - `make` the whole repo
+  - `dune exec ./_build/default/cohttp-lwt-unix/test/test_leak.exe`
+  - `curl -s 'localhost:8080/sleep'` in a different console
+  - observe the first console having a stream of "sleep messages"
+  - when stopping (CTRL+C) the `curl` request, the first console
+  should show a closing connection message; if it does, then the
+  test is successful, otherwise (and the server keeps sleeping),
+  the test failed.
+*)
+
+open Lwt
+open Cohttp_lwt_unix
+
+let port = 8080
+
+let callback (_, con) req _body =
+  (* Record connection established *)
+  let con_string = Cohttp.Connection.to_string con in
+  Format.printf "Cohttp connection on %s@." con_string;
+  (* Match given endpoint *)
+  let uri = req |> Request.uri |> Uri.path in
+  match uri with
+  | "/sleep" ->
+      (* Continuous sleep *)
+      let rec get_busy () =
+        Lwt_unix.sleep 1.0 >>= fun () ->
+        Format.printf "I slept @.";
+        get_busy ()
+      in
+      get_busy ()
+  (* Unknown call *)
+  | _ -> Server.respond_string ~status:`Not_found ~body:"Not found" ()
+
+let start_server () =
+  let server =
+    Server.create
+      ~mode:(`TCP (`Port port))
+      (Server.make
+         ~conn_closed:(fun _ -> Format.printf "Cohttp connection closed\n%!")
+         ~callback ())
+  in
+  Printf.printf "Server running on port %d\n%!" port;
+  server
+
+let () = Lwt_main.run (start_server ())

--- a/cohttp-mirage/src/io.ml
+++ b/cohttp-mirage/src/io.ml
@@ -76,4 +76,6 @@ module Make (Channel : Mirage_channel.S) = struct
       | Read_exn e -> Lwt.return_error (Read_error e)
       | Write_exn e -> Lwt.return_error (Write_error e)
       | ex -> Lwt.fail ex)
+
+  let wait_eof_or_closed _conn _ic _sleep_fn = assert false
 end


### PR DESCRIPTION
This work has been done together by the following people:
@savvadia
@vect0r-vicall
@picojulien
@johnyob
@raphael-proust

### Motivation

We have discovered that there is a resource leak for particular cases. Here are two possible scenarios:

- If the `callback` never resolves, `EOF` is never detected, leading to a resource leak.
- If the `callback` is very slow and resource-intensive, `EOF` is not detected until the `callback` resolves. Consequently, client resources are wasted even after the connection has been closed by the peer.

### Solution

A new `wait_eof_or_closed` function is introduced, which repeatedly peeks (using `MSG_PEEK`) into the data stream for an `EOF`, in which case it closes the connection. `MSG_PEEK`  used for this does not disturb reading from the stream by the `handle_client`. If the connection is closed locally before this happens, the function stops waiting for `EOF`. 

If provided to the `wait_eof_or_closed`, the `sleep_fn` argument will be used to dictate the periodicity of the checks for `EOF` from the peer, yielding control periodically. If `sleep_fn`  is not provided, the server keeps its legacy behaviour. 

### PR format

The format of the PR is as follows:
- The first `[WIP]` commit adds a `test_leak.ml` test, which showcases the `EOF` leak; the `[WIP]` tag highlights that this test is not something that we want to be added necessarily, but we would be happy if you find it desirable or helpful and choose to incorporate it
- The second commit fixes the leak showcased in the first commit

### Testing

You can observe the initial leaking behaviour by cherry picking only the first commit:

```
$ g checkout v5-backports

$ g cherry-pick <first_commit>

$ make

$ dune exec ./_build/default/cohttp-lwt-unix/test/test_leak.exe
Server running on port 8080
```

Now, the server is listening, so you can call on a separate console `curl -s 'localhost:8080/sleep'` and observe that the server keeps printing messages of `I slept`. Now, when you close the `curl` request with `CTRL+C`, the server does not stop.

To solve this problem, add the second commit as well, and re-do this test, and after stopping the `curl` request, you will see this:

```
$ dune exec ./_build/default/cohttp-lwt-unix/test/test_leak.exe
Server running on port 8080           
Cohttp connection on 1
I slept 
I slept 
I slept 
I slept 
Cohttp connection closed
```

So, the leak is now fixed.

One can also monitor the resources used by the executable thanks to a tool such as `lsof`:

```
$ lsof -c test_leak.exe | grep localhost
```