### PR TITLE
cohttp: urldecode before resolving path components for files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,28 +1,36 @@
 ## v6.3.0 (2026-08-19)
 
 - cohttp: `Cohttp.Path.resolve_local_file` no longer escapes the docroot when
-  given percent-encoded or double-encoded traversal sequences such as
-  `..%2f..%2f`.
+  given percent-encoded traversal sequences such as `..%2f..%2f`. The URI path
+  is percent-decoded exactly once before `.` and `..` segments are removed.
   (#1145 @avsm and Sapphire Livingstone, review by @mdales @edwintorok @patricoferris)
-- cohttp: Add `Cohttp.Path.normalise` to turn a request URI into a safe
-  relative path. Servers that make access-control decisions on path segments
-  should apply it to `Request.uri` before inspecting them. `Request.uri`
-  does not itself normalise absolute-form or percent-encoded targets. (@avsm)
+- cohttp: `Cohttp.Path.resolve_local_file` collapses empty path segments and
+  drops a trailing slash. A request for `/dir//sub/` now resolves to
+  `docroot/dir/sub` instead of `docroot/dir//sub/`. (#1145 @avsm)
+- cohttp: Add `Cohttp.Path.normalise`, which converts a request URI into a
+  relative path that cannot ascend above its root. Servers that make access
+  control decisions on path segments must apply it to `Request.uri` before
+  inspecting them, as `Request.uri` does not normalise absolute-form or
+  percent-encoded targets. (#1145 @avsm)
   ```ocaml
   let callback _conn req _body =
-    let path = Cohttp.Path.normalise (Cohttp.Request.uri req) in
-    match String.split_on_char '/' path with
+    let uri = Cohttp.Request.uri req in
+    match String.split_on_char '/' (Cohttp.Path.normalise uri) with
     | "admin" :: _ when not (authorised req) -> Server.respond_not_found ()
-    | _ -> Server.respond_file ~fname:path ()
+    | _ ->
+        let fname = Cohttp.Path.resolve_local_file ~docroot ~uri in
+        Server.respond_file ~fname ()
   ```
-  We cannot apply this by default since existing code may depend on the current
-  semantics, which can be safe if not combined with local file resolution.
-- cohttp-mirage: The static file server now normalises the request path before
-  looking it up in the mirage-kv store. Normalisation is now applied to every
-  request, including directory requests. 
-  The `request_fn` callback is now passed the request URI unchanged. Previously,
-  a request that fell back to an index page passed a URI rewritten to that
-  (#1145 @avsm, review by @mdales @edwintorok).
+  Normalisation is not applied by default, as existing code may depend on the
+  present semantics, which are safe when not combined with local file
+  resolution.
+- cohttp-mirage: The static file server normalises the request path of every
+  request, including directory requests, before looking it up in the mirage-kv
+  store. Keys are now percent-decoded, so `/my%20file.txt` retrieves the key
+  `my file.txt` rather than `my%20file.txt` (#1145 @avsm, review by @mdales @edwintorok)
+- cohttp-mirage: The `request_fn` callback receives the request URI unchanged.
+  A request that falls back to an index page previously received a URI
+  rewritten to that page. (#1145 @avsm)
 
 ## v6.2.2 (2026-07-26)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 - cohttp: `Cohttp.Path.resolve_local_file` no longer escapes the docroot when
   given percent-encoded or double-encoded traversal sequences such as
-  `..%2f..%2f`. (@avsm and Sapphire Livingstone)
+  `..%2f..%2f`. (#1145 @avsm and Sapphire Livingstone, review by @mdales)
 - cohttp: Add `Cohttp.Path.normalise` to turn a request URI into a safe
   relative path. Servers that make access-control decisions on path segments
   should apply it to `Request.uri` before inspecting them. `Request.uri`
@@ -17,7 +17,10 @@
   We cannot apply this by default since existing code may depend on the current
   semantics, which can be safe if not combined with local file resolution.
 - cohttp-mirage: The static file server now normalises the request path before
-  looking it up in the mirage-kv store (@avsm).
+  looking it up in the mirage-kv store. Normalisation is now applied to every
+  request, including directory requests. As a result a request for `/foo/`
+  serves `foo/index.html` rather than the top-level `index.html`,
+  which matches what a request for `/foo` already did (#1145 @avsm, review by @mdales).
 
 ## v6.2.2 (2026-07-26)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,24 @@
+## dev
+
+- cohttp: `Cohttp.Path.resolve_local_file` no longer escapes the docroot when
+  given percent-encoded or double-encoded traversal sequences such as
+  `..%2f..%2f`. (@avsm and Sapphire Livingstone)
+- cohttp: Add `Cohttp.Path.normalise` to turn a request URI into a safe
+  relative path. Servers that make access-control decisions on path segments
+  should apply it to `Request.uri` before inspecting them. `Request.uri`
+  does not itself normalise absolute-form or percent-encoded targets. (@avsm)
+  ```ocaml
+  let callback _conn req _body =
+    let path = Cohttp.Path.normalise (Cohttp.Request.uri req) in
+    match String.split_on_char '/' path with
+    | "admin" :: _ when not (authorised req) -> Server.respond_not_found ()
+    | _ -> Server.respond_file ~fname:path ()
+  ```
+  We cannot apply this by default since existing code may depend on the current
+  semantics, which can be safe if not combined with local file resolution.
+- cohttp-mirage: The static file server now normalises the request path before
+  looking it up in the mirage-kv store (@avsm).
+
 ## v6.2.2 (2026-07-26)
 
 - cohttp: remove duplicate occurance of lwt in dune-project (@Alizter, #1138)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
-## dev
+## v6.3.0 (2026-08-19)
 
 - cohttp: `Cohttp.Path.resolve_local_file` no longer escapes the docroot when
   given percent-encoded or double-encoded traversal sequences such as
-  `..%2f..%2f`. (#1145 @avsm and Sapphire Livingstone, review by @mdales)
+  `..%2f..%2f`.
+  (#1145 @avsm and Sapphire Livingstone, review by @mdales @edwintorok @patricoferris)
 - cohttp: Add `Cohttp.Path.normalise` to turn a request URI into a safe
   relative path. Servers that make access-control decisions on path segments
   should apply it to `Request.uri` before inspecting them. `Request.uri`
@@ -19,9 +20,9 @@
 - cohttp-mirage: The static file server now normalises the request path before
   looking it up in the mirage-kv store. Normalisation is now applied to every
   request, including directory requests. 
-  The `request_fn` callback is now passed the request URI unchanged;
-  previously a request that fell back to an index page passed a URI rewritten to that
-  (#1145 @avsm, review by @mdales and @edwintorok).
+  The `request_fn` callback is now passed the request URI unchanged. Previously,
+  a request that fell back to an index page passed a URI rewritten to that
+  (#1145 @avsm, review by @mdales @edwintorok).
 
 ## v6.2.2 (2026-07-26)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,9 +18,10 @@
   semantics, which can be safe if not combined with local file resolution.
 - cohttp-mirage: The static file server now normalises the request path before
   looking it up in the mirage-kv store. Normalisation is now applied to every
-  request, including directory requests. As a result a request for `/foo/`
-  serves `foo/index.html` rather than the top-level `index.html`,
-  which matches what a request for `/foo` already did (#1145 @avsm, review by @mdales).
+  request, including directory requests. 
+  The `request_fn` callback is now passed the request URI unchanged;
+  previously a request that fell back to an index page passed a URI rewritten to that
+  (#1145 @avsm, review by @mdales and @edwintorok).
 
 ## v6.2.2 (2026-07-26)
 

--- a/cohttp-mirage.opam
+++ b/cohttp-mirage.opam
@@ -38,7 +38,6 @@ depends: [
   "cohttp-lwt" {= version}
   "cstruct" {>= "6.0.0"}
   "fmt" {>= "0.8.7"}
-  "astring"
   "magic-mime"
   "ppx_sexp_conv" {>= "v0.13.0"}
   "cohttp" {= version}

--- a/cohttp-mirage.opam
+++ b/cohttp-mirage.opam
@@ -40,6 +40,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "magic-mime"
   "ppx_sexp_conv" {>= "v0.13.0"}
+  "alcotest" {with-test & >= "1.7.0"}
   "cohttp" {= version}
   "odoc" {with-doc}
 ]

--- a/cohttp-mirage/examples/dune
+++ b/cohttp-mirage/examples/dune
@@ -1,0 +1,11 @@
+(executable
+ (name static_server)
+ (modules static_server)
+ (libraries
+  cohttp-mirage
+  cohttp-lwt-unix
+  mirage-kv
+  optint
+  lwt.unix
+  logs.fmt
+  fmt.tty))

--- a/cohttp-mirage/examples/static_server.ml
+++ b/cohttp-mirage/examples/static_server.ml
@@ -1,0 +1,183 @@
+open Lwt.Infix
+
+module Dir : sig
+  include Mirage_kv.RO
+  val connect : string -> t
+end = struct
+  type t = { root : string }
+  type key = Mirage_kv.Key.t
+  type error = Mirage_kv.error
+
+  let pp_error = Mirage_kv.pp_error
+  let connect root = { root }
+  let disconnect _ = Lwt.return_unit
+
+  let path t key =
+    let segment s =
+      match s with
+      | "" | "." | ".." -> None
+      | s when String.exists (function '/' | '\000' -> true | _ -> false) s -> None
+      | s -> Some s
+    in
+    let rec go acc = function
+      | [] -> Some acc
+      | s :: rest -> (
+          match segment s with
+          | None -> None
+          | Some s -> go (Filename.concat acc s) rest)
+    in
+    go t.root (Mirage_kv.Key.segments key)
+
+  let stat t key =
+    match path t key with
+    | None -> Lwt.return None
+    | Some path ->
+        Lwt.catch
+          (fun () -> Lwt_unix.stat path >|= fun stat -> Some (path, stat))
+          (function
+            | Unix.Unix_error ((Unix.ENOENT | Unix.ENOTDIR), _, _) ->
+                Lwt.return None
+            | e -> Lwt.reraise e)
+
+  let get t key =
+    stat t key >>= function
+    | Some (path, { Unix.st_kind = Unix.S_REG; _ }) -> Lwt_io.with_file ~mode:Lwt_io.Input path Lwt_io.read >|= Result.ok
+    | Some _ -> Lwt.return (Error (`Value_expected key))
+    | None -> Lwt.return (Error (`Not_found key))
+
+  let exists t key =
+    stat t key >|= function
+    | Some (_, { Unix.st_kind = Unix.S_REG; _ }) -> Ok (Some `Value)
+    | Some (_, { Unix.st_kind = Unix.S_DIR; _ }) -> Ok (Some `Dictionary)
+    | Some _ | None -> Ok None
+
+  let size t key =
+    stat t key >|= function
+    | Some (_, { Unix.st_size = size; _ }) -> Ok (Optint.Int63.of_int size)
+    | None -> Error (`Not_found key)
+
+  let list t key =
+    match path t key with
+    | None -> Lwt.return (Error (`Not_found key))
+    | Some dir ->
+        Lwt.catch (fun () ->
+          Lwt_unix.files_of_directory dir |> Lwt_stream.to_list
+          >>= Lwt_list.filter_map_s (fun name ->
+                if name = "." || name = ".." then Lwt.return_none
+                else Lwt_unix.stat (Filename.concat dir name) >|= fun { Unix.st_kind; _ } ->
+                match st_kind with
+                | Unix.S_REG -> Some (Mirage_kv.Key.add key name, `Value)
+                | Unix.S_DIR -> Some (Mirage_kv.Key.add key name, `Dictionary)
+                | _ -> None)
+          >|= Result.ok)
+        (function
+          | Unix.Unix_error ((Unix.ENOENT | Unix.ENOTDIR), _, _) ->
+              Lwt.return (Error (`Not_found key))
+          | e -> Lwt.reraise e)
+
+  let get_partial _ key ~offset:_ ~length:_ = Lwt.return (Error (`Not_found key))
+  let last_modified _ key = Lwt.return (Error (`Not_found key))
+  let digest _ key = Lwt.return (Error (`Not_found key))
+end
+
+let html_escape s =
+  let b = Buffer.create (String.length s) in
+  String.iter
+    (function
+      | '&' -> Buffer.add_string b "&amp;"
+      | '<' -> Buffer.add_string b "&lt;"
+      | '>' -> Buffer.add_string b "&gt;"
+      | '"' -> Buffer.add_string b "&quot;"
+      | '\'' -> Buffer.add_string b "&#39;"
+      | c -> Buffer.add_char b c)
+    s;
+  Buffer.contents b
+
+let html_of_listing dir entries =
+  let segments = Mirage_kv.Key.segments dir in
+  let link segments text =
+    let href = segments |> List.map (Uri.pct_encode ~component:`Path) |> String.concat "/" |> html_escape in
+    Printf.sprintf {|<li><a href="/%s">%s</a></li>|} href (html_escape text)
+  in
+  let parent =
+    match List.rev segments with
+    | [] -> []
+    | _ :: up -> [ link (List.rev up) "../" ]
+  in
+  let entry (key, kind) =
+    let name = Mirage_kv.Key.basename key in
+    let text = match kind with `Dictionary -> name ^ "/" | `Value -> name in
+    (name, link (segments @ [ name ]) text)
+  in
+  let entries =
+    List.map entry entries
+    |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+    |> List.map snd
+  in
+  let title = "Index of " ^ html_escape (Mirage_kv.Key.to_string dir) in
+  String.concat "\n"
+    ([
+       "<!DOCTYPE html>";
+       "<html>";
+       "<head><title>" ^ title ^ "</title></head>";
+       "<body>";
+       "<h1>" ^ title ^ "</h1>";
+       "<ul>";
+     ]
+    @ parent @ entries
+    @ [ "</ul>"; "</body>"; "</html>"; "" ])
+
+module Generated_index (KV : Mirage_kv.RO) : Mirage_kv.RO with type t = KV.t =
+struct
+  include KV
+
+  let index = "index.html"
+
+  let generates t key =
+    if Mirage_kv.Key.basename key <> index then Lwt.return_false
+    else
+      KV.exists t (Mirage_kv.Key.parent key) >|= function
+      | Ok (Some `Dictionary) -> true
+      | Ok (Some `Value | None) | Error _ -> false
+
+  let get t key =
+    KV.get t key >>= function
+    | Ok _ as ok -> Lwt.return ok
+    | Error _ as error -> (
+        generates t key >>= function
+        | false -> Lwt.return error
+        | true -> (
+            let dir = Mirage_kv.Key.parent key in
+            KV.list t dir >|= function
+            | Ok entries -> Ok (html_of_listing dir entries)
+            | Error _ -> error))
+
+  let exists t key =
+    KV.exists t key >>= function
+    | Ok None -> (
+        generates t key >|= function
+        | true -> Ok (Some `Value)
+        | false -> Ok None)
+    | r -> Lwt.return r
+end
+
+module Store = Generated_index (Dir)
+module Server = Cohttp_lwt_unix.Server
+module Static = Cohttp_mirage.Static.HTTP (Store) (Server)
+
+let request_fn uri headers =
+  Cohttp.Header.add headers "x-served-by"
+    (Printf.sprintf "cohttp-mirage static (%s)" (Uri.path uri))
+
+let () =
+  let docroot = if Array.length Sys.argv > 1 then Sys.argv.(1) else "htdocs" in
+  let port =
+    if Array.length Sys.argv > 2 then int_of_string Sys.argv.(2) else 8080
+  in
+  Fmt_tty.setup_std_outputs ();
+  Logs.set_level (Some Logs.Info);
+  Logs.set_reporter (Logs_fmt.reporter ());
+  Logs.info (fun f -> f "serving %s on http://0.0.0.0:%d/" docroot port);
+  Lwt_main.run
+    (Static.start ~http_port:port ~request_fn (Dir.connect docroot)
+       (fun (`TCP port) spec -> Server.create ~mode:(`TCP (`Port port)) spec))

--- a/cohttp-mirage/src/dune
+++ b/cohttp-mirage/src/dune
@@ -10,5 +10,4 @@
   mirage-channel
   mirage-kv
   mirage-flow
-  magic-mime
-  astring))
+  magic-mime))

--- a/cohttp-mirage/src/static.ml
+++ b/cohttp-mirage/src/static.ml
@@ -37,35 +37,28 @@ module HTTP (FS : Mirage_kv.RO) (S : Cohttp_lwt.S.Server) = struct
     | Error e -> Fmt.failwith "exists %a" FS.pp_error e
 
   let dispatcher request_fn =
-    let rec fn fs uri =
-      match Cohttp.Path.normalise uri with
-      | "" ->
-          Logs.info (fun f -> f "request for '%s'" (Uri.path uri));
-          fn fs (Uri.with_path uri "index.html")
-      | path ->
-          Logs.info (fun f -> f "request for '%s'" path);
-          Lwt.catch
-            (fun () ->
-              read_fs fs path >>= fun body ->
-              let mime_type = Magic_mime.lookup path in
-              let headers = Cohttp.Header.init_with "content-type" mime_type in
-              let headers =
-                match request_fn with
-                | None -> headers
-                | Some fn -> fn uri headers
-              in
-              S.respond_string ~status:`OK ~body ~headers ())
-            (fun _exn ->
-              let with_index = Fmt.str "%s/index.html" path in
-              exists fs with_index >>= function
-              | true ->
-                  (* [with_path] expects an encoded path, and [path] has
-                     already been decoded by [normalise]. *)
-                  let encoded = Uri.pct_encode ~component:`Path with_index in
-                  fn fs (Uri.with_path uri encoded)
-              | false -> S.respond_not_found ())
+    let respond uri path body =
+      let mime_type = Magic_mime.lookup path in
+      let headers = Cohttp.Header.init_with "content-type" mime_type in
+      let headers =
+        match request_fn with None -> headers | Some fn -> fn uri headers
+      in
+      S.respond_string ~status:`OK ~body ~headers ()
     in
-    fn
+    fun fs uri ->
+      let path =
+        match Cohttp.Path.normalise uri with
+        | "" -> "index.html" | path -> path
+      in
+      Logs.info (fun f -> f "request for '%s'" path);
+      Lwt.try_bind
+        (fun () -> read_fs fs path)
+        (respond uri path)
+        (fun _exn ->
+          let with_index = path ^ "/index.html" in
+          exists fs with_index >>= function
+          | true -> read_fs fs with_index >>= respond uri with_index
+          | false -> S.respond_not_found ())
 
   let start ~http_port ?request_fn fs http =
     let callback (_, cid) request _body =

--- a/cohttp-mirage/src/static.ml
+++ b/cohttp-mirage/src/static.ml
@@ -46,7 +46,8 @@ module HTTP (FS : Mirage_kv.RO) (S : Cohttp_lwt.S.Server) = struct
       | path when String.is_suffix ~affix:"/" path ->
           Logs.info (fun f -> f "request for '%s'" path);
           fn fs (Uri.with_path uri "index.html")
-      | path ->
+      | _ ->
+          let path = Cohttp.Path.normalise uri in
           Logs.info (fun f -> f "request for '%s'" path);
           Lwt.catch
             (fun () ->

--- a/cohttp-mirage/src/static.ml
+++ b/cohttp-mirage/src/static.ml
@@ -22,7 +22,6 @@ module Connection = Cohttp.Connection [@@warning "-3"]
 
 module HTTP (FS : Mirage_kv.RO) (S : Cohttp_lwt.S.Server) = struct
   open Lwt.Infix
-  open Astring
 
   let failf fmt = Fmt.failwith fmt
 
@@ -39,15 +38,11 @@ module HTTP (FS : Mirage_kv.RO) (S : Cohttp_lwt.S.Server) = struct
 
   let dispatcher request_fn =
     let rec fn fs uri =
-      match Uri.path uri with
-      | ("" | "/") as path ->
-          Logs.info (fun f -> f "request for '%s'" path);
+      match Cohttp.Path.normalise uri with
+      | "" ->
+          Logs.info (fun f -> f "request for '%s'" (Uri.path uri));
           fn fs (Uri.with_path uri "index.html")
-      | path when String.is_suffix ~affix:"/" path ->
-          Logs.info (fun f -> f "request for '%s'" path);
-          fn fs (Uri.with_path uri "index.html")
-      | _ ->
-          let path = Cohttp.Path.normalise uri in
+      | path ->
           Logs.info (fun f -> f "request for '%s'" path);
           Lwt.catch
             (fun () ->
@@ -63,7 +58,11 @@ module HTTP (FS : Mirage_kv.RO) (S : Cohttp_lwt.S.Server) = struct
             (fun _exn ->
               let with_index = Fmt.str "%s/index.html" path in
               exists fs with_index >>= function
-              | true -> fn fs (Uri.with_path uri with_index)
+              | true ->
+                  (* [with_path] expects an encoded path, and [path] has
+                     already been decoded by [normalise]. *)
+                  let encoded = Uri.pct_encode ~component:`Path with_index in
+                  fn fs (Uri.with_path uri encoded)
               | false -> S.respond_not_found ())
     in
     fn

--- a/cohttp-mirage/src/static.ml
+++ b/cohttp-mirage/src/static.ml
@@ -50,7 +50,7 @@ module HTTP (FS : Mirage_kv.RO) (S : Cohttp_lwt.S.Server) = struct
         match Cohttp.Path.normalise uri with
         | "" -> "index.html" | path -> path
       in
-      Logs.info (fun f -> f "request for '%s'" path);
+      Logs.info (fun f -> f "request for %S" path);
       Lwt.try_bind
         (fun () -> read_fs fs path)
         (respond uri path)

--- a/cohttp-mirage/test/dune
+++ b/cohttp-mirage/test/dune
@@ -1,0 +1,10 @@
+(executable
+ (name test_static)
+ (modules test_static)
+ (libraries cohttp-mirage cohttp-lwt cohttp http lwt mirage-kv uri alcotest))
+
+(rule
+ (alias runtest)
+ (package cohttp-mirage)
+ (action
+  (run ./test_static.exe)))

--- a/cohttp-mirage/test/test_static.ml
+++ b/cohttp-mirage/test/test_static.ml
@@ -1,0 +1,216 @@
+(* Tests for [Cohttp_mirage.Static.HTTP]. *)
+
+let run p =
+  match Lwt.state p with
+  | Lwt.Return v -> v
+  | Lwt.Fail e -> raise e
+  | Lwt.Sleep -> Alcotest.fail "promise did not resolve"
+
+(* An in-memory [Mirage_kv.RO] over a list of (key, contents) pairs. *)
+module Mock_fs : sig
+  include Mirage_kv.RO
+  val create : (string * string) list -> t
+end = struct
+  type t = (string * string) list
+  type key = Mirage_kv.Key.t
+  type error = Mirage_kv.error
+
+  let pp_error = Mirage_kv.pp_error
+  let create entries = entries
+  let disconnect _ = Lwt.return_unit
+  let path key = String.concat "/" (Mirage_kv.Key.segments key)
+
+  let is_dictionary t path =
+    let prefix = path ^ "/" in
+    List.exists (fun (k, _) -> String.starts_with ~prefix k) t
+
+  let get t key =
+    let path = path key in
+    match List.assoc_opt path t with
+    | Some contents -> Lwt.return (Ok contents)
+    | None when is_dictionary t path ->
+        Lwt.return (Error (`Value_expected key))
+    | None -> Lwt.return (Error (`Not_found key))
+
+  let exists t key =
+    let path = path key in
+    if List.mem_assoc path t then Lwt.return (Ok (Some `Value))
+    else if is_dictionary t path then Lwt.return (Ok (Some `Dictionary))
+    else Lwt.return (Ok None)
+
+  let unsupported _ = Alcotest.fail "unexpected key-value store operation"
+  let get_partial _ _ ~offset:_ ~length:_ = unsupported ()
+  let list _ _ = unsupported ()
+  let last_modified _ _ = unsupported ()
+  let digest _ _ = unsupported ()
+  let size _ _ = unsupported ()
+end
+
+module Mock_server : sig
+  include Cohttp_lwt.S.Server
+  val serve : t -> string -> (Http.Response.t * Cohttp_lwt.Body.t) Lwt.t
+end = struct
+  module IO = struct
+    type 'a t = 'a Lwt.t
+
+    let ( >>= ) = Lwt.bind
+    let return = Lwt.return
+
+    type ic = unit
+    type oc = unit
+    type conn = unit
+    type error = |
+
+    let refill () = Lwt.return `Eof
+    let with_input_buffer () ~f = fst (f "" ~pos:0 ~len:0)
+    let read_line () = Lwt.return None
+    let read () _ = Lwt.return ""
+    let write () _ = Lwt.return_unit
+    let flush () = Lwt.return_unit
+    let catch f = Lwt.map Result.ok (f ())
+    let pp_error _ = function (_ : error) -> .
+  end
+
+  type body = Cohttp_lwt.Body.t
+  type conn = IO.conn * Cohttp.Connection.t [@@warning "-3"]
+  type response = Http.Response.t * body
+
+  type response_action =
+    [ `Expert of Http.Response.t * (IO.ic -> IO.oc -> unit IO.t)
+    | `Response of response ]
+
+  type t = { handler : conn -> Http.Request.t -> body -> response Lwt.t }
+
+  let make ?conn_closed:_ ~callback () = { handler = callback }
+
+  let unsupported _ = Alcotest.fail "unexpected server operation"
+  let make_response_action ?conn_closed:_ ~callback:_ () = unsupported ()
+  let make_expert ?conn_closed:_ ~callback:_ () = unsupported ()
+  let callback _ _ _ _ = unsupported ()
+  let resolve_local_file ~docroot ~uri = Cohttp.Path.resolve_local_file ~docroot ~uri
+
+  let respond ?(headers = Http.Header.init ()) ~status ~body () =
+    Lwt.return (Http.Response.make ~status ~headers (), body)
+
+  let respond_string ?headers ~status ~body () =
+    respond ?headers ~status ~body:(`String body) ()
+
+  let respond_error ?headers ?(status = `Internal_server_error) ~body () =
+    respond_string ?headers ~status ~body ()
+
+  let respond_redirect ?(headers = Http.Header.init ()) ~uri () =
+    let headers = Http.Header.add headers "location" (Uri.to_string uri) in
+    respond_string ~headers ~status:`Found ~body:"" ()
+
+  let respond_need_auth ?(headers = Http.Header.init ()) ~auth () =
+    let headers = Cohttp.Header.add_authorization_req headers auth in
+    respond_string ~headers ~status:`Unauthorized ~body:"" ()
+
+  let respond_not_found ?uri:_ () =
+    respond_string ~status:`Not_found ~body:"Not found" ()
+
+  let serve t target =
+    let request = Http.Request.make ~meth:`GET target in
+    t.handler ((), Cohttp.Connection.create () [@warning "-3"]) request `Empty
+end
+
+module Static = Cohttp_mirage.Static.HTTP (Mock_fs) (Mock_server)
+
+let store =
+  Mock_fs.create
+    [
+      ("index.html", "root index");
+      ("foo/index.html", "foo index");
+      ("foo/bar/index.html", "foo/bar index");
+      ("style.css", "css body");
+      ("my file.txt", "spaced");
+    ]
+
+let request ?request_fn target =
+  let t = Static.start ~http_port:8080 ?request_fn store (fun _ t -> t) in
+  let response, body = run (Mock_server.serve t target) in
+  (response, run (Cohttp_lwt.Body.to_string body))
+
+let check_served name ~target ~expected =
+  let response, body = request target in
+  Alcotest.(check int)
+    (name ^ ": status")
+    200
+    (Http.Status.to_int (Http.Response.status response));
+  Alcotest.(check string) (name ^ ": body") expected body
+
+let check_not_found name ~target =
+  let response, _ = request target in
+  Alcotest.(check int)
+    (name ^ ": status")
+    404
+    (Http.Status.to_int (Http.Response.status response))
+
+let test_index_pages () =
+  check_served "root" ~target:"/" ~expected:"root index";
+  check_served "directory" ~target:"/foo" ~expected:"foo index";
+  check_served "directory trailing slash" ~target:"/foo/"
+    ~expected:"foo index";
+  check_served "nested directory" ~target:"/foo/bar" ~expected:"foo/bar index";
+  check_served "nested directory trailing slash" ~target:"/foo/bar/"
+    ~expected:"foo/bar index";
+  check_served "empty segments collapsed" ~target:"/foo//bar/"
+    ~expected:"foo/bar index"
+
+let test_files () =
+  check_served "file" ~target:"/style.css" ~expected:"css body";
+  check_not_found "missing file" ~target:"/nope.css";
+  check_not_found "missing directory" ~target:"/nope/"
+
+let test_content_type () =
+  let response, _ = request "/style.css" in
+  Alcotest.(check (option string))
+    "css content-type" (Some "text/css")
+    (Http.Header.get (Http.Response.headers response) "content-type");
+  let response, _ = request "/foo/" in
+  Alcotest.(check (option string))
+    "index content-type is that of the page served, not the directory"
+    (Some "text/html")
+    (Http.Header.get (Http.Response.headers response) "content-type")
+
+let test_traversal_clamped () =
+  check_served "dot-dot" ~target:"/foo/../style.css" ~expected:"css body";
+  check_served "dot-dot above root" ~target:"/../../style.css"
+    ~expected:"css body";
+  check_served "encoded slash" ~target:"/..%2f..%2fstyle.css"
+    ~expected:"css body";
+  check_served "fully encoded" ~target:"/%2e%2e%2f%2e%2e%2fstyle.css"
+    ~expected:"css body";
+  check_served "encoded slash into directory index"
+    ~target:"/foo%2fbar%2f" ~expected:"foo/bar index"
+
+(* Percent-decoding should happens exactly once. *)
+let test_single_decode () =
+  check_served "encoded space" ~target:"/my%20file.txt" ~expected:"spaced";
+  check_not_found "double encoded slash" ~target:"/..%252f..%252fstyle.css";
+  check_not_found "double encoded, fully"
+    ~target:"/%252e%252e%252fstyle.css"
+
+let test_request_fn () =
+  let request_fn uri headers =
+    Http.Header.add headers "x-request-uri" (Uri.path uri)
+  in
+  let response, body = request ~request_fn "/foo/" in
+  Alcotest.(check string) "index still served" "foo index" body;
+  Alcotest.(check (option string))
+    "request_fn sees the request URI" (Some "/foo/")
+    (Http.Header.get (Http.Response.headers response) "x-request-uri")
+
+let () =
+  Alcotest.run "cohttp-mirage static"
+    [
+      ( "paths",
+        [
+          ("index pages", `Quick, test_index_pages);
+          ("files", `Quick, test_files);
+          ("content types", `Quick, test_content_type);
+          ("traversal clamped to root", `Quick, test_traversal_clamped);
+          ("single percent-decode", `Quick, test_single_decode);
+          ("request_fn", `Quick, test_request_fn);
+        ] );
+    ]

--- a/cohttp/src/path.ml
+++ b/cohttp/src/path.ml
@@ -1,7 +1,15 @@
-let resolve_local_file ~docroot ~uri =
-  let path = Uri.(pct_decode (path (resolve "http" (of_string "/") uri))) in
-  let rel_path =
-    if String.length path > 0 then String.sub path 1 (String.length path - 1)
-    else ""
+let remove_dot_segments path =
+  let rec go acc = function
+    | [] -> List.rev acc
+    | ("" | ".") :: rest -> go acc rest
+    | ".." :: rest -> (
+        match acc with [] -> go [] rest | _ :: tl -> go tl rest)
+    | seg :: rest -> go (seg :: acc) rest
   in
-  Filename.concat docroot rel_path
+  path |> String.split_on_char '/' |> go [] |> String.concat "/"
+
+let normalise uri =
+  uri |> Uri.path |> Uri.pct_decode |> remove_dot_segments
+
+let resolve_local_file ~docroot ~uri =
+  Filename.concat docroot (normalise uri)

--- a/cohttp/src/path.mli
+++ b/cohttp/src/path.mli
@@ -1,6 +1,15 @@
 val resolve_local_file : docroot:string -> uri:Uri.t -> string
 (** Resolve the given URI to a local file in the given docroot.
 
-    This decodes and normalises the Uri. It strips out .. characters so that the
-    request will not escape the docroot. The returned filepath is fully
-    qualified iff the given docroot is fully qualified. *)
+    This is [Filename.concat docroot (normalise uri)]. It decodes percent-encoding
+    once and removes [..] segments so that the request cannot escape the docroot.
+    The returned filepath is fully qualified iff the given docroot is fully
+    qualified. *)
+
+val normalise : Uri.t -> string
+(** [normalise uri] returns the path of [uri] with percent-encoding decoded
+    exactly once and [.]/[..] segments resolved, as a relative path that can
+    never ascend above its root.
+
+    Use this to derive a lookup key from a request URI, for example a
+    filesystem path or a key-value store key. *)

--- a/cohttp/test/test_path.ml
+++ b/cohttp/test/test_path.ml
@@ -70,6 +70,50 @@ let test_resolve_local_file () =
       ("cwd-docroot cwd", ".", "./buzz", "./buzz");
       ("cwd-docroot blank-path", ".", "https://example.com", "./");
       ("cwd-docroot blank-uri", ".", "", "./");
+      ( "percent-encoded slash grandparent blocked",
+        "/foo/bar/baz",
+        "..%2f..%2fbuzz",
+        "/foo/bar/baz/buzz" );
+      ( "fully percent-encoded grandparent blocked",
+        "/foo/bar/baz",
+        "%2e%2e%2f%2e%2e%2fbuzz",
+        "/foo/bar/baz/buzz" );
+      ( "double percent-encoded grandparent blocked",
+        "/foo/bar/baz",
+        "..%252f..%252fbuzz",
+        "/foo/bar/baz/..%2f..%2fbuzz" );
+      ( "double fully percent-encoded grandparent blocked",
+        "/foo/bar/baz",
+        "%252e%252e%252f%252e%252e%252fbuzz",
+        "/foo/bar/baz/%2e%2e%2f%2e%2e%2fbuzz" );
+      ( "triply percent-encoded grandparent blocked",
+        "/foo/bar/baz",
+        "..%25252f..%25252fbuzz",
+        "/foo/bar/baz/..%252f..%252fbuzz" );
+      ( "encoded space preserved",
+        "/foo/bar/baz",
+        "/my%20file.txt",
+        "/foo/bar/baz/my file.txt" );
+      ( "encoded utf8 preserved",
+        "/foo/bar/baz",
+        "/caf%C3%A9.txt",
+        "/foo/bar/baz/caf\xc3\xa9.txt" );
+      ( "encoded NUL preserved",
+        "/foo/bar/baz",
+        "/secret%00.txt",
+        "/foo/bar/baz/secret\x00.txt" );
+      ( "encoded newline preserved",
+        "/foo/bar/baz",
+        "/a%0ab.txt",
+        "/foo/bar/baz/a\nb.txt" );
+      ( "encoded DEL preserved",
+        "/foo/bar/baz",
+        "/a%7fb.txt",
+        "/foo/bar/baz/a\x7fb.txt" );
+      ( "encoded control does not collapse onto plain name",
+        "/foo/bar/baz",
+        "/sol%001.html",
+        "/foo/bar/baz/sol\x001.html" )
     ]
   in
   List.iter
@@ -79,10 +123,43 @@ let test_resolve_local_file () =
         (Cohttp.Path.resolve_local_file ~docroot ~uri:(Uri.of_string uri)))
     tests
 
+let test_normalise () =
+  let tests =
+    [
+      ("relative simple", "/foo/bar", "foo/bar");
+      ("relative dot", "/foo/./bar", "foo/bar");
+      ("relative grandparent blocked", "/../../etc/passwd", "etc/passwd");
+      ("encoded slash traversal blocked", "/..%2f..%2fetc/passwd", "etc/passwd");
+      ("absolute-form grandparent blocked", "http://host/../../etc/passwd",
+       "etc/passwd");
+      ( "absolute-form deep grandparent blocked",
+        "https://example.com/a/../../../../etc/shadow",
+        "etc/shadow" );
+      ("encoded control preserved", "/sol%001.html", "sol\x001.html");
+      ("plain slash separator", "/private/secret.txt", "private/secret.txt");
+      ( "backslash preserved, distinct from slash",
+        "/private%5csecret.txt",
+        "private\\secret.txt" );
+      ( "encoded backslash traversal preserved verbatim",
+        "/..%5c..%5cwindows",
+        "..\\..\\windows" );
+    ]
+  in
+  List.iter
+    (fun (name, uri, expected) ->
+      Alcotest.(check string)
+        name expected
+        (Cohttp.Path.normalise (Uri.of_string uri)))
+    tests
+
 let () = Printexc.record_backtrace true
 
 let () =
   Alcotest.run "test_path"
     [
-      ("Path", [ ("Check resolve_local_file", `Quick, test_resolve_local_file) ]);
+      ( "Path",
+        [
+          ("Check resolve_local_file", `Quick, test_resolve_local_file);
+          ("Check normalise", `Quick, test_normalise);
+        ] );
     ]

--- a/cohttp/test/test_path.ml
+++ b/cohttp/test/test_path.ml
@@ -135,6 +135,11 @@ let test_normalise () =
       ( "absolute-form deep grandparent blocked",
         "https://example.com/a/../../../../etc/shadow",
         "etc/shadow" );
+      ("root path empty", "/", "");
+      ("empty path", "", "");
+      ("trailing slash dropped", "/foo/bar/", "foo/bar");
+      ("encoded trailing slash dropped", "/foo/bar%2f", "foo/bar");
+      ("empty segments collapsed", "/foo//bar", "foo/bar");
       ("encoded control preserved", "/sol%001.html", "sol\x001.html");
       ("plain slash separator", "/private/secret.txt", "private/secret.txt");
       ( "backslash preserved, distinct from slash",

--- a/dune-project
+++ b/dune-project
@@ -250,7 +250,6 @@
    (>= 6.0.0))
   (fmt
    (>= 0.8.7))
-  astring
   magic-mime
   (ppx_sexp_conv
    (>= v0.13.0))

--- a/dune-project
+++ b/dune-project
@@ -253,6 +253,10 @@
   magic-mime
   (ppx_sexp_conv
    (>= v0.13.0))
+  (alcotest
+   (and
+    :with-test
+    (>= 1.7.0)))
   (cohttp
    (= :version))))
 

--- a/flake.nix
+++ b/flake.nix
@@ -117,9 +117,10 @@
           };
           cohttp-mirage = pkg {
             pname = "cohttp-mirage";
+            checkInputs = [ alcotest ];
             propagatedBuildInputs = [
               mirage-flow mirage-channel conduit conduit-mirage
-              mirage-kv lwt cohttp-lwt cstruct fmt astring magic-mime ppx_sexp_conv
+              mirage-kv lwt cohttp-lwt cstruct fmt magic-mime ppx_sexp_conv
             ];
           };
           cohttp-bench = pkg {


### PR DESCRIPTION
This patch prevents escaping the docroot in resolve_local_file via urlencoded components. In order to prevent request path gating, it also exposes a new `normalise` function that can be called when splitting paths to apply the same logic; e.g.

```
let callback _conn req _body =
    let path = Cohttp.Path.normalise (Cohttp.Request.uri req) in
    match String.split_on_char '/' path with
    | "admin" :: _ when not (authorised req) -> Server.respond_not_found ()
    | _ -> Server.respond_file ~fname:path ()
```

This also applies the change to cohttp-mirage. The change affects cohttp-lwt, cohttp-mirage and cohttp-async, but not cohttp-eio which uses its own path resolution mechanism.