### PR TITLE
fix: remove transfer encoding from request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 - cohttp-eio: Improve error handling in example server (talex5 #1023)
 - cohttp-eio: Don't blow up `Server.callback` on client disconnections. (mefyl #1015)
 - http: Fix assertion in `Source.to_string_trim` when `pos <> 0` (mefyl #1017)
+- cohttp: `Cohttp.Request.make_for_client` no longer allows setting both
+  `~chunked:true` and `~body_length`.
 - cohttp-lwt-unix: Don't blow up when certificates are not available and no-network requests are made. (akuhlens #1027)
   + Makes `cohttp-lwt.S.default_ctx` lazy. 
 

--- a/cohttp/src/s.ml
+++ b/cohttp/src/s.ml
@@ -88,8 +88,6 @@ module type Request = sig
     scheme : string option;  (** URI scheme (http or https) *)
     resource : string;  (** Request path and query *)
     version : Code.version;  (** HTTP version, usually 1.1 *)
-    encoding : Transfer.encoding;
-        [@deprecated "this field will be removed in the future"]
   }
   [@@deriving sexp]
 

--- a/cohttp/test/test_request.ml
+++ b/cohttp/test/test_request.ml
@@ -329,8 +329,7 @@ let useless_null_content_length_header () =
   let output = Buffer.create 1024 in
   let () =
     let r =
-      Cohttp.Request.make_for_client ~chunked:false ~body_length:0L `GET
-        (Uri.of_string "http://someuri.com")
+      Cohttp.Request.make_for_client `GET (Uri.of_string "http://someuri.com")
     in
     Request.write_header r output
   in

--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -388,8 +388,6 @@ module Request : sig
     scheme : string option;  (** URI scheme (http or https) *)
     resource : string;  (** Request path and query *)
     version : Version.t;  (** HTTP version, usually 1.1 *)
-    encoding : Transfer.encoding;
-        [@deprecated "this field will be removed in the future"]
   }
 
   val has_body : t -> [ `No | `Unknown | `Yes ]
@@ -398,7 +396,6 @@ module Request : sig
   val scheme : t -> string option
   val resource : t -> string
   val version : t -> Version.t
-  val encoding : t -> Transfer.encoding
   val compare : t -> t -> int
 
   val is_keep_alive : t -> bool

--- a/http/test/test_parser.ml
+++ b/http/test/test_parser.ml
@@ -37,16 +37,8 @@ let assert_req_success ~here ~expected_req ~expected_consumed ?pos ?len buf =
     (Http.Header.to_list @@ Http.Request.headers req);
   [%test_result: int] ~here ~expect:expected_consumed consumed
 
-let[@warning "-3"] make_req ~headers ?(encoding = Http.Transfer.Fixed 0L) meth
-    resource =
-  {
-    Http.Request.headers;
-    meth;
-    resource;
-    scheme = None;
-    encoding;
-    version = `HTTP_1_1;
-  }
+let[@warning "-3"] make_req ~headers meth resource =
+  { Http.Request.headers; meth; resource; scheme = None; version = `HTTP_1_1 }
 
 let req_expected =
   make_req


### PR DESCRIPTION
it can be set via the header

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>