### PR TITLE
feat(cohttp-async): add [close_finished] in [Connection]

### DIFF
--- a/cohttp-async/src/client.ml
+++ b/cohttp-async/src/client.ml
@@ -98,6 +98,7 @@ module Connection = struct
     Throttle.kill t;
     Throttle.cleaned t
 
+  let close_finished t = Throttle.cleaned t
   let is_closed t = Throttle.is_dead t
 
   let request ?(body = Body.empty) t req =

--- a/cohttp-async/src/client.mli
+++ b/cohttp-async/src/client.mli
@@ -37,6 +37,7 @@ module Connection : sig
     t Async_kernel.Deferred.t
 
   val close : t -> unit Async_kernel.Deferred.t
+  val close_finished : t -> unit Async_kernel.Deferred.t
   val is_closed : t -> bool
 
   val request :


### PR DESCRIPTION
This method is useful for [`Persistent_connection`](https://ocaml.org/p/async_kernel/v0.16.0/doc/Persistent_connection_kernel/module-type-Closable/index.html#val-close_finished).

I had to resort to `let close_finished (conn : t) = Throttle.cleaned (Obj.magic conn)`, but if you think it's appropriate to extend the API in v6, this function might be a good addition.