### PR TITLE
Client: Expose `IO`.

### DIFF
--- a/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.ml
+++ b/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.ml
@@ -48,7 +48,16 @@ let string_of_uint8array u8a offset len =
   String.init len (fun i -> Char.chr (Typed_array.unsafe_get u8a (offset + i)))
 
 module String_io = Cohttp.Private.String_io
-module IO = Cohttp_lwt.Private.String_io
+
+module IO = struct
+  include Cohttp_lwt.Private.String_io
+
+  type error = |
+
+  let catch f = Lwt.map (fun v -> Result.Ok v) @@ f ()
+  let pp_error _ (e : error) = match e with _ -> .
+end
+
 module Header_io = Cohttp.Private.Header_io.Make (IO)
 
 module Body_builder (P : Params) = struct
@@ -141,6 +150,7 @@ module Make_api (X : sig
     (Response.t * Cohttp_lwt.Body.t) Lwt.t
 end) =
 struct
+  module IO = IO
   module Request = X.Request
   module Response = X.Response
 

--- a/cohttp-lwt/src/client.ml
+++ b/cohttp-lwt/src/client.ml
@@ -3,6 +3,7 @@ module Header = Cohttp.Header
 
 module Make (Connection : S.Connection) = struct
   module Net = Connection.Net
+  module IO = Net.IO
   module No_cache = Connection_cache.Make_no_cache (Connection)
   module Request = Make.Request (Net.IO)
 

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -193,6 +193,8 @@ end
 module type Client = sig
   type ctx
 
+  module IO : IO with type 'a t = 'a Lwt.t
+
   (** @param ctx
         If provided, no connection cache is used, but
         {!val:Connection_cache.Make_no_cache.create} is used to resolve uri and


### PR DESCRIPTION
The lwt `IO` implementation defines a private `IO_error` exception, which can only be handled via the `catch` method. Yet since the `IO` module is not exposed, when working with an agnostic `Cohttp.Client.S`, there is AFAICT no way to actually stop these exceptions.

This PR exposes the `IO` module so that it's possible to properly handle all errors with zero assumptions on the IO implementation. I suppose it also doesn't hurt to be able to write cohttp code that works with any IO monad.