### PR TITLE
Use connection cache instead of Net.ctx as Client.ctx

### DIFF
--- a/cohttp-lwt-unix/examples/docker_lwt.ml
+++ b/cohttp-lwt-unix/examples/docker_lwt.ml
@@ -6,7 +6,8 @@ let ctx =
     Hashtbl.add h "docker" (`Unix_domain_socket "/var/run/docker.sock");
     Resolver_lwt_unix.static h
   in
-  Cohttp_lwt_unix.Client.custom_ctx ~resolver ()
+  let net_ctx = Cohttp_lwt_unix.Client.custom_ctx ~resolver () in
+  Cohttp_lwt_unix.No_cache.(call (create ~ctx:net_ctx ()))
 
 let t =
   Cohttp_lwt_unix.Client.get ~ctx (Uri.of_string "http://docker/version")

--- a/cohttp-lwt-unix/src/cohttp_lwt_unix.ml
+++ b/cohttp-lwt-unix/src/cohttp_lwt_unix.ml
@@ -30,6 +30,8 @@ module Response = struct
 
 module Connection = Cohttp_lwt.Connection.Make (Net)
 
+module No_cache = Cohttp_lwt.Connection_cache.Make_no_cache (Connection)
+
 module Connection_cache =
   Cohttp_lwt.Connection_cache.Make
     (Connection)
@@ -42,7 +44,7 @@ module Client : sig
   (** The [Client] module implements the full UNIX HTTP client interface,
       including the UNIX-specific functions defined in {!C}. *)
 
-  include Cohttp_lwt.S.Client with type ctx = Net.ctx
+  include Cohttp_lwt.S.Client with type ctx = Cohttp_lwt.S.call
 
   val custom_ctx :
     ?ctx:Conduit_lwt_unix.ctx -> ?resolver:Resolver_lwt.t -> unit -> Net.ctx

--- a/cohttp-lwt-unix/test/test_sanity.ml
+++ b/cohttp-lwt-unix/test/test_sanity.ml
@@ -78,9 +78,8 @@ let check_logs test () =
 
 let ts =
   Cohttp_lwt_unix_test.test_server_s server (fun uri ->
-      let ctx = Lazy.force Cohttp_lwt_unix.Net.default_ctx in
       let t () =
-        Client.get ~ctx uri >>= fun (_, body) ->
+        Client.get uri >>= fun (_, body) ->
         body |> Body.to_string >|= fun body -> assert_equal body message
       in
       let pipelined_chunk () =
@@ -94,7 +93,7 @@ let ts =
           ]
         in
         let counter = ref 0 in
-        Client.callv ~ctx uri (Lwt_stream.of_list reqs) >>= fun resps ->
+        Client.callv uri (Lwt_stream.of_list reqs) >>= fun resps ->
         Lwt_stream.iter_s
           (fun (_, rbody) ->
             rbody |> Body.to_string >|= fun rbody ->
@@ -115,7 +114,7 @@ let ts =
         let reqs, push = Lwt_stream.create () in
         push (Some (r 1));
         push (Some (r 2));
-        Client.callv ~ctx uri reqs >>= fun resps ->
+        Client.callv uri reqs >>= fun resps ->
         let resps = Lwt_stream.map_s (fun (_, b) -> Body.to_string b) resps in
         Lwt_stream.fold
           (fun b i ->
@@ -135,7 +134,7 @@ let ts =
         >|= fun l -> assert_equal l 3
       in
       let massive_chunked () =
-        Client.get ~ctx uri >>= fun (_resp, body) ->
+        Client.get uri >>= fun (_resp, body) ->
         Body.to_string body >|= fun body ->
         assert_equal ~printer:string_of_int (1000 * 64) (String.length body)
       in
@@ -145,19 +144,19 @@ let ts =
         in
         Lwt_stream.fold_s
           (fun uri () ->
-            Client.head ~ctx uri >>= fun resp_head ->
+            Client.head uri >>= fun resp_head ->
             assert_equal (Response.status resp_head) `OK;
-            Client.get ~ctx uri >>= fun (resp_get, body) ->
+            Client.get uri >>= fun (resp_get, body) ->
             assert_equal (Response.status resp_get) `OK;
             Body.drain_body body)
           stream ()
       in
       let expert_pipelined () =
         let printer x = x in
-        Client.get ~ctx uri >>= fun (_rsp, body) ->
+        Client.get uri >>= fun (_rsp, body) ->
         Body.to_string body >>= fun body ->
         assert_equal ~printer "expert 1" body;
-        Client.get ~ctx uri >>= fun (_rsp, body) ->
+        Client.get uri >>= fun (_rsp, body) ->
         Body.to_string body >|= fun body ->
         assert_equal ~printer "expert 2" body
       in

--- a/cohttp-lwt-unix/test/test_sanity_noisy.ml
+++ b/cohttp-lwt-unix/test/test_sanity_noisy.ml
@@ -35,14 +35,13 @@ let server_noisy =
 
 let ts_noisy =
   Cohttp_lwt_unix_test.test_server_s ~port:10193 server_noisy (fun uri ->
-      let ctx = Lazy.force Cohttp_lwt_unix.Net.default_ctx in
       let empty_chunk () =
-        Client.get ~ctx uri >>= fun (_, body) ->
+        Client.get uri >>= fun (_, body) ->
         body |> Body.to_string >|= fun body ->
         assert_equal body (String.concat "" chunk_body)
       in
       let not_modified_has_no_body () =
-        Client.get ~ctx uri >>= fun (resp, body) ->
+        Client.get uri >>= fun (resp, body) ->
         assert_equal (Response.status resp) `Not_modified;
         let headers = Response.headers resp in
         assert_equal ~printer:Transfer.string_of_encoding Transfer.Unknown
@@ -59,7 +58,7 @@ let ts_noisy =
             >>= fun oc ->
             Lwt_io.write_line oc "never read" >>= fun () ->
             Lwt_io.close oc >>= fun () ->
-            ( Client.post ~ctx uri ~body:(Body.of_string fname)
+            ( Client.post uri ~body:(Body.of_string fname)
             >>= fun (resp, body) ->
               assert_equal ~printer:Code.string_of_status (Response.status resp)
                 `Internal_server_error;

--- a/cohttp-lwt/src/client.ml
+++ b/cohttp-lwt/src/client.ml
@@ -6,15 +6,10 @@ module Make (Connection : S.Connection) = struct
   module No_cache = Connection_cache.Make_no_cache (Connection)
   module Request = Make.Request (Net.IO)
 
+  type ctx = S.call
+
   let cache = ref No_cache.(call (create ()))
   let set_cache c = cache := c
-
-  type ctx = Net.ctx
-
-  let cache ?ctx =
-    match ctx with
-    | None -> !cache
-    | Some ctx -> No_cache.(call (create ~ctx ()))
 
   include
     Cohttp.Generic.Client.Make
@@ -25,21 +20,26 @@ module Make (Connection : S.Connection) = struct
 
         let map_context v f ?ctx = f (v ?ctx)
 
-        let call ?ctx ?headers ?body ?chunked meth uri =
+        let call ?(ctx :ctx option) ?headers ?body ?chunked meth uri =
+          let cache =
+            match ctx with
+            | None -> !cache
+            | Some ctx -> ctx
+          in
           let add_transfer =
             Header.add_transfer_encoding
               (Option.value ~default:(Header.init ()) headers)
           in
           match chunked with
-          | None -> cache ?ctx ?headers ?body meth uri
+          | None -> cache ?headers ?body meth uri
           | Some true ->
               let headers = add_transfer Cohttp.Transfer.Chunked in
-              cache ?ctx ~headers ?body meth uri
+              cache ~headers ?body meth uri
           | Some false ->
               Option.value ~default:`Empty body |> Body.length
               >>= fun (length, body) ->
               let headers = add_transfer (Cohttp.Transfer.Fixed length) in
-              cache ?ctx ~headers ~body meth uri
+              cache ~headers ~body meth uri
       end)
       (Connection.Net.IO)
 
@@ -50,22 +50,4 @@ module Make (Connection : S.Connection) = struct
     in
     let body = Body.of_string (Uri.encoded_of_query params) in
     post ?ctx ~chunked:false ~headers ~body uri
-
-  let callv ?(ctx = Lazy.force Net.default_ctx) uri reqs =
-    let mutex = Lwt_mutex.create () in
-    Net.resolve ~ctx uri >>= Connection.connect ~ctx >>= fun connection ->
-    Lwt.return
-    @@ Lwt_stream.from
-    @@ fun () ->
-    Lwt_stream.get reqs >>= function
-    | None ->
-        Connection.close connection |> ignore;
-        Lwt.return_none
-    | Some (req, body) ->
-        Lwt_mutex.with_lock mutex @@ fun () ->
-        let headers, meth, uri, enc =
-          Request.(headers req, meth req, uri req, encoding req)
-        in
-        let headers = Header.add_transfer_encoding headers enc in
-        Connection.call connection ~headers ~body meth uri >|= Option.some
 end

--- a/cohttp-lwt/src/client.mli
+++ b/cohttp-lwt/src/client.mli
@@ -7,4 +7,4 @@
     will be logged and easier to track. *)
 
 module Make (Connection : S.Connection) :
-  S.Client with type ctx = Connection.Net.ctx
+  S.Client with type ctx = S.call

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -211,13 +211,6 @@ module type Client = sig
     params:(string * string list) list ->
     Uri.t ->
     (Http.Response.t * Body.t) Lwt.t
-
-  val callv :
-    ?ctx:ctx ->
-    Uri.t ->
-    (Http.Request.t * Body.t) Lwt_stream.t ->
-    (Http.Response.t * Body.t) Lwt_stream.t Lwt.t
-  (** @deprecated use {!module:Cohttp_lwt.Connection} instead. *)
 end
 
 (** The [Server] module implements a pipelined HTTP/1.1 server. *)


### PR DESCRIPTION
This is a proposal to make the semantics of connection cache and `Net.ctx` in the Cohttp_lwt.Client module clearer.
This change is essentially summarized in `cohttp-lwt/src/client.mli`:
``` diff
 module Make (Connection : S.Connection) :
-  S.Client with type ctx = Connection.Net.ctx
+  S.Client with type ctx = S.call
```
This is just a proof-of-concept on how to fix #1074