### PR TITLE
cohttp-mirage: support conduit 8.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,8 +16,9 @@
 - cohttp: `Cohttp.Request.make_for_client` no longer allows setting both
   `~chunked:true` and `~body_length`.
 - cohttp-lwt-unix: Don't blow up when certificates are not available and no-network requests are made. (akuhlens #1027)
-  + Makes `cohttp-lwt.S.default_ctx` lazy. 
+  + Makes `cohttp-lwt.S.default_ctx` lazy.
 - cohttp-lwt-unix: Add http/https proxy support for client requests (MisterDA #1080)
+- cohttp-mirage: Support conduit 8.0.0 (#@hannesm, #1104)
 
 ## v6.0.0~beta2 (2024-01-05)
 

--- a/cohttp-eio.opam
+++ b/cohttp-eio.opam
@@ -29,8 +29,7 @@ depends: [
   "logs"
   "uri"
   "tls-eio" {with-test & >= "1.0.0"}
-  "mirage-crypto-rng" {with-test & < "1.2.0"}
-  "mirage-crypto-rng-eio" {with-test & >= "0.11.2"}
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
   "ca-certs" {with-test & >= "1.0.0"}
   "fmt"
   "ptime"

--- a/cohttp-eio/examples/client_tls.ml
+++ b/cohttp-eio/examples/client_tls.ml
@@ -26,7 +26,7 @@ let https ~authenticator =
 
 let () =
   Eio_main.run @@ fun env ->
-  Mirage_crypto_rng_eio.run (module Mirage_crypto_rng.Fortuna) env @@ fun () ->
+  Mirage_crypto_rng_unix.use_default ();
   let client = Client.make ~https:(Some (https ~authenticator)) env#net in
   Eio.Switch.run @@ fun sw ->
   let resp, body =

--- a/cohttp-eio/examples/dune
+++ b/cohttp-eio/examples/dune
@@ -10,7 +10,7 @@
   logs.threaded
   tls-eio
   ca-certs
-  mirage-crypto-rng-eio))
+  mirage-crypto-rng.unix))
 
 (alias
  (name runtest)

--- a/cohttp-mirage.opam
+++ b/cohttp-mirage.opam
@@ -31,8 +31,8 @@ depends: [
   "ocaml" {>= "4.08"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.3.0"}
+  "conduit" {>= "8.0.0"}
+  "conduit-mirage" {>= "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp-lwt" {= version}

--- a/cohttp-mirage/src/client.ml
+++ b/cohttp-mirage/src/client.ml
@@ -17,12 +17,8 @@
  * %%NAME%% %%VERSION%%
  *)
 
-module Make
-    (P : Mirage_clock.PCLOCK)
-    (R : Resolver_mirage.S)
-    (S : Conduit_mirage.S) =
-struct
-  module Net = Net.Make (P) (R) (S)
+module Make (R : Resolver_mirage.S) (S : Conduit_mirage.S) = struct
+  module Net = Net.Make (R) (S)
   module Connection = Cohttp_lwt.Connection.Make (Net)
   include Cohttp_lwt.Client.Make (Connection)
 

--- a/cohttp-mirage/src/client.mli
+++ b/cohttp-mirage/src/client.mli
@@ -1,7 +1,4 @@
-module Make
-    (_ : Mirage_clock.PCLOCK)
-    (R : Resolver_mirage.S)
-    (S : Conduit_mirage.S) : sig
+module Make (R : Resolver_mirage.S) (S : Conduit_mirage.S) : sig
   module Connection : Cohttp_lwt.S.Connection
   include Cohttp_lwt.S.Client with type ctx = Connection.Net.ctx
 

--- a/cohttp-mirage/src/net.ml
+++ b/cohttp-mirage/src/net.ml
@@ -1,11 +1,6 @@
-module Make
-    (P : Mirage_clock.PCLOCK)
-    (R : Resolver_mirage.S)
-    (S : Conduit_mirage.S) =
-struct
+module Make (R : Resolver_mirage.S) (S : Conduit_mirage.S) = struct
   module Channel = Mirage_channel.Make (S.Flow)
   module Input_channel = Input_channel.Make (Channel)
-  module Endpoint = Conduit_mirage.Endpoint (P)
   module IO = Io.Make (Channel)
   open IO
 
@@ -28,7 +23,8 @@ struct
   let resolve ~ctx uri = R.resolve_uri ~uri ctx.resolver
 
   let connect_endp ~ctx endp =
-    Endpoint.client ?tls_authenticator:ctx.authenticator endp >>= fun client ->
+    Conduit_mirage.Endpoint.client ?tls_authenticator:ctx.authenticator endp
+    >>= fun client ->
     match ctx.conduit with
     | None -> failwith "conduit not initialised"
     | Some c ->

--- a/cohttp-mirage/src/net.mli
+++ b/cohttp-mirage/src/net.mli
@@ -1,7 +1,4 @@
-module Make
-    (_ : Mirage_clock.PCLOCK)
-    (R : Resolver_mirage.S)
-    (S : Conduit_mirage.S) : sig
+module Make (R : Resolver_mirage.S) (S : Conduit_mirage.S) : sig
   type ctx = {
     resolver : R.t;
     conduit : S.t option;

--- a/dune-project
+++ b/dune-project
@@ -218,9 +218,9 @@
   (mirage-channel
    (>= 4.0.0))
   (conduit
-   (>= 2.0.2))
+   (>= 8.0.0))
   (conduit-mirage
-   (>= 2.3.0))
+   (>= 8.0.0))
   (mirage-kv
    (>= 3.0.0))
   (lwt

--- a/dune-project
+++ b/dune-project
@@ -382,8 +382,7 @@
   logs
   uri
   (tls-eio (and :with-test (>= 1.0.0)))
-  (mirage-crypto-rng (and :with-test (< 1.2.0)))
-  (mirage-crypto-rng-eio (and :with-test (>= 0.11.2)))
+  (mirage-crypto-rng (and :with-test (>= 1.2.0)))
   (ca-certs (and :with-test  (>= "1.0.0")))
   fmt
   ptime


### PR DESCRIPTION
Would be great to merge and release once https://github.com/ocaml/opam-repository/pull/27466 is merged.

The reasoning behind removing the functor argument is in more detail in https://github.com/mirage/mirage/pull/1599

This PR is an effort to keep cohttp in line / up to date with other MirageOS development.