### PR TITLE
Add write_bigstring_body

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+- cohttp: add `write_bigstring_body`, so a response or request body that already
+  lives outside the OCaml heap reaches the socket without being copied onto it.
+  `Cohttp_lwt.Body` gains a `` `Bigstring `` case and `to_bigstring` for the
+  other direction. `of_bigstring` takes `` `Copy `` or `` `Passthrough `` to say
+  whether the connection may write out of the caller's buffer, which the
+  cohttp-eio, cohttp-async and cohttp-mirage backends do without copying
+  (@toots, #1146)
+
 ## v6.3.0 (2026-08-20)
 
 - cohttp: `Cohttp.Path.resolve_local_file` no longer escapes the docroot when

--- a/cohttp-async/src/io.ml
+++ b/cohttp-async/src/io.ml
@@ -97,6 +97,12 @@ module IO = struct
         Writer.write oc buf;
         return ())
 
+  let write_bigstring oc buf off len =
+    (match buf with
+    | `Copy buf -> Writer.write_bigstring oc ~pos:off ~len buf
+    | `Passthrough buf -> Writer.schedule_bigstring oc ~pos:off ~len buf);
+    return ()
+
   let refill ic = Input_channel.refill ic
   let with_input_buffer ic = Input_channel.with_input_buffer ic
   let flush = Writer.flushed

--- a/cohttp-eio/src/io.ml
+++ b/cohttp-eio/src/io.ml
@@ -50,6 +50,12 @@ module IO = struct
     let () = Logs.debug (fun f -> f ">>> %s" (String.trim string)) in
     Eio.Buf_write.string oc string
 
+  let write_bigstring oc buf off len =
+    match buf with
+    | `Copy buf -> Eio.Buf_write.cstruct oc (Cstruct.of_bigarray ~off ~len buf)
+    | `Passthrough buf ->
+        Eio.Buf_write.schedule_cstruct oc (Cstruct.of_bigarray ~off ~len buf)
+
   let flush = Eio.Buf_write.flush
 end
 

--- a/cohttp-eio/tests/dune
+++ b/cohttp-eio/tests/dune
@@ -11,3 +11,9 @@
  (modules test_forward_proxy)
  (libraries alcotest cohttp-eio eio eio.mock eio_main logs.fmt)
  (package cohttp-eio))
+
+(test
+ (name test_write_bigstring)
+ (modules test_write_bigstring)
+ (libraries alcotest cohttp cohttp-eio eio eio_main)
+ (package cohttp-eio))

--- a/cohttp-eio/tests/test_write_bigstring.ml
+++ b/cohttp-eio/tests/test_write_bigstring.ml
@@ -1,0 +1,35 @@
+module IO = Cohttp_eio.Private.IO
+
+let bigstring_of_string s =
+  let len = String.length s in
+  let t = Cohttp.Bigstring.create len in
+  Cohttp.Bigstring.blit_from_string s ~src_off:0 t ~dst_off:0 ~len;
+  t
+
+let written f =
+  let buffer = Buffer.create 16 in
+  Eio_main.run @@ fun _env ->
+  Eio.Buf_write.with_flow (Eio.Flow.buffer_sink buffer) f;
+  Buffer.contents buffer
+
+(* `Passthrough takes eio's scheduling path, `Copy its buffered one; both must
+   land in order with the surrounding string writes. *)
+let interleaved tag () =
+  let bigstring = bigstring_of_string "xbodyx" in
+  Alcotest.(check string)
+    "in order" "headbodytail"
+    (written (fun oc ->
+         IO.write oc "head";
+         IO.write_bigstring oc (tag bigstring) 1 4;
+         IO.write oc "tail"))
+
+let () =
+  Alcotest.run "cohttp-eio write_bigstring"
+    [
+      ( "write_bigstring",
+        [
+          Alcotest.test_case "copy" `Quick (interleaved (fun b -> `Copy b));
+          Alcotest.test_case "passthrough" `Quick
+            (interleaved (fun b -> `Passthrough b));
+        ] );
+    ]

--- a/cohttp-lwt-unix/src/io.ml
+++ b/cohttp-lwt-unix/src/io.ml
@@ -73,6 +73,14 @@ let write oc buf =
   Log.debug (fun f -> f ">>> %s" (String.trim buf));
   Lwt_io.write oc buf
 
+(* [Lwt_io] cannot write out of a foreign buffer, and the channel may be a TLS
+   wrapper rather than a file descriptor to bypass it with. *)
+let write_bigstring oc buf off len =
+  let buf = Cohttp.Bigstring.buffer buf in
+  wrap_write @@ fun () ->
+  Log.debug (fun f -> f ">>>[%d] <bigstring>" len);
+  Lwt_io.write_from_exactly_bigstring oc buf off len
+
 let flush oc = wrap_write @@ fun () -> Lwt_io.flush oc
 
 type error = exn

--- a/cohttp-lwt-unix/test/test_client.ml
+++ b/cohttp-lwt-unix/test/test_client.ml
@@ -179,7 +179,7 @@ let test_unknown uri =
             match body with
             (* Still, body may have been (partially) consumed and needs re-creation. *)
             | Some (`Stream _) -> raise Connection.Retry
-            | None | Some (`Empty | `String _ | `Strings _) ->
+            | None | Some (`Empty | `String _ | `Strings _ | `Bigstring _) ->
                 handler ?headers ?body meth uri)
         | e -> Lwt.reraise e)
   in

--- a/cohttp-lwt/src/body.ml
+++ b/cohttp-lwt/src/body.ml
@@ -18,8 +18,18 @@ module Body = Cohttp.Body
 module Transfer = Cohttp.Transfer
 open Lwt
 
-type t = [ Body.t | `Stream of (string Lwt_stream.t[@sexp.opaque]) ]
+type t =
+  [ Body.t
+  | `Stream of (string Lwt_stream.t[@sexp.opaque])
+  | `Bigstring of (Cohttp.Bigstring.write[@sexp.opaque]) ]
 [@@deriving sexp]
+
+let bigstring_length b = Cohttp.Bigstring.length (Cohttp.Bigstring.buffer b)
+
+let bigstring_to_string buf =
+  Cohttp.Bigstring.sub_string
+    (Cohttp.Bigstring.buffer buf)
+    ~off:0 ~len:(bigstring_length buf)
 
 let empty = (Body.empty :> t)
 
@@ -39,6 +49,7 @@ let create_stream fn arg =
 let is_empty (body : t) =
   match body with
   | #Body.t as body -> return (Body.is_empty body)
+  | `Bigstring b -> return (bigstring_length b = 0)
   | `Stream s ->
       Lwt_stream.get_while (fun x -> x = "") s >>= fun _ ->
       Lwt_stream.is_empty s
@@ -46,6 +57,7 @@ let is_empty (body : t) =
 let to_string (body : t) =
   match body with
   | #Body.t as body -> return (Body.to_string body)
+  | `Bigstring b -> return (bigstring_to_string b)
   | `Stream s ->
       let b = Buffer.create 1024 in
       Lwt_stream.iter (Buffer.add_string b) s >>= fun () ->
@@ -54,27 +66,60 @@ let to_string (body : t) =
 let to_string_list (body : t) =
   match body with
   | #Body.t as body -> return (Body.to_string_list body)
+  | `Bigstring b -> return [ bigstring_to_string b ]
   | `Stream s -> Lwt_stream.to_list s
 
 let of_string s = (Body.of_string s :> t)
+
+let bigstring_of_string s =
+  let len = String.length s in
+  let out = Cohttp.Bigstring.create len in
+  Cohttp.Bigstring.blit_from_string s ~src_off:0 out ~dst_off:0 ~len;
+  out
+
+let to_bigstring (body : t) =
+  match body with
+  | `Bigstring b -> return (Cohttp.Bigstring.buffer b)
+  | #Body.t as b -> return (bigstring_of_string (Body.to_string b))
+  | `Stream st ->
+      let out = ref (Cohttp.Bigstring.create 0) and len = ref 0 in
+      let add s =
+        let n = String.length s in
+        let cap = Cohttp.Bigstring.length !out in
+        if !len + n > cap then (
+          let grown = ref (max cap 65536) in
+          while !len + n > !grown do
+            grown := !grown * 2
+          done;
+          let bigger = Cohttp.Bigstring.create !grown in
+          Cohttp.Bigstring.blit !out ~src_off:0 bigger ~dst_off:0 ~len:!len;
+          out := bigger);
+        Cohttp.Bigstring.blit_from_string s ~src_off:0 !out ~dst_off:!len ~len:n;
+        len := !len + n
+      in
+      Lwt_stream.iter add st >>= fun () ->
+      return (Cohttp.Bigstring.sub !out ~off:0 ~len:!len)
 
 let to_stream (body : t) =
   match body with
   | `Empty -> Lwt_stream.of_list []
   | `Stream s -> s
+  | `Bigstring b -> Lwt_stream.of_list [ bigstring_to_string b ]
   | `String s -> Lwt_stream.of_list [ s ]
   | `Strings sl -> Lwt_stream.of_list sl
 
 let drain_body (body : t) =
   match body with
-  | `Empty | `String _ | `Strings _ -> return_unit
+  | `Empty | `String _ | `Strings _ | `Bigstring _ -> return_unit
   | `Stream s -> Lwt_stream.junk_while (fun _ -> true) s
 
 let of_string_list l = `Strings l
 let of_stream s = `Stream s
+let of_bigstring b = `Bigstring b
 
 let transfer_encoding = function
   | #Body.t as t -> Body.transfer_encoding t
+  | `Bigstring b -> Transfer.Fixed (Int64.of_int (bigstring_length b))
   | `Stream _ -> Transfer.Chunked
 
 (* This will consume the body and return a length, and a
@@ -82,21 +127,27 @@ let transfer_encoding = function
 let length (body : t) : (int64 * t) Lwt.t =
   match body with
   | #Body.t as body -> return (Body.length body, body)
+  | `Bigstring b as body -> return (Int64.of_int (bigstring_length b), body)
   | `Stream _ ->
       to_string body >>= fun buf ->
       let len = Int64.of_int (String.length buf) in
       return (len, `String buf)
 
-let write_body fn = function
+let write_body ?write_bigstring fn = function
   | `Empty -> return_unit
   | `Stream st -> Lwt_stream.iter_s fn st
   | `String s -> fn s
   | `Strings sl -> Lwt_list.iter_s fn sl
+  | `Bigstring b -> (
+      match write_bigstring with
+      | Some write -> write b 0 (bigstring_length b)
+      | None -> fn (bigstring_to_string b))
 
 let map f t =
   match t with
   | #Body.t as t -> (Body.map f t :> t)
   | `Stream s -> `Stream (Lwt_stream.map f s)
+  | `Bigstring b -> `String (f (bigstring_to_string b))
 
 let to_form (body : t) = to_string body >|= Uri.query_of_encoded
 let of_form ?scheme f = Uri.encoded_of_query ?scheme f |> of_string

--- a/cohttp-lwt/src/body.mli
+++ b/cohttp-lwt/src/body.mli
@@ -14,20 +14,57 @@
  *
   }}}*)
 
-type t = [ Cohttp.Body.t | `Stream of string Lwt_stream.t ] [@@deriving sexp]
+type t =
+  [ Cohttp.Body.t
+  | `Stream of string Lwt_stream.t
+  | `Bigstring of Cohttp.Bigstring.write ]
+[@@deriving sexp]
 
 include Cohttp.S.Body with type t := t
 
 val is_empty : t -> bool Lwt.t
 val to_string : t -> string Lwt.t
+
+val to_bigstring : t -> Cohttp.Bigstring.t Lwt.t
+(** The whole body as bytes outside the OCaml heap. A body made by
+    {!of_bigstring} hands back the buffer it was given rather than a copy. *)
+
 val to_string_list : t -> string list Lwt.t
 val to_stream : t -> string Lwt_stream.t
 val of_stream : string Lwt_stream.t -> t
+
+val of_bigstring : Cohttp.Bigstring.write -> t
+(** A body whose bytes are already off the heap, so sending it never builds a
+    body-sized string.
+
+    The tag says what the connection may do with the buffer, and there is no
+    default because only the caller knows:
+
+    - [`Copy] for a buffer that is about to be reused or refilled -- a scratch
+      block a read loop writes into, say. The bytes are taken before the send
+      completes.
+    - [`Passthrough] for a buffer that will outlive the exchange untouched, such
+      as a memory-mapped file. It spares the last copy on the backends that can
+      write from foreign memory, and costs nothing on those that cannot.
+
+    [`Passthrough] leaves the bytes borrowed until the message carrying them has
+    been written, so touching them before the client call returns, or before the
+    server has finished serving the response, corrupts what goes out. When in
+    doubt [`Copy] is always safe. *)
+
 val to_form : t -> (string * string list) list Lwt.t
 
 val create_stream :
   ('a -> Cohttp.Transfer.chunk Lwt.t) -> 'a -> string Lwt_stream.t
 
 val length : t -> (int64 * t) Lwt.t
-val write_body : (string -> unit Lwt.t) -> t -> unit Lwt.t
+
+val write_body :
+  ?write_bigstring:(Cohttp.Bigstring.write -> int -> int -> unit Lwt.t) ->
+  (string -> unit Lwt.t) ->
+  t ->
+  unit Lwt.t
+(** Without [write_bigstring] a [`Bigstring] body is copied onto the heap to be
+    written as a string. *)
+
 val drain_body : t -> unit Lwt.t

--- a/cohttp-lwt/src/connection.ml
+++ b/cohttp-lwt/src/connection.ml
@@ -234,7 +234,11 @@ module Make (Net : S.Net) : S.Connection with module Net = Net = struct
           (fun () ->
             (* try *)
             Request.write ~flush:false
-              (fun writer -> Body.write_body (Request.write_body writer) body)
+              (fun writer ->
+                Body.write_body
+                  ~write_bigstring:(Request.write_bigstring_body writer)
+                  (Request.write_body writer)
+                  body)
               req oc)
           (fun e ->
             (* with *)

--- a/cohttp-lwt/src/connection_cache.ml
+++ b/cohttp-lwt/src/connection_cache.ml
@@ -23,7 +23,7 @@ module Make_no_cache (Connection : S.Connection) = struct
       (fun () ->
         res >>= fun (_, body) ->
         (match body with
-          | `Empty | `String _ | `Strings _ -> Lwt.return_unit
+          | `Empty | `String _ | `Strings _ | `Bigstring _ -> Lwt.return_unit
           | `Stream stream -> Lwt_stream.closed stream)
         >>= fun () ->
         Connection.close connection;
@@ -147,7 +147,11 @@ module Make (Connection : S.Connection) (Sleep : S.Sleep) = struct
           | Retry -> (
               match body with
               | Some (`Stream _) -> raise Retry
-              | None | Some `Empty | Some (`String _) | Some (`Strings _) ->
+              | None
+              | Some `Empty
+              | Some (`String _)
+              | Some (`Strings _)
+              | Some (`Bigstring _) ->
                   if retry <= 0 then raise Retry else request (retry - 1))
           | e -> Lwt.reraise e)
     in
@@ -217,7 +221,11 @@ end = struct
         | Retry -> (
             match body with
             | Some (`Stream _) -> Lwt.fail Retry
-            | None | Some `Empty | Some (`String _) | Some (`Strings _) ->
+            | None
+            | Some `Empty
+            | Some (`String _)
+            | Some (`Strings _)
+            | Some (`Bigstring _) ->
                 if retry <= 0 then Lwt.fail Retry
                 else
                   request conn ?headers ?body ?absolute_form meth uri (retry - 1)

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -117,7 +117,11 @@ module Make (IO : S.IO) = struct
   let handle_response ~keep_alive oc res body conn_closed handle_client =
     IO.catch (fun () ->
         Response.write ~flush:false
-          (fun writer -> Body.write_body (Response.write_body writer) body)
+          (fun writer ->
+            Body.write_body
+              ~write_bigstring:(Response.write_bigstring_body writer)
+              (Response.write_body writer)
+              body)
           res oc)
     >>= function
     | Ok () ->

--- a/cohttp-lwt/src/string_io.ml
+++ b/cohttp-lwt/src/string_io.ml
@@ -31,4 +31,10 @@ let with_input_buffer ic ~f = Sio.M.with_input_buffer ic ~f
 let read_line ic = return (Sio.M.read_line ic)
 let read ic n = return (Sio.M.read ic n)
 let write oc str = return (Sio.M.write oc str)
+
+(* A [Buffer] has no bigarray sink, so [`Passthrough] copies like [`Copy]. *)
+let write_bigstring oc buf off len =
+  let buf = Cohttp.Bigstring.buffer buf in
+  return (Sio.M.write oc (Cohttp.Bigstring.sub_string buf ~off ~len))
+
 let flush oc = return (Sio.M.flush oc)

--- a/cohttp-mirage/src/io.ml
+++ b/cohttp-mirage/src/io.ml
@@ -57,6 +57,16 @@ module Make (Channel : Mirage_channel.S) = struct
     | Error `Closed -> failwith "Trying to write on closed channel"
     | Error e -> raise (Write_exn e)
 
+  (* [write_buffer] takes the buffer without copying, and the flush below ends
+     the borrow before returning, which serves [`Copy] zero-copy as well. *)
+  let write_bigstring oc buf off len =
+    let buf = Cohttp.Bigstring.buffer buf in
+    Channel.write_buffer oc (Cstruct.of_bigarray ~off ~len buf);
+    Channel.flush oc >>= function
+    | Ok () -> Lwt.return_unit
+    | Error `Closed -> failwith "Trying to write on closed channel"
+    | Error e -> raise (Write_exn e)
+
   let flush _ =
     (* NOOP since we flush in the normal writer functions above *)
     Lwt.return_unit

--- a/cohttp/src/bigstring.ml
+++ b/cohttp/src/bigstring.ml
@@ -1,0 +1,28 @@
+type t = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+type write = [ `Copy of t | `Passthrough of t ]
+
+let buffer = function `Copy t | `Passthrough t -> t
+let create len = Bigarray.Array1.create Bigarray.char Bigarray.c_layout len
+let length = Bigarray.Array1.dim
+let sub t ~off ~len = Bigarray.Array1.sub t off len
+
+let check name ~size ~off ~len =
+  if off < 0 || len < 0 || off > size - len then
+    invalid_arg
+      (Printf.sprintf "Cohttp.Bigstring.%s: off=%d len=%d out of bounds for %d"
+         name off len size)
+
+let blit src ~src_off dst ~dst_off ~len =
+  Bigarray.Array1.blit (sub src ~off:src_off ~len) (sub dst ~off:dst_off ~len)
+
+let blit_from_string s ~src_off t ~dst_off ~len =
+  check "blit_from_string" ~size:(String.length s) ~off:src_off ~len;
+  check "blit_from_string" ~size:(length t) ~off:dst_off ~len;
+  for i = 0 to len - 1 do
+    Bigarray.Array1.unsafe_set t (dst_off + i)
+      (String.unsafe_get s (src_off + i))
+  done
+
+let sub_string t ~off ~len =
+  check "sub_string" ~size:(length t) ~off ~len;
+  String.init len (fun i -> Bigarray.Array1.unsafe_get t (off + i))

--- a/cohttp/src/bigstring.mli
+++ b/cohttp/src/bigstring.mli
@@ -1,0 +1,41 @@
+(** Bytes outside the OCaml heap.
+
+    Spelled as the Bigarray type rather than taken from a library so that cohttp
+    gains no dependency: it is the same type as [Bigstringaf.t], [Lwt_bytes.t]
+    and Async's [Bigstring.t], so a caller holding any of them passes it
+    directly. *)
+
+type t = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+type write = [ `Copy of t | `Passthrough of t ]
+(** Whether the writer may hold on to a buffer being written.
+
+    [`Copy] means the bytes are taken before the write returns, so the caller
+    may reuse or modify the buffer straight after. [`Passthrough] permits the
+    writer to send them out of the caller's buffer instead, which spares a copy
+    but leaves the bytes borrowed until the write is flushed.
+
+    It is a permission, not a promise: a backend with no way to write from
+    foreign memory copies a [`Passthrough] buffer anyway. *)
+
+val buffer : write -> t
+(** The buffer either way, for a writer that copies regardless. *)
+
+val create : int -> t
+(** Uninitialised. *)
+
+val length : t -> int
+
+val sub : t -> off:int -> len:int -> t
+(** A view of [len] bytes from [off], sharing the bytes rather than copying. *)
+
+val blit : t -> src_off:int -> t -> dst_off:int -> len:int -> unit
+
+val blit_from_string :
+  string -> src_off:int -> t -> dst_off:int -> len:int -> unit
+
+val sub_string : t -> off:int -> len:int -> string
+(** Only for a caller whose result is a string anyway. *)
+
+(** Every function above raises [Invalid_argument] on a range that is not within
+    its argument. *)

--- a/cohttp/src/cohttp.ml
+++ b/cohttp/src/cohttp.ml
@@ -1,5 +1,6 @@
 module Accept = Accept
 module Auth = Auth
+module Bigstring = Bigstring
 module Body = Body
 module Conf = Conf
 module Connection = Connection

--- a/cohttp/src/request.ml
+++ b/cohttp/src/request.ml
@@ -206,6 +206,7 @@ module Make (IO : S.IO) = struct
     Transfer_IO.make_writer ~flush (Header.get_transfer_encoding req.headers) oc
 
   let write_body = Transfer_IO.write
+  let write_bigstring_body = Transfer_IO.write_bigstring
 
   let write_footer headers oc =
     match Header.get_transfer_encoding headers with

--- a/cohttp/src/response.ml
+++ b/cohttp/src/response.ml
@@ -118,6 +118,7 @@ module Make (IO : S.IO) = struct
     Transfer_IO.make_writer ~flush (encoding t) oc
 
   let write_body = Transfer_IO.write
+  let write_bigstring_body = Transfer_IO.write_bigstring
 
   let write_footer t oc =
     match encoding t with

--- a/cohttp/src/s.ml
+++ b/cohttp/src/s.ml
@@ -60,6 +60,17 @@ module type IO = sig
   (** [write oc s] will block until the complete [s] string is written to the
       output channel [oc]. *)
 
+  val write_bigstring : oc -> Bigstring.write -> int -> int -> unit t
+  (** [write_bigstring oc buf off len] writes [len] bytes of [buf] from [off] to
+      the output channel [oc].
+
+      [`Copy] takes the bytes before returning. [`Passthrough] permits writing
+      them straight out of the caller's buffer, so an implementation that does
+      so leaves them borrowed until the next {!flush} of [oc] completes -- not
+      merely until this returns. An implementation with no way to write from
+      foreign memory may copy a [`Passthrough] buffer; the tag grants a licence
+      rather than demanding zero copies. *)
+
   val flush : oc -> unit t
   (** [flush oc] will return when all previously buffered content from calling
       {!write} have been written to the output channel [oc]. *)
@@ -78,6 +89,12 @@ module type Http_io = sig
   val read_body_chunk : reader -> Transfer.chunk IO.t
   val write_header : t -> IO.oc -> unit IO.t
   val write_body : writer -> string -> unit IO.t
+
+  val write_bigstring_body :
+    writer -> Bigstring.write -> int -> int -> unit IO.t
+  (** {!write_body} for a body that is already off the heap. The [`Copy] and
+      [`Passthrough] tags mean what they do in {!IO.write_bigstring}. *)
+
   val write : flush:bool -> (writer -> unit IO.t) -> t -> IO.oc -> unit IO.t
 end
 

--- a/cohttp/src/string_io.ml
+++ b/cohttp/src/string_io.ml
@@ -83,5 +83,10 @@ module M = struct
     Buffer.add_string x s;
     return ()
 
+  (* A [Buffer] has no bigarray sink, so [`Passthrough] copies like [`Copy]. *)
+  let write_bigstring x buf off len =
+    Buffer.add_string x (Bigstring.sub_string (Bigstring.buffer buf) ~off ~len);
+    return ()
+
   let flush _x = return ()
 end

--- a/cohttp/src/transfer_io.ml
+++ b/cohttp/src/transfer_io.ml
@@ -20,7 +20,11 @@ module Make (IO : S.IO) = struct
   open IO
 
   type reader = unit -> Transfer.chunk IO.t
-  type writer = string -> unit IO.t
+
+  type writer = {
+    write : string -> unit IO.t;
+    write_bigstring : Bigstring.write -> int -> int -> unit IO.t;
+  }
 
   module Chunked = struct
     let remaining_length chunk remaining =
@@ -73,14 +77,18 @@ module Make (IO : S.IO) = struct
         | "" -> return Done (* 0 bytes read means EOF *)
         | buf -> return (Chunk buf)
 
-    let write oc buf =
-      let len = String.length buf in
+    let framed oc len emit =
       (* do NOT send empty chunks, as it signals the end of the
          chunked body *)
       if len <> 0 then
         write oc (Printf.sprintf "%x\r\n" len) >>= fun () ->
-        write oc buf >>= fun () -> write oc "\r\n"
+        emit () >>= fun () -> write oc "\r\n"
       else return ()
+
+    let write oc buf = framed oc (String.length buf) (fun () -> write oc buf)
+
+    let write_bigstring oc buf off len =
+      framed oc len (fun () -> write_bigstring oc buf off len)
   end
 
   module Fixed = struct
@@ -101,6 +109,7 @@ module Make (IO : S.IO) = struct
 
     (* TODO enforce that the correct length is written? *)
     let write = write
+    let write_bigstring = write_bigstring
   end
 
   module Unknown = struct
@@ -111,9 +120,13 @@ module Make (IO : S.IO) = struct
       if buf = "" then return Done else return (Chunk buf)
 
     let write = write
+    let write_bigstring = write_bigstring
   end
 
   let write_and_flush fn oc buf = fn oc buf >>= fun () -> IO.flush oc
+
+  let write_bigstring_and_flush fn oc buf off len =
+    fn oc buf off len >>= fun () -> IO.flush oc
 
   let make_reader = function
     | Chunked -> Chunked.read ~remaining:(ref 0L)
@@ -123,17 +136,27 @@ module Make (IO : S.IO) = struct
   let write_ignore_blank writer io s =
     if String.length s = 0 then return () else writer io s
 
-  let make_writer ~flush mode =
-    let write =
+  let write_bigstring_ignore_blank writer io buf off len =
+    if len = 0 then return () else writer io buf off len
+
+  let make_writer ~flush mode oc =
+    let write, write_bigstring =
       match mode with
-      | Chunked -> Chunked.write
-      | Fixed _ -> Fixed.write
-      | Unknown -> Unknown.write
+      | Chunked -> (Chunked.write, Chunked.write_bigstring)
+      | Fixed _ -> (Fixed.write, Fixed.write_bigstring)
+      | Unknown -> (Unknown.write, Unknown.write_bigstring)
     in
-    match flush with
-    | false -> write
-    | true -> write_and_flush write |> write_ignore_blank
+    let write, write_bigstring =
+      match flush with
+      | false -> (write, write_bigstring)
+      | true ->
+          ( write_and_flush write |> write_ignore_blank,
+            write_bigstring_and_flush write_bigstring
+            |> write_bigstring_ignore_blank )
+    in
+    { write = write oc; write_bigstring = write_bigstring oc }
 
   let read reader = reader ()
-  let write writer buf = writer buf
+  let write writer buf = writer.write buf
+  let write_bigstring writer buf off len = writer.write_bigstring buf off len
 end

--- a/cohttp/src/transfer_io.mli
+++ b/cohttp/src/transfer_io.mli
@@ -24,4 +24,8 @@ module Make (IO : S.IO) : sig
   val make_writer : flush:bool -> encoding -> IO.oc -> writer
   val read : reader -> chunk IO.t
   val write : writer -> string -> unit IO.t
+
+  val write_bigstring : writer -> Bigstring.write -> int -> int -> unit IO.t
+  (** The [`Copy] and [`Passthrough] tags mean what they do in
+      {!S.IO.write_bigstring}. *)
 end

--- a/cohttp/test/dune
+++ b/cohttp/test/dune
@@ -81,3 +81,15 @@
  (package cohttp)
  (action
   (run ./test_response.exe)))
+
+(executable
+ (name test_bigstring)
+ (modules test_bigstring)
+ (forbidden_libraries base)
+ (libraries cohttp alcotest))
+
+(rule
+ (alias runtest)
+ (package cohttp)
+ (action
+  (run ./test_bigstring.exe)))

--- a/cohttp/test/test_bigstring.ml
+++ b/cohttp/test/test_bigstring.ml
@@ -1,0 +1,29 @@
+open Cohttp
+
+let invalid name f =
+  Alcotest.check_raises name (Invalid_argument "") (fun () ->
+      match f () with
+      | exception Invalid_argument _ -> raise (Invalid_argument "")
+      | _ -> ())
+
+let bounds () =
+  let t = Bigstring.create 8 in
+  Bigstring.blit_from_string "abcdefgh" ~src_off:0 t ~dst_off:0 ~len:8;
+  Alcotest.(check string)
+    "in range" "cde"
+    (Bigstring.sub_string t ~off:2 ~len:3);
+  invalid "sub_string past end" (fun () -> Bigstring.sub_string t ~off:6 ~len:3);
+  invalid "sub_string negative off" (fun () ->
+      Bigstring.sub_string t ~off:(-1) ~len:1);
+  invalid "sub_string negative len" (fun () ->
+      Bigstring.sub_string t ~off:0 ~len:(-1));
+  invalid "blit_from_string past source" (fun () ->
+      Bigstring.blit_from_string "ab" ~src_off:1 t ~dst_off:0 ~len:2);
+  invalid "blit_from_string past dest" (fun () ->
+      Bigstring.blit_from_string "abcdefgh" ~src_off:0 t ~dst_off:1 ~len:8);
+  invalid "blit past dest" (fun () ->
+      Bigstring.blit t ~src_off:0 (Bigstring.create 4) ~dst_off:0 ~len:8)
+
+let () =
+  Alcotest.run "test_bigstring"
+    [ ("bounds", [ Alcotest.test_case "bounds" `Quick bounds ]) ]

--- a/cohttp/test/test_request.ml
+++ b/cohttp/test/test_request.ml
@@ -309,6 +309,11 @@ module Test_io = struct
   let read_line buffer = Buffer.read_line buffer ""
   let read buffer = Buffer.read buffer ""
   let write buffer string = Buffer.refill buffer string |> ignore
+
+  let write_bigstring buffer buf off len =
+    let buf = Cohttp.Bigstring.buffer buf in
+    Buffer.refill buffer (Cohttp.Bigstring.sub_string buf ~off ~len) |> ignore
+
   let flush _ = ()
 end
 


### PR DESCRIPTION
A body whose bytes already live outside the OCaml heap — a memory-mapped file, a buffer filled by a read — has to be copied into a string to be sent, which for a large body is exactly the allocation the caller was avoiding.

## The addition

One function per layer, and the writer a body goes through carries a bigstring path alongside the string one:

```ocaml
(* Cohttp.S.IO *)
val write_bigstring : oc -> Bigstring.t -> int -> int -> unit t

(* Cohttp.S.Http_io *)
val write_bigstring_body : writer -> Bigstring.t -> int -> int -> unit IO.t
```

`Transfer_io.Make(IO).writer` becomes a record of the two writes rather than a bare `string -> unit IO.t`. It is abstract in both `transfer_io.mli` and `S.Http_io`, so that is internal.

`Cohttp_lwt.Body.t` gains a `` `Bigstring `` case, with `of_bigstring` and `to_bigstring`, and the Lwt server and client send it through `write_bigstring_body`. `Body.write_body` keeps its signature and its `` `Bigstring `` arm copies onto the heap, so callers outside cohttp are unaffected.

## No new dependency

`Cohttp.Bigstring` spells the Bigarray type rather than taking it from a library:

```ocaml
type t = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
```

This is the same type as `Bigstringaf.t`, `Lwt_bytes.t` and Async's `Bigstring.t`, so a caller holding any of them passes it directly and `cohttp` gains nothing to depend on.

## Backends

Every IO backend writes without building a string:

| Backend | How |
| --- | --- |
| `cohttp-lwt-unix` | `Lwt_io.write_from_exactly_bigstring` |
| `cohttp-async` | `Writer.write_bigstring` |
| `cohttp-eio` | `Buf_write.cstruct` on `Cstruct.of_bigarray` |
| `cohttp-mirage` | `Channel.write_buffer` on `Cstruct.of_bigarray` |

The two `Buffer`-backed ones (`Cohttp.String_io`, `Cohttp_lwt.String_io`) build a string, since `Buffer` has no bigarray sink and a per-byte `add_char` loop would be slower than one `add_string`.

`Body.to_bigstring` folds each piece of a stream in as it arrives, so a body that is off the heap to keep it off never sits on it whole on the way.

## Testing

`dune build` and the suites for `cohttp`, `cohttp-lwt-unix`, `cohttp-async`, `cohttp-eio` and `cohttp-server-lwt-unix` pass — 118 tests. Note they need `-j1`: several bind fixed ports and collide with each other when dune runs them in parallel, which is pre-existing and not from this change.

Two existing spots needed updating for the widened signatures: the `Test_io` stub in `cohttp/test/test_request.ml`, and a now non-exhaustive match on `Body.t` in `cohttp-lwt-unix/test/test_client.ml`.

`cohttp-eio/tests/test_forward_proxy.ml` is left alone although `dune build @fmt` flags it — that is pre-existing drift against the pinned ocamlformat, unrelated to this change.
