### PR TITLE
chore: rename main function on main page example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ open Lwt
 open Cohttp
 open Cohttp_lwt_unix
 
-let body =
+let main =
   Client.get (Uri.of_string "https://www.reddit.com/") >>= fun (resp, body) ->
   let code = resp |> Response.status |> Code.code_of_status in
   Printf.printf "Response code: %d\n" code;
@@ -89,7 +89,7 @@ let body =
   body
 
 let () =
-  let body = Lwt_main.run body in
+  let body = Lwt_main.run main in
   print_endline ("Received body\n" ^ body)
 ```
 


### PR DESCRIPTION
This is a tiny pr renaming the main function on the first usage example of the lib. 
Even though it probably looks like it, this is not a troll hacktoberfest I want my free t-shirt kind of PR.
I just picked up ocaml and this was the first code example I got up and running. I was very confused by the fact that there was this variable `body` everywhere and couldn't quite figure out what it meant. Then it clicked that there are indeed 2 variables called body each of which has nothing to do with each other.
I believe many others will also start their ocaml journey by making some http requests and it would be great to have this example be more self explanatory. 
This is even done later on this same readme under ## Basic server tutorial