### PR TITLE
factor cohttp-lwt-unix binaries into their own project

### DIFF
--- a/cohttp-lwt-unix.opam
+++ b/cohttp-lwt-unix.opam
@@ -4,13 +4,15 @@ synopsis: "CoHTTP implementation for Unix and Windows using Lwt"
 description: """
 An implementation of an HTTP client and server using the Lwt
 concurrency library. See the `Cohttp_lwt_unix` module for information
-on how to use this.  The package also installs `cohttp-curl-lwt`
-and a `cohttp-server-lwt` binaries for quick uses of a HTTP(S)
-client and server respectively.
+on how to use this.
 
 Although the name implies that this only works under Unix, it
 should also be fine under Windows too.
-"""
+
+The accompanying `cohttp-curl-lwt`, `cohttp-proxy-lwt`, and
+`cohttp-server-lwt` command-line utilities ship in the separate
+`cohttp-lwt-unix-bin` package so that library consumers do not
+transitively depend on `cmdliner`."""
 maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
 authors: [
   "Anil Madhavapeddy"
@@ -32,7 +34,6 @@ depends: [
   "http" {= version}
   "cohttp" {= version}
   "cohttp-lwt" {= version}
-  "cmdliner" {>= "2.0.0"}
   "lwt" {>= "3.0.0"}
   "conduit-lwt" {>= "7.1.0"}
   "conduit-lwt-unix" {>= "7.1.0"}

--- a/cohttp-lwt-unix/bin/dune
+++ b/cohttp-lwt-unix/bin/dune
@@ -1,5 +1,7 @@
 (executables
  (names cohttp_curl_lwt cohttp_proxy_lwt cohttp_server_lwt)
+ (public_names cohttp-curl-lwt cohttp-proxy-lwt cohttp-server-lwt)
+ (package cohttp-lwt-unix-bin)
  (libraries
   cohttp-lwt-unix
   cohttp_server

--- a/dune-project
+++ b/dune-project
@@ -91,7 +91,7 @@
  (name cohttp-lwt-unix)
  (synopsis "CoHTTP implementation for Unix and Windows using Lwt")
  (description
-  "An implementation of an HTTP client and server using the Lwt\nconcurrency library. See the `Cohttp_lwt_unix` module for information\non how to use this.  The package also installs `cohttp-curl-lwt`\nand a `cohttp-server-lwt` binaries for quick uses of a HTTP(S)\nclient and server respectively.\n\nAlthough the name implies that this only works under Unix, it\nshould also be fine under Windows too.\n")
+  "An implementation of an HTTP client and server using the Lwt\nconcurrency library. See the `Cohttp_lwt_unix` module for information\non how to use this.\n\nAlthough the name implies that this only works under Unix, it\nshould also be fine under Windows too.\n\nThe accompanying `cohttp-curl-lwt`, `cohttp-proxy-lwt`, and\n`cohttp-server-lwt` command-line utilities ship in the separate\n`cohttp-lwt-unix-bin` package so that library consumers do not\ntransitively depend on `cmdliner`.")
  (depends
   (ocaml
    (>= 4.08))
@@ -101,8 +101,6 @@
    (= :version))
   (cohttp-lwt
    (= :version))
-  (cmdliner
-   (>= 2.0.0))
   (lwt
    (>= 3.0.0))
   (conduit-lwt
@@ -117,6 +115,27 @@
   magic-mime
   logs
   (ounit2 :with-test)))
+
+(package
+ (name cohttp-lwt-unix-bin)
+ (synopsis "Command-line utilities shipped with cohttp-lwt-unix")
+ (description
+  "This package contains the `cohttp-curl-lwt`, `cohttp-proxy-lwt`, and\n`cohttp-server-lwt` command-line utilities. They were previously built\nas part of `cohttp-lwt-unix`, but were split out so that library\nconsumers do not transitively depend on `cmdliner`.")
+ (depends
+  (ocaml
+   (>= 4.08))
+  (cohttp
+   (= :version))
+  (cohttp-lwt
+   (= :version))
+  (cohttp-lwt-unix
+   (= :version))
+  (cmdliner
+   (>= 2.0.0))
+  (conduit-lwt
+   (>= 7.1.0))
+  fmt
+  logs))
 
 (package
  (name cohttp-server-lwt-unix)


### PR DESCRIPTION
The `cohttp-curl-lwt`, `cohttp-proxy-lwt`, and `cohttp-server-lwt` executables were previously built as part of the `cohttp-lwt-unix` package. Because they use the cmdliner 2.0 API, this forced every library consumer of `cohttp-lwt-unix` to transitively depend on `cmdliner >= 2.0.0`, which is disruptive for downstreams that are still on `cmdliner` 1.x.  Library users likely have no need for this binary; it's mostly an example/curio.

This patch moves the executables into a new package that encapsulates the `cmdliner` dependency.  Now, library consumers of `cohttp-lwt-unix` now build without cmdliner at all.