### PR TITLE
cohttp-eio: update tests for new Eio 1.4 getaddrinfo exception

### DIFF
--- a/cohttp-eio/tests/test_forward_proxy.ml
+++ b/cohttp-eio/tests/test_forward_proxy.ml
@@ -109,7 +109,8 @@ let () =
          https://www.rfc-editor.org/rfc/rfc2606 *)
     let uri = Uri.of_string "http://foo.invalid" in
     match Cohttp_eio.Client.get ~sw client uri with
-    | exception Failure _ ->
+    | exception Failure _
+    | exception Eio.Io (Eio.Net.E _, _) ->
         (* This should fail, since we are not using the proxy *)
         ()
     | unexepcted_resp, _ ->


### PR DESCRIPTION
Trying to connect to "http://foo.invalid" now raises `Eio.Io Net Address_lookup_failed`, not `Failure`.

Before (`getaddrinfo` returns `[]` and cohttp-eio raises an exception):
```
test_forward_proxy.exe: [INFO] GET http://foo.invalid
[failure] failed to resolve hostname
```
With Eio 1.4 `getaddrinfo` raises:
```
test_forward_proxy.exe: [INFO] GET http://foo.invalid
[exception] Eio.Io Net Address_lookup_failed NONAME (name or service is not known),
  looking up "foo.invalid" (service "http")
```