### PR TITLE
remove use of Sexplib (Sexplib0 has the same function)

### DIFF
--- a/cohttp-lwt-unix/test/test_parser.ml
+++ b/cohttp-lwt-unix/test/test_parser.ml
@@ -221,7 +221,7 @@ let res_content_parse () =
       Rep_io.read_body_chunk reader >>= fun body ->
       assert_equal
         ~printer:(fun chunk ->
-          Transfer.sexp_of_chunk chunk |> Sexplib.Sexp.to_string_hum)
+          Transfer.sexp_of_chunk chunk |> Sexplib0.Sexp.to_string_hum)
         (Transfer.Final_chunk "home=Cosby&favorite+flavor=flies") body;
       return ()
   | _ -> assert false


### PR DESCRIPTION
I think with this change the bounds on `conduit-lwt<"7.0.0"` can be removed  (they were added in https://github.com/ocaml/opam-repository/pull/26463/commits/f77632c3736d2025f17a60857140dc17bb3af879