### PR TITLE
Don't add Transfer-Encoding to responses that cannot have a body.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,9 @@
 - cohttp: do not add `Transfer-Encoding`/`Content-Length` framing headers to
   responses that cannot have a body (1xx, 204 and 304). This fixes WebSocket
   handshakes. (@mefyl @avsm, #1141)
+- http: add `Status.body_allowed`, the response-status counterpart to the
+  existing `Method.body_allowed`, for users constructing responses by hand
+  (#1141)
 
 ## v6.2.2 (2026-07-26)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,9 @@
 - cohttp-mirage: The `request_fn` callback receives the request URI unchanged.
   A request that falls back to an index page previously received a URI
   rewritten to that page. (#1145 @avsm)
+- cohttp: do not add `Transfer-Encoding`/`Content-Length` framing headers to
+  responses that cannot have a body (1xx, 204 and 304). This fixes WebSocket
+  handshakes. (@mefyl @avsm, #1141)
 
 ## v6.2.2 (2026-07-26)
 

--- a/cohttp-lwt-unix/test/test_sanity_noisy.ml
+++ b/cohttp-lwt-unix/test/test_sanity_noisy.ml
@@ -45,8 +45,7 @@ let ts_noisy =
         Client.get ~ctx uri >>= fun (resp, body) ->
         assert_equal (Response.status resp) `Not_modified;
         let headers = Response.headers resp in
-        assert_equal ~printer:Transfer.string_of_encoding
-          Transfer.(Fixed 0L)
+        assert_equal ~printer:Transfer.string_of_encoding Transfer.Unknown
           (Header.get_transfer_encoding headers);
         body |> Body.is_empty >|= fun is_empty ->
         assert_bool "No body returned when not modified" is_empty

--- a/cohttp/src/response.ml
+++ b/cohttp/src/response.ml
@@ -39,13 +39,22 @@ let status t = t.status
 
 let make ?(version = `HTTP_1_1) ?(status = `OK) ?(encoding = Transfer.Unknown)
     ?(headers = Header.init ()) () =
+  (* RFC 7230 §3.3.1: Transfer-Encoding MUST NOT be sent in a 1xx, 204, or 304
+     response. Skip encoding headers for responses that cannot have a body. *)
+  let body_allowed =
+    match status with
+    | #Code.informational_status | `No_content | `Not_modified -> false
+    | #Code.status_code -> true
+  in
   let headers =
-    match encoding with
-    | Unknown -> (
-        match Header.get_transfer_encoding headers with
-        | Unknown -> Header.add_transfer_encoding headers Chunked
-        | _ -> headers)
-    | _ -> Header.add_transfer_encoding headers encoding
+    if not body_allowed then headers
+    else
+      match encoding with
+      | Unknown -> (
+          match Header.get_transfer_encoding headers with
+          | Unknown -> Header.add_transfer_encoding headers Chunked
+          | _ -> headers)
+      | _ -> Header.add_transfer_encoding headers encoding
   in
   { headers; version; status }
 

--- a/cohttp/src/response.ml
+++ b/cohttp/src/response.ml
@@ -39,15 +39,8 @@ let status t = t.status
 
 let make ?(version = `HTTP_1_1) ?(status = `OK) ?(encoding = Transfer.Unknown)
     ?(headers = Header.init ()) () =
-  (* RFC 7230 §3.3.1: Transfer-Encoding MUST NOT be sent in a 1xx, 204, or 304
-     response. Skip encoding headers for responses that cannot have a body. *)
-  let body_allowed =
-    match status with
-    | #Code.informational_status | `No_content | `Not_modified -> false
-    | #Code.status_code -> true
-  in
   let headers =
-    if not body_allowed then headers
+    if not (Http.Status.body_allowed status) then headers
     else
       match encoding with
       | Unknown -> (
@@ -61,11 +54,7 @@ let make ?(version = `HTTP_1_1) ?(status = `OK) ?(encoding = Transfer.Unknown)
 let pp_hum ppf r =
   Format.fprintf ppf "%s" (r |> sexp_of_t |> Sexplib0.Sexp.to_string_hum)
 
-let allowed_body response =
-  (* rfc7230#section-5.7.1 *)
-  match status response with
-  | #Code.informational_status | `No_content | `Not_modified -> false
-  | #Code.status_code -> true
+let allowed_body response = Http.Status.body_allowed (status response)
 
 let has_body response =
   if allowed_body response then Transfer.has_body (encoding response) else `No

--- a/cohttp/test/dune
+++ b/cohttp/test/dune
@@ -69,3 +69,15 @@
  (package cohttp)
  (action
   (run ./test_proxy.exe)))
+
+(executable
+ (name test_response)
+ (modules test_response)
+ (forbidden_libraries base)
+ (libraries cohttp alcotest))
+
+(rule
+ (alias runtest)
+ (package cohttp)
+ (action
+  (run ./test_response.exe)))

--- a/cohttp/test/test_response.ml
+++ b/cohttp/test/test_response.ml
@@ -29,6 +29,7 @@ let bodyless_statuses =
     `Checkpoint;
     `No_content;
     `Not_modified;
+    `Code 199;
   ]
 
 let iter_bodyless f =

--- a/cohttp/test/test_response.ml
+++ b/cohttp/test/test_response.ml
@@ -1,0 +1,147 @@
+open Cohttp
+module String_io = Cohttp.Private.String_io
+module Response_io = Response.Private.Make (String_io.M)
+
+let t_encoding =
+  Alcotest.testable
+    (fun fmt e -> Format.pp_print_string fmt (Transfer.string_of_encoding e))
+    ( = )
+
+let check_encoding name expected response =
+  Alcotest.check t_encoding name expected (Response.encoding response)
+
+let check_no_framing_headers name response =
+  let headers = Response.headers response in
+  Alcotest.(check (option string))
+    (name ^ ": no transfer-encoding header")
+    None
+    (Header.get headers "transfer-encoding");
+  Alcotest.(check (option string))
+    (name ^ ": no content-length header")
+    None
+    (Header.get headers "content-length")
+
+let bodyless_statuses =
+  [
+    `Continue;
+    `Switching_protocols;
+    `Processing;
+    `Checkpoint;
+    `No_content;
+    `Not_modified;
+  ]
+
+let iter_bodyless f =
+  List.iter
+    (fun status -> f (Code.string_of_status status) status)
+    bodyless_statuses
+
+let default_encoding_is_chunked () =
+  check_encoding "unspecified encoding defaults to chunked" Transfer.Chunked
+    (Response.make ())
+
+let explicit_encoding_is_used () =
+  check_encoding "explicit encoding is used" (Transfer.Fixed 5L)
+    (Response.make ~status:`OK ~encoding:(Transfer.Fixed 5L) ())
+
+let encoding_from_headers () =
+  check_encoding "encoding taken from supplied headers" (Transfer.Fixed 42L)
+    (Response.make ~status:`OK
+       ~headers:(Header.of_list [ ("content-length", "42") ])
+       ())
+
+let bodyless_has_no_encoding () =
+  iter_bodyless (fun name status ->
+      let r = Response.make ~status () in
+      check_encoding (name ^ " is not chunked by default") Transfer.Unknown r;
+      check_no_framing_headers name r)
+
+let bodyless_ignores_explicit_encoding () =
+  iter_bodyless (fun name status ->
+      let chunked = Response.make ~status ~encoding:Transfer.Chunked () in
+      check_encoding
+        (name ^ " drops an explicit chunked encoding")
+        Transfer.Unknown chunked;
+      check_no_framing_headers (name ^ " (chunked)") chunked;
+      let fixed = Response.make ~status ~encoding:(Transfer.Fixed 0L) () in
+      check_encoding
+        (name ^ " drops an explicit fixed encoding")
+        Transfer.Unknown fixed;
+      check_no_framing_headers (name ^ " (fixed)") fixed)
+
+let t_has_body =
+  Alcotest.testable
+    (fun fmt -> function
+      | `No -> Format.pp_print_string fmt "`No"
+      | `Unknown -> Format.pp_print_string fmt "`Unknown"
+      | `Yes -> Format.pp_print_string fmt "`Yes")
+    ( = )
+
+let bodyless_has_no_body () =
+  iter_bodyless (fun name status ->
+      Alcotest.check t_has_body (name ^ " has no body") `No
+        (Response.has_body (Response.make ~status ())))
+
+let write_response r =
+  let buf = Buffer.create 128 in
+  Response_io.write ~flush:false (fun _ -> ()) r buf;
+  Buffer.contents buf
+
+let write_chunked_response () =
+  Alcotest.(check string)
+    "a 200 response is framed as chunked"
+    "HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n0\r\n\r\n"
+    (write_response (Response.make ()))
+
+let write_switching_protocols () =
+  let r =
+    Response.make ~status:`Switching_protocols
+      ~headers:
+        (Header.of_list [ ("upgrade", "websocket"); ("connection", "Upgrade") ])
+      ()
+  in
+  Alcotest.(check string)
+    "a 101 response is written without any framing"
+    "HTTP/1.1 101 Switching Protocols\r\n\
+     upgrade: websocket\r\n\
+     connection: Upgrade\r\n\
+     \r\n"
+    (write_response r)
+
+let write_no_content () =
+  Alcotest.(check string)
+    "a 204 response is written without any framing"
+    "HTTP/1.1 204 No Content\r\n\r\n"
+    (write_response (Response.make ~status:`No_content ()))
+
+let write_not_modified () =
+  Alcotest.(check string)
+    "a 304 response is written without any framing"
+    "HTTP/1.1 304 Not Modified\r\n\r\n"
+    (write_response (Response.make ~status:`Not_modified ()))
+
+let () =
+  Alcotest.run "test_response"
+    [
+      ( "Encoding",
+        [
+          ("default is chunked", `Quick, default_encoding_is_chunked);
+          ("explicit encoding", `Quick, explicit_encoding_is_used);
+          ("from headers", `Quick, encoding_from_headers);
+        ] );
+      ( "Bodyless statuses",
+        [
+          ("no encoding by default", `Quick, bodyless_has_no_encoding);
+          ( "explicit encoding ignored",
+            `Quick,
+            bodyless_ignores_explicit_encoding );
+          ("no body", `Quick, bodyless_has_no_body);
+        ] );
+      ( "Serialization",
+        [
+          ("chunked", `Quick, write_chunked_response);
+          ("101 Switching Protocols", `Quick, write_switching_protocols);
+          ("204 No Content", `Quick, write_no_content);
+          ("304 Not Modified", `Quick, write_not_modified);
+        ] );
+    ]

--- a/http/src/http.ml
+++ b/http/src/http.ml
@@ -569,6 +569,10 @@ module Status = struct
     | `Network_connect_timeout_error -> 599
     | `Code code -> code
 
+  (* Defined for status codes in RFC7230 *)
+  let body_allowed t =
+    match to_int t with 204 | 304 -> false | code -> code < 100 || code >= 200
+
   let reason_phrase_of_code : int -> string = function
     | 100 -> "Continue"
     | 101 -> "Switching Protocols"

--- a/http/src/http.mli
+++ b/http/src/http.mli
@@ -153,6 +153,15 @@ module Status : sig
   val to_string : t -> string
   val to_int : t -> int
   val of_int : int -> t
+
+  val body_allowed : t -> bool
+  (** [body_allowed status] returns whether a response with [status] allows a
+      payload body to be present per RFC7230. A [1xx], [204] or [304] response
+      is always terminated by the first empty line after the header fields, and
+      so carries neither a body nor any framing header.
+
+      https://www.rfc-editor.org/rfc/rfc7230#section-3.3 *)
+
   val reason_phrase_of_code : int -> string
   val pp : Format.formatter -> t -> unit
 end

--- a/http/test/test_response.ml
+++ b/http/test/test_response.ml
@@ -56,6 +56,32 @@ let content_length_tests =
   ( "content_length",
     [ ("OK", `Quick, ok_status); ("`No_content", `Quick, no_content_status) ] )
 
+let body_allowed_tests =
+  let case (status, expected) =
+    ( Status.to_string status,
+      `Quick,
+      fun () ->
+        Status.body_allowed status
+        |> aeb ("body_allowed " ^ Status.to_string status) expected )
+  in
+  ( "body_allowed",
+    List.map case
+      [
+        (`Continue, false);
+        (`Switching_protocols, false);
+        (`Processing, false);
+        (`Checkpoint, false);
+        (`No_content, false);
+        (`Not_modified, false);
+        (`Code 199, false);
+        (`OK, true);
+        (`Created, true);
+        (`Found, true);
+        (`Bad_request, true);
+        (`Internal_server_error, true);
+        (`Code 250, true);
+      ] )
+
 let () =
   Alcotest.run "test_response"
-    [ requires_content_length_tests; content_length_tests ]
+    [ requires_content_length_tests; content_length_tests; body_allowed_tests ]


### PR DESCRIPTION
RFC 7230 §3.3.1 forbids Transfer-Encoding in 1xx, 204, and 304 responses. The previous cohttp 6.x change that defaulted Unknown encoding to Chunked did not account for these response types, causing e.g. WebSocket 101 Switching Protocols responses to include a spurious Transfer-Encoding: chunked header and a trailing chunked body terminator (`0\r\n\r\n`), breaking the WebSocket handshake for conforming clients.