### PR TITLE
6.0.0 release

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,6 +49,10 @@ jobs:
           opam install conf-libcurl
         if: ${{ matrix.os == 'ubuntu-latest' }}
 
+      - run: |
+          brew update
+        if: ${{ matrix.os == 'macos-latest' }}
+
       - run: echo "PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig" >>"$GITHUB_ENV"
         if: ${{ matrix.os == 'macos-latest' }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _build/
 .merlin
 _opam/
 node_modules
+dune.lock/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
-## Unreleased
+## v6.0.0 (2024-11-21)
 
+- bump minimum dune version to 3.8 (@avsm)
 - cohttp-eio: Use system authenticator in example.
 - http, cohttp: remove the scheme field from requests. This means that
   [Request.uri] no longer returns the same URI as was to create the request

--- a/cohttp-async.opam
+++ b/cohttp-async.opam
@@ -24,7 +24,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.14"}
   "http" {= version}
   "cohttp" {= version}

--- a/cohttp-bench.opam
+++ b/cohttp-bench.opam
@@ -23,7 +23,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "core" {>= "v0.13.0"}
   "core_bench"
   "eio" {>= "0.12"}

--- a/cohttp-curl-async.opam
+++ b/cohttp-curl-async.opam
@@ -20,7 +20,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "ocurl" {>= "0.9.2"}
   "http" {= version}
   "stringext"

--- a/cohttp-curl-lwt.opam
+++ b/cohttp-curl-lwt.opam
@@ -20,7 +20,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.08"}
   "ocurl" {>= "0.9.2"}
   "http" {= version}

--- a/cohttp-curl.opam
+++ b/cohttp-curl.opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.08"}
   "ocurl" {>= "0.9.2"}
   "http" {= version}

--- a/cohttp-eio.opam
+++ b/cohttp-eio.opam
@@ -19,7 +19,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "alcotest" {with-test & >= "1.7.0"}
   "base-domains"
   "cohttp" {= version}

--- a/cohttp-lwt-jsoo.opam
+++ b/cohttp-lwt-jsoo.opam
@@ -23,7 +23,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.08"}
   "http" {= version}
   "cohttp" {= version}

--- a/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.mli
+++ b/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.mli
@@ -44,11 +44,11 @@ end
 
 (** Build an asynchronous engine with chunked/unchucked response data treated as
     raw bytes or UTF *)
-module Make_client_async (P : Params) : Cohttp_lwt.S.Client
+module Make_client_async (_ : Params) : Cohttp_lwt.S.Client
 
 (** Build a synchronous engine with chunked/unchucked response data treated as
     raw bytes or UTF *)
-module Make_client_sync (P : Params) : Cohttp_lwt.S.Client
+module Make_client_sync (_ : Params) : Cohttp_lwt.S.Client
 
 module Client : Cohttp_lwt.S.Client
 (** The [Client] module implements an HTTP client interface using asynchronous

--- a/cohttp-lwt-unix.opam
+++ b/cohttp-lwt-unix.opam
@@ -27,7 +27,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.08"}
   "http" {= version}
   "cohttp" {= version}

--- a/cohttp-lwt.opam
+++ b/cohttp-lwt.opam
@@ -25,7 +25,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.08"}
   "http" {= version}
   "cohttp" {= version}

--- a/cohttp-mirage.opam
+++ b/cohttp-mirage.opam
@@ -27,7 +27,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.08"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}

--- a/cohttp-mirage/src/client.mli
+++ b/cohttp-mirage/src/client.mli
@@ -1,5 +1,5 @@
 module Make
-    (P : Mirage_clock.PCLOCK)
+    (_ : Mirage_clock.PCLOCK)
     (R : Resolver_mirage.S)
     (S : Conduit_mirage.S) : sig
   module Connection : Cohttp_lwt.S.Connection

--- a/cohttp-mirage/src/net.mli
+++ b/cohttp-mirage/src/net.mli
@@ -1,5 +1,5 @@
 module Make
-    (P : Mirage_clock.PCLOCK)
+    (_ : Mirage_clock.PCLOCK)
     (R : Resolver_mirage.S)
     (S : Conduit_mirage.S) : sig
   type ctx = {

--- a/cohttp-server-lwt-unix.opam
+++ b/cohttp-server-lwt-unix.opam
@@ -21,7 +21,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.08"}
   "http" {= version}
   "lwt" {>= "5.5.0"}

--- a/cohttp-top.opam
+++ b/cohttp-top.opam
@@ -23,7 +23,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.08"}
   "cohttp" {= version}
   "odoc" {with-doc}

--- a/cohttp.opam
+++ b/cohttp.opam
@@ -34,7 +34,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "http" {= version}
   "ocaml" {>= "4.08"}
   "re" {>= "1.9.0"}

--- a/dune-project
+++ b/dune-project
@@ -1,10 +1,10 @@
-(lang dune 3.0)
+(lang dune 3.8)
 
 (name cohttp)
 
 (license ISC)
 
-(using mdx 0.2)
+(using mdx 0.4)
 
 (cram enable)
 

--- a/http.opam
+++ b/http.opam
@@ -21,7 +21,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.08"}
   "ppx_expect" {with-test & >= "v0.17.0"}
   "alcotest" {with-test & >= "1.7.0"}

--- a/http/src/bytebuffer/bytebuffer.ml
+++ b/http/src/bytebuffer/bytebuffer.ml
@@ -17,11 +17,7 @@ module Bytes = BytesLabels
    on the bytebuffer.
 *)
 
-type t = {
-  buf : Bytes.t;
-  mutable pos_read : int;
-  mutable pos_fill : int;
-}
+type t = { buf : Bytes.t; mutable pos_read : int; mutable pos_fill : int }
 
 let create size =
   let buf = Bytes.create size in

--- a/http/src/bytebuffer/bytebuffer.ml
+++ b/http/src/bytebuffer/bytebuffer.ml
@@ -18,7 +18,7 @@ module Bytes = BytesLabels
 *)
 
 type t = {
-  mutable buf : Bytes.t;
+  buf : Bytes.t;
   mutable pos_read : int;
   mutable pos_fill : int;
 }


### PR DESCRIPTION
A few housekeeping changes:

- bump dune lang to 3.8 to get a reasonable mdx bound
- this brings in some new default warnings, so remove unused names in signatures
- bytebuffer has an unnecessary mutable annotation in the implementation, as Bytes is already mutable