### PR TITLE
fix(curl): proper error handling

### DIFF
--- a/cohttp-curl-async/src/cohttp_curl_async.mli
+++ b/cohttp-curl-async/src/cohttp_curl_async.mli
@@ -27,6 +27,13 @@ module Context : sig
   val create : unit -> t
 end
 
+module Error : sig
+  type t
+
+  val message : t -> string
+  val is_timeout : t -> bool
+end
+
 module Response : sig
   (** Response for the http requests *)
 
@@ -34,8 +41,10 @@ module Response : sig
   (** ['a t] represents a response for a request. ['a] determines how the
       response body is handled *)
 
-  val response : _ t -> Http.Response.t Async_kernel.Deferred.t
-  val body : 'a t -> 'a Async_kernel.Deferred.t
+  val response :
+    _ t -> (Http.Response.t, Error.t) result Async_kernel.Deferred.t
+
+  val body : 'a t -> ('a, Error.t) result Async_kernel.Deferred.t
   val cancel : _ t -> unit
 
   module Expert : sig

--- a/cohttp-curl-async/test/cohttp_curl_async_tests.ml
+++ b/cohttp-curl-async/test/cohttp_curl_async_tests.ml
@@ -1,6 +1,7 @@
 module Server = Cohttp_async.Server
 module Body = Cohttp_async.Body
 module Deferred = Async_kernel.Deferred
+open Async_kernel
 
 let ( let+ ) x f = Deferred.map x ~f
 let ( let* ) x f = Deferred.bind x ~f
@@ -26,7 +27,11 @@ let test =
               Cohttp_curl_async.Request.create `GET ~uri ~input ~output
             in
             let resp = Cohttp_curl_async.submit ctx req in
-            let+ body = Cohttp_curl_async.Response.body resp in
+            let+ body =
+              Cohttp_curl_async.Response.body resp >>| function
+              | Ok s -> s
+              | Error _ -> assert false
+            in
             Alcotest.check Alcotest.string "test 1" body "hello curl" );
       ])
 

--- a/cohttp-curl-lwt/bin/curl.ml
+++ b/cohttp-curl-lwt/bin/curl.ml
@@ -23,6 +23,14 @@ let client uri ofile meth' =
   let* resp, response_body =
     Lwt.both (Curl.Response.response reply) (Curl.Response.body reply)
   in
+  let resp, response_body =
+    match (resp, response_body) with
+    | Ok _, Error _ | Error _, Ok _ -> assert false
+    | Ok x, Ok y -> (x, y)
+    | Error _, Error e ->
+        Format.eprintf "error: %s@.%!" (Curl.Error.message e);
+        exit 1
+  in
   Format.eprintf "response:%a@.%!" Sexp.pp_hum (Response.sexp_of_t resp);
   let status = Response.status resp in
   Log.debug (fun d ->

--- a/cohttp-curl-lwt/src/cohttp_curl_lwt.mli
+++ b/cohttp-curl-lwt/src/cohttp_curl_lwt.mli
@@ -27,6 +27,13 @@ module Context : sig
   val create : unit -> t
 end
 
+module Error : sig
+  type t
+
+  val message : t -> string
+  val is_timeout : t -> bool
+end
+
 module Response : sig
   (** Response for the http requests *)
 
@@ -34,8 +41,8 @@ module Response : sig
   (** ['a t] represents a response for a request. ['a] determines how the
       response body is handled *)
 
-  val response : _ t -> Http.Response.t Lwt.t
-  val body : 'a t -> 'a Lwt.t
+  val response : _ t -> (Http.Response.t, Error.t) result Lwt.t
+  val body : 'a t -> ('a, Error.t) result Lwt.t
 
   module Expert : sig
     val curl : _ t -> Curl.t

--- a/cohttp-curl-lwt/test/cohttp_curl_lwt_tests.ml
+++ b/cohttp-curl-lwt/test/cohttp_curl_lwt_tests.ml
@@ -1,6 +1,7 @@
 module Server = Cohttp_lwt_unix.Server
 module Body = Cohttp_lwt.Body
 open Lwt.Syntax
+open Lwt.Infix
 
 let server =
   List.map Cohttp_lwt_unix_test.const
@@ -9,6 +10,12 @@ let server =
        Server.respond ~status:`OK ~body ());
     ]
   |> Cohttp_lwt_unix_test.response_sequence
+
+let check_error = function Ok _ -> failwith "expected error" | Error _ -> ()
+
+let without_error = function
+  | Ok s -> s
+  | Error e -> failwith (Cohttp_curl_lwt.Error.message e)
 
 let test =
   Cohttp_lwt_unix_test.test_server_s ~port:25_190 server (fun uri ->
@@ -21,8 +28,20 @@ let test =
             let ctx = Cohttp_curl_lwt.Context.create () in
             let req = Cohttp_curl_lwt.Request.create `GET ~uri ~input ~output in
             let resp = Cohttp_curl_lwt.submit ctx req in
-            let+ body = Cohttp_curl_lwt.Response.body resp in
+            let+ body = Cohttp_curl_lwt.Response.body resp >|= without_error in
             Alcotest.check Alcotest.string "test 1" body "hello curl" );
+        ( "failing request",
+          fun () ->
+            let uri = "0.0.0.0:45_120" in
+            let input = Cohttp_curl_lwt.Source.empty in
+            let output = Cohttp_curl_lwt.Sink.string in
+            let ctx = Cohttp_curl_lwt.Context.create () in
+            let req = Cohttp_curl_lwt.Request.create `GET ~uri ~input ~output in
+            let resp = Cohttp_curl_lwt.submit ctx req in
+            let* http_resp = Cohttp_curl_lwt.Response.response resp in
+            check_error http_resp;
+            let+ body = Cohttp_curl_lwt.Response.body resp in
+            check_error body );
       ])
 
 let _ = test |> Cohttp_lwt_unix_test.run_async_tests |> Lwt_main.run

--- a/cohttp-curl/src/cohttp_curl.ml
+++ b/cohttp-curl/src/cohttp_curl.ml
@@ -5,6 +5,17 @@ module Sink = struct
   let discard = Discard
 end
 
+module Error = struct
+  type t = Curl.curlCode
+
+  let create x = x
+
+  let is_timeout (t : t) =
+    match t with Curl.CURLE_OPERATION_TIMEOUTED -> true | _ -> false
+
+  let message t = Curl.strerror t
+end
+
 module Source = struct
   type t = Empty | String of string
 
@@ -132,6 +143,7 @@ module Request = struct
 end
 
 module Private = struct
+  module Error = Error
   module Sink = Sink
   module Source = Source
   module Request = Request

--- a/cohttp-curl/src/cohttp_curl.mli
+++ b/cohttp-curl/src/cohttp_curl.mli
@@ -1,4 +1,12 @@
 module Private : sig
+  module Error : sig
+    type t
+
+    val create : Curl.curlCode -> t
+    val message : t -> string
+    val is_timeout : t -> bool
+  end
+
   module Sink : sig
     type 'a t
 


### PR DESCRIPTION
* Use a result type for responses and bodies. This makes it easier to use the API correctly.

* Properly handle errors. Wake up the response lwt/defererd when we get a code on errors.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>