### PR TITLE
Fix uncatchable IO exceptions.

### DIFF
--- a/cohttp-lwt-unix/test/test_client.ml
+++ b/cohttp-lwt-unix/test/test_client.ml
@@ -199,6 +199,7 @@ let test_cache uri =
 
 let test_client_cached uri =
   let cache = Cache.create () in
+  let module Client = Cohttp_lwt.Client.Make (Cohttp_lwt_unix.Connection) in
   Client.set_cache (Cache.call cache);
   test_client uri
 

--- a/cohttp-lwt-unix/test/test_client.ml
+++ b/cohttp-lwt-unix/test/test_client.ml
@@ -204,7 +204,7 @@ let test_client_cached uri =
 
 let tests uri =
   [
-    ("high-level interface", fun () -> test_persistent uri);
+    ("high-level interface", fun () -> test_client uri);
     ("persistent connection", fun () -> test_persistent uri);
     ("non-persistent connection", fun () -> test_non_persistent uri);
     ("unknown persistence connection", fun () -> test_unknown uri);

--- a/cohttp-lwt/src/connection_cache.ml
+++ b/cohttp-lwt/src/connection_cache.ml
@@ -28,7 +28,12 @@ module Make_no_cache (Connection : S.Connection) = struct
         >>= fun () ->
         Connection.close connection;
         Lwt.return_unit)
-      (function Retry -> () | e -> raise e);
+      (function
+        | _ ->
+        (* Since [res] is already returned below, we need not reraise anything
+            here. It would trigger Lwt's async exception handler even though the
+            caller already saw and probably handled the exception. *)
+        ());
     res
 end
 


### PR DESCRIPTION
Recreating #1137 because github does not enable changing source branch.

There is currently a bug where IO write exception are "uncatchable": even if the underlying `IO_error` is handled, it would still find its way out and kill the main loop as demonstrated in [this test](141253d724d95d74ddca3b9e1439b5004a1f95de).

Bamboozled by the backtrace, I initially [reported this in lwt](https://github.com/ocsigen/lwt/issues/1067) and lived with it for some time. I finally had enough and jumped into the rabbit hole, copiously hitting my head every meter during the fall, but finally hunted it down to [this Lwt.dont_wait](https://github.com/mirage/ocaml-cohttp/commit/7150778c57f56e17315fe589d6a9d8da840c1dc8). Cruel irony, I already [addressed this very issue](https://github.com/mirage/ocaml-cohttp/pull/995) but was too shy. This is the harsher version, which I think is the correct one:

* No exception escaping `res` should be reported twice.
* AFAICT the only other thing that could raise is `Connection.close`, but I don't think any exception there should kill the Lwt loop either.