### PR TITLE
Raise and reraise exceptions with Stdlib rather than Lwt

### DIFF
--- a/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.ml
+++ b/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.ml
@@ -269,7 +269,7 @@ module Make_client_async (P : Params) = Make_api (struct
         CLB.to_string body >>= fun body ->
         let bs = binary_string body in
         (*Js.Opt.case (File.CoerceTo.blob (Obj.magic blob))
-          (fun () -> Lwt.fail_with "could not coerce to blob")
+          (fun () -> failwith "could not coerce to blob")
           (fun blob -> Lwt.return (xml##(send_blob blob)))*)
         (*Lwt.return (xml##send (Js.Opt.return bs)) *)
         Lwt.return (xml##send (Js.Opt.return (Obj.magic bs))))

--- a/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.ml
+++ b/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.ml
@@ -188,7 +188,7 @@ struct
   (* No implementation (can it be done?).  What should the failure exception be? *)
   exception Cohttp_lwt_xhr_callv_not_implemented
 
-  let callv ?ctx:_ _uri _reqs = Lwt.fail Cohttp_lwt_xhr_callv_not_implemented
+  let callv ?ctx:_ _uri _reqs = raise Cohttp_lwt_xhr_callv_not_implemented
 
   (* ??? *)
 end

--- a/cohttp-lwt-unix/bin/cohttp_server_lwt.ml
+++ b/cohttp-lwt-unix/bin/cohttp_server_lwt.ml
@@ -79,8 +79,8 @@ let serve ~info ~docroot ~index uri path =
             Server.respond_string ~status:`Not_found
               ~body:(html_of_not_found path info)
               ()
-          else Lwt.fail e
-      | e -> Lwt.fail e)
+          else Lwt.reraise e
+      | e -> Lwt.reraise e)
 
 let handler ~info ~docroot ~index (ch, _conn) req _body =
   let uri = Cohttp.Request.uri req in

--- a/cohttp-lwt-unix/examples/client_lwt_timeout.ml
+++ b/cohttp-lwt-unix/examples/client_lwt_timeout.ml
@@ -11,7 +11,7 @@ let compute ~time ~f =
 let body =
   let get () = Client.get (Uri.of_string "https://www.reddit.com/") in
   compute ~time:0.1 ~f:get >>= function
-  | `Timeout -> Lwt.fail_with "Timeout expired"
+  | `Timeout -> failwith "Timeout expired"
   | `Done (resp, body) ->
       let code = resp |> Response.status |> Code.code_of_status in
       Printf.printf "Response code: %d\n" code;

--- a/cohttp-lwt-unix/src/io.ml
+++ b/cohttp-lwt-unix/src/io.ml
@@ -80,6 +80,6 @@ type error = exn
 let catch f =
   Lwt.try_bind f Lwt.return_ok (function
     | IO_error e -> Lwt.return_error e
-    | ex -> Lwt.fail ex)
+    | ex -> Lwt.reraise ex)
 
 let pp_error = Fmt.exn

--- a/cohttp-lwt-unix/src/io.ml
+++ b/cohttp-lwt-unix/src/io.ml
@@ -40,12 +40,12 @@ let wrap_read f ~if_closed =
      https://github.com/ocsigen/lwt/pull/635 *)
   Lwt.catch f (function
     | Lwt_io.Channel_closed _ -> Lwt.return if_closed
-    | Unix.Unix_error _ as e -> Lwt.fail (IO_error e)
+    | Unix.Unix_error _ as e -> raise (IO_error e)
     | exn -> raise exn)
 
 let wrap_write f =
   Lwt.catch f (function
-    | Unix.Unix_error _ as e -> Lwt.fail (IO_error e)
+    | Unix.Unix_error _ as e -> raise (IO_error e)
     | exn -> raise exn)
 
 let read_line ic =

--- a/cohttp-lwt-unix/src/server.ml
+++ b/cohttp-lwt-unix/src/server.ml
@@ -16,8 +16,8 @@ let respond_file ?headers ~fname () =
     (fun () ->
       (* Check this isn't a directory first *)
       ( fname |> Lwt_unix.stat >>= fun s ->
-        if Unix.(s.st_kind <> S_REG) then Lwt.fail Isnt_a_file
-        else Lwt.return_unit )
+        if Unix.(s.st_kind <> S_REG) then raise Isnt_a_file else Lwt.return_unit
+      )
       >>= fun () ->
       let count = 16384 in
       Lwt_io.open_file ~buffer:(Lwt_bytes.create count) ~mode:Lwt_io.input fname

--- a/cohttp-lwt-unix/src/server.ml
+++ b/cohttp-lwt-unix/src/server.ml
@@ -55,7 +55,7 @@ let respond_file ?headers ~fname () =
     (function
       | Unix.Unix_error (Unix.ENOENT, _, _) | Isnt_a_file ->
           respond_not_found ()
-      | exn -> Lwt.fail exn)
+      | exn -> Lwt.reraise exn)
 
 let log_on_exn = function
   | Unix.Unix_error (error, func, arg) ->

--- a/cohttp-lwt-unix/test/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.ml
+++ b/cohttp-lwt-unix/test/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.ml
@@ -36,9 +36,9 @@ let temp_server ?port spec callback =
       (fun () -> Server.create ~backlog:40 ~mode:(`TCP (`Port port)) server)
       (function
         | Lwt.Canceled -> Lwt.return_unit
-        | x ->
-            Lwt.wakeup_exn server_failed_wake x;
-            Lwt.fail x)
+        | exn ->
+            Lwt.wakeup_exn server_failed_wake exn;
+            Lwt.reraise exn)
   in
   Lwt.pick [ Lwt_unix.with_timeout 5.0 (fun () -> callback uri); server_failed ]
   >|= fun res ->

--- a/cohttp-lwt-unix/test/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.ml
+++ b/cohttp-lwt-unix/test/cohttp_lwt_unix_test/src/cohttp_lwt_unix_test.ml
@@ -20,7 +20,7 @@ let expert ?(rsp = Http.Response.make ()) f _req _body =
   return (`Expert (rsp, f))
 
 let const rsp _req _body = rsp >|= response
-let response_sequence = Cohttp_test.response_sequence Lwt.fail_with
+let response_sequence = Cohttp_test.response_sequence failwith
 let () = Debug.activate_debug ()
 let () = Logs.set_level (Some Info)
 

--- a/cohttp-lwt-unix/test/test_client.ml
+++ b/cohttp-lwt-unix/test/test_client.ml
@@ -174,7 +174,7 @@ let test_unknown uri =
             | Some (`Stream _) -> Lwt.fail Connection.Retry
             | None | Some (`Empty | `String _ | `Strings _) ->
                 handler ?headers ?body meth uri)
-        | e -> Lwt.fail e)
+        | e -> Lwt.reraise e)
   in
   tests handler uri
 

--- a/cohttp-lwt-unix/test/test_client.ml
+++ b/cohttp-lwt-unix/test/test_client.ml
@@ -54,7 +54,7 @@ let methods (handler : Cohttp_lwt.S.call) uri =
     Body.drain_body body >>= fun () ->
     match Response.status res with
     | `Created | `No_content | `OK -> Lwt.return_unit
-    | _ -> Lwt.fail_with "put failed"
+    | _ -> failwith "put failed"
   and get k =
     handler `GET Uri.(with_path uri k) >>= fun (res, body) ->
     match Response.status res with

--- a/cohttp-lwt-unix/test/test_client.ml
+++ b/cohttp-lwt-unix/test/test_client.ml
@@ -59,13 +59,13 @@ let methods (handler : Cohttp_lwt.S.call) uri =
     handler `GET Uri.(with_path uri k) >>= fun (res, body) ->
     match Response.status res with
     | `OK | `No_content -> Body.to_string body
-    | _ -> Body.drain_body body >>= fun () -> Lwt.fail Not_found
+    | _ -> Body.drain_body body >>= fun () -> raise Not_found
   and delete k =
     handler `DELETE Uri.(with_path uri k) >>= fun (res, body) ->
     Body.drain_body body >>= fun () ->
     match Response.status res with
     | `OK | `No_content -> Lwt.return_unit
-    | _ -> Lwt.fail Not_found
+    | _ -> raise Not_found
   and mem k =
     handler `HEAD Uri.(with_path uri k) >>= fun (res, body) ->
     Body.drain_body body >|= fun () ->
@@ -171,7 +171,7 @@ let test_unknown uri =
             connection := c;
             match body with
             (* Still, body may have been (partially) consumed and needs re-creation. *)
-            | Some (`Stream _) -> Lwt.fail Connection.Retry
+            | Some (`Stream _) -> raise Connection.Retry
             | None | Some (`Empty | `String _ | `Strings _) ->
                 handler ?headers ?body meth uri)
         | e -> Lwt.reraise e)

--- a/cohttp-lwt/src/connection.ml
+++ b/cohttp-lwt/src/connection.ml
@@ -172,7 +172,7 @@ module Make (Net : S.Net) : S.Connection with module Net = Net = struct
         Queue.push { uri; meth; headers; body; res_r } connection.waiting;
         Lwt_condition.broadcast connection.condition ();
         res
-    | Closing _ | Half _ | Closed | Failed _ -> Lwt.fail Retry
+    | Closing _ | Half _ | Closed | Failed _ -> raise Retry
 
   let rec writer connection =
     match connection.state with

--- a/cohttp-lwt/src/connection_cache.ml
+++ b/cohttp-lwt/src/connection_cache.ml
@@ -161,9 +161,9 @@ end = struct
         (function
           | Retry -> (
               match body with
-              | Some (`Stream _) -> Lwt.fail Retry
+              | Some (`Stream _) -> raise Retry
               | None | Some `Empty | Some (`String _) | Some (`Strings _) ->
-                  if retry <= 0 then Lwt.fail Retry else request (retry - 1))
+                  if retry <= 0 then raise Retry else request (retry - 1))
           | e -> Lwt.reraise e)
     in
     request self.retry

--- a/cohttp-lwt/src/connection_cache.ml
+++ b/cohttp-lwt/src/connection_cache.ml
@@ -164,7 +164,7 @@ end = struct
               | Some (`Stream _) -> Lwt.fail Retry
               | None | Some `Empty | Some (`String _) | Some (`Strings _) ->
                   if retry <= 0 then Lwt.fail Retry else request (retry - 1))
-          | e -> Lwt.fail e)
+          | e -> Lwt.reraise e)
     in
     request self.retry
 end

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -105,7 +105,7 @@ module Make (IO : S.IO) = struct
         Lwt.catch
           (fun () -> callback conn req body)
           (function
-            | Out_of_memory -> Lwt.fail Out_of_memory
+            | Out_of_memory -> Lwt.reraise Out_of_memory
             | exn ->
                 Log.err (fun f ->
                     f "Error handling %a: %s" Request.pp_hum req
@@ -177,5 +177,5 @@ module Make (IO : S.IO) = struct
             Lwt.return_unit)
       (fun e ->
         conn_closed ();
-        Lwt.fail e)
+        Lwt.reraise e)
 end

--- a/cohttp-mirage/src/input_channel.ml
+++ b/cohttp-mirage/src/input_channel.ml
@@ -13,7 +13,7 @@ module Make (Channel : Mirage_channel.S) = struct
         Cstruct.blit_to_bytes v 0 buf pos len;
         Lwt.return (`Ok len)
     | Ok `Eof -> Lwt.return `Eof
-    | Error e -> Lwt.fail (Read_exn e)
+    | Error e -> raise (Read_exn e)
 
   let create ?(buf_len = 0x4000) chan =
     { buf = Bytebuffer.create buf_len; chan }

--- a/cohttp-mirage/src/io.ml
+++ b/cohttp-mirage/src/io.ml
@@ -54,7 +54,7 @@ module Make (Channel : Mirage_channel.S) = struct
     Channel.write_string oc buf 0 (String.length buf);
     Channel.flush oc >>= function
     | Ok () -> Lwt.return_unit
-    | Error `Closed -> Lwt.fail_with "Trying to write on closed channel"
+    | Error `Closed -> failwith "Trying to write on closed channel"
     | Error e -> Lwt.fail (Write_exn e)
 
   let flush _ =

--- a/cohttp-mirage/src/io.ml
+++ b/cohttp-mirage/src/io.ml
@@ -55,7 +55,7 @@ module Make (Channel : Mirage_channel.S) = struct
     Channel.flush oc >>= function
     | Ok () -> Lwt.return_unit
     | Error `Closed -> failwith "Trying to write on closed channel"
-    | Error e -> Lwt.fail (Write_exn e)
+    | Error e -> raise (Write_exn e)
 
   let flush _ =
     (* NOOP since we flush in the normal writer functions above *)

--- a/cohttp-mirage/src/io.ml
+++ b/cohttp-mirage/src/io.ml
@@ -68,5 +68,5 @@ module Make (Channel : Mirage_channel.S) = struct
     Lwt.try_bind f Lwt.return_ok (function
       | Input_channel.Read_exn e -> Lwt.return_error (Read_error e)
       | Write_exn e -> Lwt.return_error (Write_error e)
-      | ex -> Lwt.fail ex)
+      | ex -> Lwt.reraise ex)
 end

--- a/cohttp-mirage/src/static.ml
+++ b/cohttp-mirage/src/static.ml
@@ -24,7 +24,7 @@ module HTTP (FS : Mirage_kv.RO) (S : Cohttp_lwt.S.Server) = struct
   open Lwt.Infix
   open Astring
 
-  let failf fmt = Fmt.kstr Lwt.fail_with fmt
+  let failf fmt = Fmt.failwith fmt
 
   let read_fs t name =
     FS.get t (Key.v name) >>= function


### PR DESCRIPTION
Lwt's documentation reads:

> In most cases, it is better to use `failwith s` from the standard
> library.

and

> Whenever possible, it is recommended to use `raise exn` instead, as
> raise captures a backtrace, while `Lwt.fail` does not. If you call
> `raise exn` in a callback that is expected by Lwt to return a
> promise, Lwt will automatically wrap `exn` in a rejected promise,
> but the backtrace will have been recorded by the OCaml runtime.
>
> For example, `bind`'s second argument is a callback which returns a
> promise. And so it is recommended to use `raise` in the body of that
> callback.
>
> Use `Lwt.fail` only when you specifically want to create a rejected
> promise, to pass to another function, or store in a data structure.

Prefer to capture backtraces to improve debugability.

See also https://github.com/ocsigen/lwt/pull/1008 and https://github.com/mirage/ocaml-conduit/pull/430.