### PR TITLE
chore: update CI scripts

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,6 +8,6 @@ on:
 jobs:
   Changelog-Entry-Check:
     name: Check Changelog Action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: tarides/changelog-check-action@v1
+      - uses: tarides/changelog-check-action@v2

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: cachix/install-nix-action@V27
+    - uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' || github.sha }}
-  cancel-in-progress: true      
+  cancel-in-progress: true
 
 jobs:
   build-test-default:
@@ -22,12 +22,16 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ocaml-compiler:
-          - ocaml-variants.4.08.1+afl
-          - ocaml-variants.4.09.1+afl
-          - ocaml-variants.4.10.1+afl
-          - ocaml-variants.4.11.2+afl
+          - ocaml-variants.4.10.2+afl
           - ocaml-variants.4.12.1+options,ocaml-option-afl
           - ocaml-variants.4.13.1+options,ocaml-option-afl
+        include:
+          - os: ubuntu-latest
+            ocaml-compiler: ocaml-variants.4.08.1+afl
+          - os: ubuntu-latest
+            ocaml-compiler: ocaml-variants.4.09.1+afl
+          - os: ubuntu-latest
+            ocaml-compiler: ocaml-variants.4.11.2+afl
         local-packages:
           - |
             *.opam
@@ -40,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
@@ -73,7 +77,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ocaml-compiler:
-          - ocaml-variants.4.14.1+options,ocaml-option-afl
+          - ocaml-variants.4.14.2+options,ocaml-option-afl
         local-packages:
           - |
             *.opam
@@ -83,7 +87,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
@@ -116,7 +120,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ocaml-compiler:
-          - 5.0.x
+          - 5.x
         local-packages:
           - |
             http.opam
@@ -127,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -22,16 +22,8 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ocaml-compiler:
-          - ocaml-variants.4.10.2+afl
-          - ocaml-variants.4.12.1+options,ocaml-option-afl
-          - ocaml-variants.4.13.1+options,ocaml-option-afl
-        include:
-          - os: ubuntu-latest
-            ocaml-compiler: ocaml-variants.4.08.1+afl
-          - os: ubuntu-latest
-            ocaml-compiler: ocaml-variants.4.09.1+afl
-          - os: ubuntu-latest
-            ocaml-compiler: ocaml-variants.4.11.2+afl
+          - ocaml-variants.4.14.2+options,ocaml-option-afl
+          - ocaml-variants.5.02.0+options,ocaml-option-afl
         local-packages:
           - |
             *.opam
@@ -77,6 +69,7 @@ jobs:
           - macos-latest
         ocaml-compiler:
           - ocaml-variants.4.14.2+options,ocaml-option-afl
+          - ocaml-variants.5.02.0+options,ocaml-option-afl
         local-packages:
           - |
             *.opam

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -82,6 +82,7 @@ jobs:
           - |
             *.opam
             !cohttp-eio.opam
+            !cohttp-bench.opam
 
     runs-on: ${{ matrix.os }}
 
@@ -107,9 +108,9 @@ jobs:
       - run: echo "PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig" >>"$GITHUB_ENV"
         if: ${{ matrix.os == 'macos-latest' }}
 
-      - run: opam install --with-test --deps-only http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-async cohttp-curl-async cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
-      - run: opam exec -- dune build http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-async cohttp-curl-async cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
-      - run: opam exec -- dune runtest http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-async cohttp-curl-async cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top cohttp-bench
+      - run: opam install --with-test --deps-only http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-async cohttp-curl-async cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top
+      - run: opam exec -- dune build http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-async cohttp-curl-async cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top
+      - run: opam exec -- dune runtest http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-async cohttp-curl-async cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top
 
   build-test-cohttp-eio:
     if: github.event.pull_request.draft == false
@@ -146,3 +147,36 @@ jobs:
       - run: opam install --with-test --deps-only cohttp-eio
       - run: opam exec -- dune build cohttp-eio
       - run: opam exec -- dune runtest cohttp-eio
+
+  build-test-cohttp-bench:
+    if: github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - 5.x
+        local-packages:
+          - |
+            *.opam
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: ${{ matrix.os == 'ubuntu-latest' }}
+          opam-local-packages: ${{ matrix.local-packages }}
+          opam-repositories: |
+            default: https://github.com/ocaml/opam-repository.git
+            alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
+
+      - run: opam install --with-test --deps-only cohttp-bench
+      - run: opam exec -- dune build cohttp-bench
+      - run: opam exec -- dune runtest cohttp-bench

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -56,8 +56,7 @@ jobs:
           opam-local-packages: ${{ matrix.local-packages }}
 
       - run: |
-          sudo apt update
-          sudo apt upgrade
+          sudo apt-get update && sudo apt-get upgrade
           opam depext conf-libcurl
         if: ${{ matrix.os == 'ubuntu-latest' }}
 
@@ -81,6 +80,12 @@ jobs:
         local-packages:
           - |
             *.opam
+            !cohttp-mirage.opam
+            !cohttp-curl-lwt.opam
+            !cohttp-lwt-jsoo.opam
+            !cohttp-lwt-unix.opam
+            !cohttp-lwt.opam
+            !cohttp-server-lwt-unix.opam
             !cohttp-eio.opam
             !cohttp-bench.opam
 
@@ -100,17 +105,16 @@ jobs:
           opam-local-packages: ${{ matrix.local-packages }}
 
       - run: |
-          sudo apt update
-          sudo apt upgrade
+          sudo apt-get update && sudo apt-get upgrade
           opam depext conf-libcurl
         if: ${{ matrix.os == 'ubuntu-latest' }}
 
       - run: echo "PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig" >>"$GITHUB_ENV"
         if: ${{ matrix.os == 'macos-latest' }}
 
-      - run: opam install --with-test --deps-only http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-async cohttp-curl-async cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top
-      - run: opam exec -- dune build http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-async cohttp-curl-async cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top
-      - run: opam exec -- dune runtest http cohttp cohttp-lwt cohttp-lwt-unix cohttp-server-lwt-unix cohttp-async cohttp-curl-async cohttp-mirage cohttp-curl-lwt cohttp-curl cohttp-top
+      - run: opam install --with-test --deps-only http cohttp cohttp-async cohttp-curl-async cohttp-curl cohttp-top
+      - run: opam exec -- dune build http cohttp cohttp-async cohttp-curl-async cohttp-curl cohttp-top
+      - run: opam exec -- dune runtest http cohttp cohttp-async cohttp-curl-async cohttp-curl cohttp-top
 
   build-test-cohttp-eio:
     if: github.event.pull_request.draft == false

--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -41,7 +41,7 @@ depends: [
   "fmt" {>= "0.8.2"}
   "sexplib0"
   "ppx_sexp_conv" {>= "v0.13.0"}
-  "ounit" {with-test}
+  "ounit2" {with-test}
   "uri" {>= "2.0.0"}
   "uri-sexp"
   "ipaddr"

--- a/cohttp-async/test/dune
+++ b/cohttp-async/test/dune
@@ -6,7 +6,7 @@
   base
   core
   async_kernel
-  oUnit
+  ounit2
   cohttp-async))
 
 (rule

--- a/cohttp-curl-async.opam
+++ b/cohttp-curl-async.opam
@@ -32,7 +32,7 @@ depends: [
   "cohttp-async" {with-test & = version}
   "uri" {with-test & >= "4.2.0"}
   "fmt" {with-test}
-  "ounit" {with-test}
+  "ounit2" {with-test}
   "alcotest" {with-test & >= "1.7.0"}
   "odoc" {with-doc}
 ]

--- a/cohttp-curl-async.opam
+++ b/cohttp-curl-async.opam
@@ -33,7 +33,7 @@ depends: [
   "uri" {with-test & >= "4.2.0"}
   "fmt" {with-test}
   "ounit" {with-test}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "1.7.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"

--- a/cohttp-curl-async.opam
+++ b/cohttp-curl-async.opam
@@ -27,8 +27,9 @@ depends: [
   "cohttp-curl" {= version}
   "core" {>= "v0.16.0"}
   "core_unix" {>= "v0.14.0"}
-  "async_kernel"
-  "async_unix"
+  "core_kernel" {with-test}
+  "async_kernel" {with-test & >= "v0.17.0"}
+  "async_unix" {with-test}
   "cohttp-async" {with-test & = version}
   "uri" {with-test & >= "4.2.0"}
   "fmt" {with-test}

--- a/cohttp-curl-lwt.opam
+++ b/cohttp-curl-lwt.opam
@@ -28,7 +28,7 @@ depends: [
   "stringext"
   "lwt" {>= "5.3.0"}
   "uri" {with-test & >= "4.2.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "1.7.0"}
   "cohttp-lwt-unix" {with-test & = version}
   "cohttp" {with-test & = version}
   "cohttp-lwt" {with-test & = version}

--- a/cohttp-curl-lwt.opam
+++ b/cohttp-curl-lwt.opam
@@ -33,7 +33,7 @@ depends: [
   "cohttp" {with-test & = version}
   "cohttp-lwt" {with-test & = version}
   "conduit-lwt" {with-test}
-  "ounit" {with-test}
+  "ounit2" {with-test}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"

--- a/cohttp-eio.opam
+++ b/cohttp-eio.opam
@@ -20,7 +20,7 @@ doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "dune" {>= "3.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "1.7.0"}
   "base-domains"
   "cohttp" {= version}
   "eio" {>= "0.12"}

--- a/cohttp-lwt-unix.opam
+++ b/cohttp-lwt-unix.opam
@@ -41,7 +41,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.13.0"}
   "magic-mime"
   "logs"
-  "ounit" {with-test}
+  "ounit2" {with-test}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"

--- a/cohttp-lwt-unix/test/cohttp_lwt_unix_test/src/dune
+++ b/cohttp-lwt-unix/test/cohttp_lwt_unix_test/src/dune
@@ -1,3 +1,3 @@
 (library
  (name cohttp_lwt_unix_test)
- (libraries conduit-lwt cohttp-lwt-unix cohttp_test oUnit))
+ (libraries conduit-lwt cohttp-lwt-unix cohttp_test ounit2))

--- a/cohttp-lwt-unix/test/dune
+++ b/cohttp-lwt-unix/test/dune
@@ -1,7 +1,7 @@
 (executable
  (name test_parser)
  (modules test_parser)
- (libraries cohttp-lwt-unix oUnit lwt.unix))
+ (libraries cohttp-lwt-unix ounit2 lwt.unix))
 
 (rule
  (alias runtest)

--- a/cohttp-lwt-unix/test/test_parser.ml
+++ b/cohttp-lwt-unix/test/test_parser.ml
@@ -349,7 +349,7 @@ let test_cases =
   List.map (fun (n, x) -> n >:: fun () -> Lwt_main.run (x ())) tests
 
 (* Returns true if the result list contains successes only.
-   Copied from oUnit source as it isnt exposed by the mli *)
+   Copied from ounit2 source as it isnt exposed by the mli *)
 let rec was_successful = function
   | [] -> true
   | RSuccess _ :: t | RSkip _ :: t -> was_successful t

--- a/cohttp.opam
+++ b/cohttp.opam
@@ -46,7 +46,7 @@ depends: [
   "stringext"
   "base64" {>= "3.1.0"}
   "fmt" {with-test}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "1.7.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"

--- a/dune-project
+++ b/dune-project
@@ -322,8 +322,9 @@
    (>= v0.16.0))
   (core_unix
    (>= v0.14.0))
-  async_kernel
-  async_unix
+  (core_kernel :with-test)
+  (async_kernel (and :with-test (>= v0.17.0)))
+  (async_unix :with-test)
   (cohttp-async
    (and
     :with-test

--- a/dune-project
+++ b/dune-project
@@ -50,7 +50,7 @@
   (base64
    (>= 3.1.0))
   (fmt :with-test)
-  (alcotest :with-test)))
+  (alcotest (and :with-test (>= 1.7.0)))))
 
 (package
  (name cohttp-top)
@@ -245,7 +245,7 @@
   (ocaml
    (>= 4.08))
   (ppx_expect (and :with-test (>= v0.17.0)))
-  (alcotest :with-test)
+  (alcotest (and :with-test (>= 1.7.0)))
   (base_quickcheck :with-test)
   (ppx_assert :with-test)
   (ppx_sexp_conv :with-test)
@@ -289,7 +289,7 @@
    (and
     :with-test
     (>= 4.2.0)))
-  (alcotest :with-test)
+  (alcotest (and :with-test (>= 1.7.0)))
   (cohttp-lwt-unix
    (and
     :with-test
@@ -334,7 +334,7 @@
     (>= 4.2.0)))
   (fmt :with-test)
   (ounit :with-test)
-  (alcotest :with-test)))
+  (alcotest (and :with-test (>= 1.7.0)))))
 
 (package
  (name cohttp-bench)
@@ -367,7 +367,7 @@
  (description
   "A CoHTTP server and client implementation based on `eio` library. `cohttp-eio`features a multicore capable HTTP 1.1 server. The library promotes and is built with direct style of coding as opposed to a monadic.")
  (depends
-  (alcotest :with-test)
+  (alcotest (and :with-test (>= 1.7.0)))
   base-domains
   (cohttp
    (= :version))

--- a/dune-project
+++ b/dune-project
@@ -113,7 +113,7 @@
    (>= v0.13.0))
   magic-mime
   logs
-  (ounit :with-test)))
+  (ounit2 :with-test)))
 
 (package
  (name cohttp-server-lwt-unix)
@@ -197,7 +197,7 @@
   sexplib0
   (ppx_sexp_conv
    (>= v0.13.0))
-  (ounit :with-test)
+  (ounit2 :with-test)
   (uri
    (>= 2.0.0))
   uri-sexp
@@ -303,7 +303,7 @@
     :with-test
     (= :version)))
   (conduit-lwt :with-test)
-  (ounit :with-test)))
+  (ounit2 :with-test)))
 
 (package
  (name cohttp-curl-async)
@@ -333,7 +333,7 @@
     :with-test
     (>= 4.2.0)))
   (fmt :with-test)
-  (ounit :with-test)
+  (ounit2 :with-test)
   (alcotest (and :with-test (>= 1.7.0)))))
 
 (package

--- a/flake.nix
+++ b/flake.nix
@@ -56,12 +56,12 @@
           };
           cohttp-curl-lwt = pkg {
             pname = "cohttp-curl-lwt";
-            checkInputs = [ cohttp-lwt-unix cohttp cohttp-lwt conduit-lwt ounit uri ];
+            checkInputs = [ cohttp-lwt-unix cohttp cohttp-lwt conduit-lwt ounit2 uri ];
             propagatedBuildInputs = [ ocurl http stringext lwt ];
           };
           cohttp-curl-async = pkg {
             pname = "cohttp-curl-async";
-            checkInputs = [ uri fmt ounit alcotest cohttp-async ];
+            checkInputs = [ uri fmt ounit2 alcotest cohttp-async ];
             propagatedBuildInputs = [
               ocurl http stringext cohttp-curl core core_unix
               async_kernel async_unix 
@@ -80,7 +80,7 @@
           };
           cohttp-async = pkg {
             pname = "cohttp-async";
-            checkInputs = [ mirage-crypto ounit ];
+            checkInputs = [ mirage-crypto ounit2 ];
             propagatedBuildInputs = [ http cohttp async_kernel async_unix async base
               core core_unix conduit-async magic-mime logs fmt sexplib0 ppx_sexp_conv
               uri uri-sexp ipaddr
@@ -88,7 +88,7 @@
           };
           cohttp-lwt-unix = pkg {
             pname = "cohttp-lwt-unix";
-            checkInputs = [ ounit ];
+            checkInputs = [ ounit2 ];
             propagatedBuildInputs = [
               http cohttp cohttp-lwt cmdliner lwt conduit-lwt
               conduit-lwt-unix fmt ppx_sexp_conv magic-mime logs

--- a/http.opam
+++ b/http.opam
@@ -24,7 +24,7 @@ depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08"}
   "ppx_expect" {with-test & >= "v0.17.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "1.7.0"}
   "base_quickcheck" {with-test}
   "ppx_assert" {with-test}
   "ppx_sexp_conv" {with-test}

--- a/test_helpers/cohttp_test/src/dune
+++ b/test_helpers/cohttp_test/src/dune
@@ -1,3 +1,3 @@
 (library
  (name cohttp_test)
- (libraries cohttp oUnit))
+ (libraries cohttp ounit2))


### PR DESCRIPTION
This PR updates the GitHub Actions scripts for internal dependencies, updates cohttp test dependencies lower bounds, applies ocamlformat, then splits jobs between "default" (lwt and mirage), "async", "eio", and "bench" groups, to avoid conflicts. Finally, only 4.14 and 5.2 remain in testing with afl.

The CI doesn't pass yet because it's awaiting fixes for deprecation warnings from #1040, and the Ubuntu Snap Store seems currently down. 