### PR TITLE
http: fix compiler warning

### DIFF
--- a/cohttp/src/s.ml
+++ b/cohttp/src/s.ml
@@ -144,8 +144,8 @@ module type Response = sig
   val version : t -> Code.version
   val status : t -> Code.status_code
 
-  val flush :
-    (t -> bool[@deprecated "this field will be removed in the future"])
+  val flush : (t -> bool)
+  [@@deprecated "this field will be removed in the future"]
 
   val compare : t -> t -> int
 

--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -465,10 +465,10 @@ module Response : sig
   val status : t -> Status.t
 
   val flush :
-    (t -> bool
-    [@deprecated
-      "this field will be removed in the future. Provide flush in the \
-       [respond_*] function instead."])
+    (t -> bool)
+  [@@deprecated
+    "this field will be removed in the future. Provide flush in the \
+     [respond_*] function instead."]
 
   val compare : t -> t -> int
 


### PR DESCRIPTION
OCaml 5.2 complains:

    Error (warning 53 [misplaced-attribute]): the "deprecated" attribute cannot appear in this context

I'm not sure I understand what the deprecation message is asking the user to do, but I hope it still makes as much sense as before when attached to the function.

The attribute was added in #831.