### PR TITLE
chore: fix CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -22,7 +22,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ocaml-compiler:
-          - "4.14"
           - "5"
         local-packages:
           - |
@@ -66,7 +65,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ocaml-compiler:
-          - "4.14"
           - "5"
         local-packages:
           - |

--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -36,7 +36,7 @@ depends: [
   "core_unix" {>= "v0.14.0"}
   "conduit-async" {>= "1.2.0"}
   "magic-mime"
-  "mirage-crypto" {with-test}
+  "digestif" {with-test}
   "logs"
   "fmt" {>= "0.8.2"}
   "sexplib0"

--- a/cohttp-async/examples/dune
+++ b/cohttp-async/examples/dune
@@ -1,7 +1,7 @@
 (executables
  (names hello_world receive_post)
  (libraries
-  mirage-crypto
+  digestif.c
   http
   cohttp-async
   base

--- a/cohttp-curl-async.opam
+++ b/cohttp-curl-async.opam
@@ -21,7 +21,7 @@ doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocurl"
+  "ocurl" {>= "0.9.2"}
   "http" {= version}
   "stringext"
   "cohttp-curl" {= version}

--- a/cohttp-curl-lwt.opam
+++ b/cohttp-curl-lwt.opam
@@ -22,7 +22,7 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08"}
-  "ocurl"
+  "ocurl" {>= "0.9.2"}
   "http" {= version}
   "cohttp-curl" {= version}
   "stringext"

--- a/cohttp-curl.opam
+++ b/cohttp-curl.opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08"}
-  "ocurl"
+  "ocurl" {>= "0.9.2"}
   "http" {= version}
   "stringext"
   "odoc" {with-doc}

--- a/cohttp-eio.opam
+++ b/cohttp-eio.opam
@@ -28,7 +28,7 @@ depends: [
   "mdx" {with-test}
   "logs"
   "uri"
-  "tls-eio" {with-test & >= "0.17.2"}
+  "tls-eio" {with-test & >= "1.0.0"}
   "mirage-crypto-rng-eio" {with-test & >= "0.11.2"}
   "fmt"
   "ptime"

--- a/cohttp-eio/examples/client_tls.ml
+++ b/cohttp-eio/examples/client_tls.ml
@@ -9,7 +9,11 @@ let null_auth ?ip:_ ~host:_ _ =
   Ok None (* Warning: use a real authenticator in your code! *)
 
 let https ~authenticator =
-  let tls_config = Tls.Config.client ~authenticator () in
+  let tls_config =
+    match Tls.Config.client ~authenticator () with
+    | Error (`Msg msg) -> failwith ("tls configuration problem: " ^ msg)
+    | Ok tls_config -> tls_config
+  in
   fun uri raw ->
     let host =
       Uri.host uri

--- a/cohttp-lwt-unix/test/test_parser.ml
+++ b/cohttp-lwt-unix/test/test_parser.ml
@@ -221,7 +221,7 @@ let res_content_parse () =
       Rep_io.read_body_chunk reader >>= fun body ->
       assert_equal
         ~printer:(fun chunk ->
-          Transfer.sexp_of_chunk chunk |> Sexplib.Sexp.to_string_hum)
+          Transfer.sexp_of_chunk chunk |> Sexplib0.Sexp.to_string_hum)
         (Transfer.Final_chunk "home=Cosby&favorite+flavor=flies") body;
       return ()
   | _ -> assert false

--- a/dune-project
+++ b/dune-project
@@ -264,7 +264,7 @@
  (depends
   (ocaml
    (>= 4.08))
-  ocurl
+  (ocurl (>= 0.9.2))
   (http
    (= :version))
   stringext))
@@ -277,7 +277,7 @@
  (depends
   (ocaml
    (>= 4.08))
-  ocurl
+  (ocurl (>= 0.9.2))
   (http
    (= :version))
   (cohttp-curl
@@ -312,7 +312,7 @@
  (description
   "An HTTP client that relies on Curl + Async for the backend. Does not require\nconduit for SSL.")
  (depends
-  ocurl
+  (ocurl (>= 0.9.2))
   (http
    (= :version))
   stringext

--- a/dune-project
+++ b/dune-project
@@ -379,7 +379,7 @@
   (mdx :with-test)
   logs
   uri
-  (tls-eio (and :with-test (>= 0.17.2)))
+  (tls-eio (and :with-test (>= 1.0.0)))
   (mirage-crypto-rng-eio (and :with-test (>= 0.11.2)))
   fmt
   ptime

--- a/dune-project
+++ b/dune-project
@@ -190,7 +190,7 @@
   (conduit-async
    (>= 1.2.0))
   magic-mime
-  (mirage-crypto :with-test)
+  (digestif :with-test)
   logs
   (fmt
    (>= 0.8.2))

--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1719186318,
-        "narHash": "sha256-H6bVeSIy34Fmhe756Q+hTlHnCgYLsKpOklY69tyj9NM=",
+        "lastModified": 1725916231,
+        "narHash": "sha256-kaU41Z43Uv2As0Sor8FPACJfWjkbUsWnZMtbCgqicvU=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "97eb195f9e19d3a006a84d978de2cdafe610d429",
+        "rev": "d63aa7b62251c70bbf0a28a67c30555077a2b758",
         "type": "github"
       },
       "original": {
@@ -57,17 +57,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1719146883,
-        "narHash": "sha256-DAyIfQgyqalov0DcEKRvDOUin7axELasaP6NCPt7UQA=",
+        "lastModified": 1725857262,
+        "narHash": "sha256-m9n0PncgZepVgmjOO1rfVXMgUACDOwZbhjSRjJ/NUpM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "084f8df2f3ff80cdec6f515931036f63c5d2f36c",
+        "rev": "5af6aefbcc55670e36663fd1f8a796e1e323001a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "084f8df2f3ff80cdec6f515931036f63c5d2f36c",
+        "rev": "5af6aefbcc55670e36663fd1f8a796e1e323001a",
         "type": "github"
       }
     },


### PR DESCRIPTION
There was a number of breaking changes in the recent releases of `tls` and `mirage-crypto`. Furthermore `ppx_expect` bump to v0.17.0 in https://github.com/mirage/ocaml-cohttp/pull/1043 requires ocaml >=5.1.0, so github actions couldn't run the tests anymore.