### PR TITLE
refactor: make [flush] non optional in private API

### DIFF
--- a/cohttp-async/src/client.ml
+++ b/cohttp-async/src/client.ml
@@ -60,7 +60,7 @@ let request ?interrupt ?ssl_config ?uri ?(body = `Empty) req =
   let uri = match uri with Some t -> t | None -> Cohttp.Request.uri req in
   Net.connect_uri ?interrupt ?ssl_config uri >>= fun (ic, oc) ->
   try_with (fun () ->
-      Io.Request.write
+      Io.Request.write ~flush:false
         (fun writer ->
           Body.Private.write_body Io.Request.write_body body writer)
         req oc
@@ -103,7 +103,7 @@ module Connection = struct
   let request ?(body = Body.empty) t req =
     let res = Ivar.create () in
     Throttle.enqueue t (fun { ic; oc } ->
-        Io.Request.write
+        Io.Request.write ~flush:false
           (fun writer ->
             Body.Private.write_body Io.Request.write_body body writer)
           req oc

--- a/cohttp-async/src/server.ml
+++ b/cohttp-async/src/server.ml
@@ -94,7 +94,7 @@ let handle_client handle_request sock rd wr =
                     in
                     { res with Http.Response.headers }
                   in
-                  Io.Response.write
+                  Io.Response.write ~flush:false
                     (Body.Private.write_body Io.Response.write_body res_body)
                     res wr
                   >>= fun () ->

--- a/cohttp-eio/src/client.ml
+++ b/cohttp-eio/src/client.ml
@@ -38,7 +38,7 @@ include
         Eio.Buf_write.with_flow socket @@ fun output ->
         let () =
           Eio.Fiber.fork ~sw @@ fun () ->
-          Io.Request.write
+          Io.Request.write ~flush:false
             (fun writer ->
               match body with
               | None -> ()

--- a/cohttp-eio/src/server.ml
+++ b/cohttp-eio/src/server.ml
@@ -79,7 +79,7 @@ let write output (response : Cohttp.Response.t) body =
   in
   let () = Logs.debug (fun m -> m "send headers") in
   let () =
-    Io.Response.write
+    Io.Response.write ~flush:false
       (fun writer ->
         let () =
           Logs.debug (fun m ->

--- a/cohttp-lwt-unix/test/test_parser.ml
+++ b/cohttp-lwt-unix/test/test_parser.ml
@@ -254,7 +254,7 @@ let write_req expected req =
   let buf = Lwt_bytes.create 4096 in
   let oc = oc_of_buffer buf in
   let body = Cohttp_lwt.Body.of_string "foobar" in
-  Req_io.write
+  Req_io.write ~flush:false
     (fun writer -> Cohttp_lwt.Body.write_body (Req_io.write_body writer) body)
     req oc
   >>= fun () ->
@@ -263,7 +263,9 @@ let write_req expected req =
    * by re-using it *)
   let buf = Lwt_bytes.create 4096 in
   let oc = oc_of_buffer buf in
-  Req_io.write (fun writer -> Req_io.write_body writer "foobar") req oc
+  Req_io.write ~flush:false
+    (fun writer -> Req_io.write_body writer "foobar")
+    req oc
   >|= fun () -> assert_equal expected (get_substring oc buf)
 
 let make_simple_req () =
@@ -315,7 +317,7 @@ let make_simple_res () =
   let oc = oc_of_buffer buf in
   let res = Response.make ~headers:(Header.of_list [ ("foo", "bar") ]) () in
   let body = Cohttp_lwt.Body.of_string "foobar" in
-  Rep_io.write
+  Rep_io.write ~flush:false
     (fun writer -> Cohttp_lwt.Body.write_body (Rep_io.write_body writer) body)
     res oc
   >>= fun () ->
@@ -324,7 +326,9 @@ let make_simple_res () =
    * by re-using it *)
   let buf = Lwt_bytes.create 4096 in
   let oc = oc_of_buffer buf in
-  Rep_io.write (fun writer -> Rep_io.write_body writer "foobar") res oc
+  Rep_io.write ~flush:false
+    (fun writer -> Rep_io.write_body writer "foobar")
+    res oc
   >>= fun () ->
   assert_equal expected (get_substring oc buf);
   return ()

--- a/cohttp-lwt/src/connection.ml
+++ b/cohttp-lwt/src/connection.ml
@@ -229,7 +229,7 @@ module Make (Net : S.Net) : S.Connection with module Net = Net = struct
         Lwt.catch
           (fun () ->
             (* try *)
-            Request.write
+            Request.write ~flush:false
               (fun writer -> Body.write_body (Request.write_body writer) body)
               req oc)
           (fun e ->

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -116,7 +116,7 @@ module Make (IO : S.IO) = struct
 
   let handle_response ~keep_alive oc res body conn_closed handle_client =
     IO.catch (fun () ->
-        Response.write
+        Response.write ~flush:false
           (fun writer -> Body.write_body (Response.write_body writer) body)
           res oc)
     >>= function

--- a/cohttp/src/request.ml
+++ b/cohttp/src/request.ml
@@ -205,8 +205,8 @@ module Make (IO : S.IO) = struct
     in
     IO.write oc fst_line >>= fun _ -> Header_IO.write headers oc
 
-  let make_body_writer ?flush req oc =
-    Transfer_IO.make_writer ?flush req.encoding oc
+  let make_body_writer ~flush req oc =
+    Transfer_IO.make_writer ~flush req.encoding oc
 
   let write_body = Transfer_IO.write
 
@@ -217,9 +217,9 @@ module Make (IO : S.IO) = struct
         IO.write oc "0\r\n\r\n"
     | Transfer.Fixed _ | Transfer.Unknown -> return ()
 
-  let write ?flush write_body req oc =
+  let write ~flush write_body req oc =
     write_header req oc >>= fun () ->
-    let writer = make_body_writer ?flush req oc in
+    let writer = make_body_writer ~flush req oc in
     write_body writer >>= fun () -> write_footer req oc
 end
 

--- a/cohttp/src/response.ml
+++ b/cohttp/src/response.ml
@@ -123,8 +123,8 @@ module Make (IO : S.IO) = struct
     in
     Header_IO.write headers oc
 
-  let make_body_writer ?flush { encoding; _ } oc =
-    Transfer_IO.make_writer ?flush encoding oc
+  let make_body_writer ~flush { encoding; _ } oc =
+    Transfer_IO.make_writer ~flush encoding oc
 
   let write_body = Transfer_IO.write
 
@@ -135,9 +135,9 @@ module Make (IO : S.IO) = struct
         IO.write oc "0\r\n\r\n"
     | Transfer.Fixed _ | Transfer.Unknown -> return ()
 
-  let write ?flush fn req oc =
+  let write ~flush fn req oc =
     write_header req oc >>= fun () ->
-    let writer = make_body_writer ?flush req oc in
+    let writer = make_body_writer ~flush req oc in
     fn writer >>= fun () -> write_footer req oc
 end
 

--- a/cohttp/src/s.ml
+++ b/cohttp/src/s.ml
@@ -73,12 +73,12 @@ module type Http_io = sig
   module IO : IO
 
   val read : IO.ic -> [ `Eof | `Invalid of string | `Ok of t ] IO.t
-  val make_body_writer : ?flush:bool -> t -> IO.oc -> writer
+  val make_body_writer : flush:bool -> t -> IO.oc -> writer
   val make_body_reader : t -> IO.ic -> reader
   val read_body_chunk : reader -> Transfer.chunk IO.t
   val write_header : t -> IO.oc -> unit IO.t
   val write_body : writer -> string -> unit IO.t
-  val write : ?flush:bool -> (writer -> unit IO.t) -> t -> IO.oc -> unit IO.t
+  val write : flush:bool -> (writer -> unit IO.t) -> t -> IO.oc -> unit IO.t
 end
 
 module type Request = sig

--- a/cohttp/src/transfer_io.ml
+++ b/cohttp/src/transfer_io.ml
@@ -123,7 +123,7 @@ module Make (IO : S.IO) = struct
   let write_ignore_blank writer io s =
     if String.length s = 0 then return () else writer io s
 
-  let make_writer ?(flush = false) mode =
+  let make_writer ~flush mode =
     match flush with
     | false -> (
         match mode with

--- a/cohttp/src/transfer_io.mli
+++ b/cohttp/src/transfer_io.mli
@@ -21,7 +21,7 @@ module Make (IO : S.IO) : sig
   type writer
 
   val make_reader : encoding -> IO.ic -> reader
-  val make_writer : ?flush:bool -> encoding -> IO.oc -> writer
+  val make_writer : flush:bool -> encoding -> IO.oc -> writer
   val read : reader -> chunk IO.t
   val write : writer -> string -> unit IO.t
 end


### PR DESCRIPTION
This change isn't visible to users. It just makes it easier to keep track internally where we explicitly pass [flush]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>