### PR TITLE
Fix deprecation warnings

### DIFF
--- a/cohttp-async/src/client.ml
+++ b/cohttp-async/src/client.ml
@@ -109,7 +109,7 @@ module Connection = struct
           req oc
         >>= fun () ->
         read_response ic >>= fun (resp, body) ->
-        Ivar.fill res (resp, `Pipe body);
+        Ivar.fill_exn res (resp, `Pipe body);
         (* block starting any more requests until the consumer has finished reading this request *)
         Pipe.closed body)
     |> don't_wait_for;

--- a/cohttp-async/src/server.ml
+++ b/cohttp-async/src/server.ml
@@ -85,7 +85,6 @@ let handle_client handle_request sock rd wr =
                     Http.Request.is_keep_alive req
                     && Http.Response.is_keep_alive res
                   in
-                  let flush = Http.Response.flush res in
                   let res =
                     let headers =
                       Http.Header.add_unless_exists
@@ -95,7 +94,7 @@ let handle_client handle_request sock rd wr =
                     in
                     { res with Http.Response.headers }
                   in
-                  Io.Response.write ~flush
+                  Io.Response.write
                     (Body.Private.write_body Io.Response.write_body res_body)
                     res wr
                   >>= fun () ->

--- a/cohttp-curl-async/src/cohttp_curl_async.ml
+++ b/cohttp-curl-async/src/cohttp_curl_async.ml
@@ -40,7 +40,7 @@ module Context = struct
           | None -> ()
           | Some w ->
               Hashtbl.remove t.wakeners h;
-              Ivar.fill w code);
+              Ivar.fill_exn w code);
           finished s
     in
     let on_readable fd =
@@ -102,7 +102,7 @@ module Context = struct
         | Some _, true -> ()
         | None, true -> set_event (Some (create_event fd what))
         | Some ivar, false ->
-            Ivar.fill ivar ();
+            Ivar.fill_exn ivar ();
             set_event None
       in
       update current.fd
@@ -168,7 +168,8 @@ module Request = struct
           timeout
       in
       Cohttp_curl.Request.create ?timeout_ms ?headers method_ ~uri ~input
-        ~output ~on_response:(Ivar.fill response_ready)
+        ~output
+        ~on_response:(Ivar.fill_exn response_ready)
     in
     { base; response_ready = Ivar.read response_ready; body_ready }
 end

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -116,8 +116,7 @@ module Make (IO : S.IO) = struct
 
   let handle_response ~keep_alive oc res body conn_closed handle_client =
     IO.catch (fun () ->
-        let flush = Response.flush res in
-        Response.write ~flush
+        Response.write
           (fun writer -> Body.write_body (Response.write_body writer) body)
           res oc)
     >>= function

--- a/http/test/bytebuffer/dune
+++ b/http/test/bytebuffer/dune
@@ -1,14 +1,6 @@
 (library
  (name bytebuffer_tests)
- (libraries
-  http_bytebuffer
-  ;; This is because of the (implicit_transitive_deps false)
-  ;; in dune-project
-  ppx_expect.config
-  ppx_expect.config_types
-  ppx_expect
-  base
-  ppx_inline_test.config)
+ (libraries http_bytebuffer)
  (inline_tests)
  (preprocess
   (pps ppx_expect)))


### PR DESCRIPTION
This PR fixes deprecation warnings, and the error that `ppx_expect.common` isn't found. As we're not using dune's explicit transitive deps feature (anymore?), they can be deleted from the dune file too.